### PR TITLE
refactor(p2): split ChatMessageTools (2605 → 838, 4 siblings)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAskUserStep.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAskUserStep.kt
@@ -1,0 +1,457 @@
+package me.rerere.rikkahub.ui.components.message
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.ui.ToolApprovalState
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.BubbleChatQuestion
+import me.rerere.hugeicons.stroke.Refresh01
+import me.rerere.hugeicons.stroke.Tick01
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.ui.components.ui.ChainOfThoughtScope
+import me.rerere.rikkahub.ui.components.ui.DotLoading
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
+import me.rerere.rikkahub.ui.modifier.shimmer
+import me.rerere.rikkahub.utils.JsonInstant
+import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ChainOfThoughtScope.AskUserToolStep(
+    tool: UIMessagePart.Tool,
+    loading: Boolean,
+    onToolAnswer: ((toolCallId: String, answer: String) -> Unit)?,
+) {
+    val isPending = tool.approvalState is ToolApprovalState.Pending
+    val isAnswered = tool.approvalState is ToolApprovalState.Answered
+    val arguments = remember(tool.input) { tool.inputAsJson() }
+    val answeredAnswers = remember(tool.approvalState) {
+        val state = tool.approvalState
+        if (state is ToolApprovalState.Answered) {
+            runCatching {
+                JsonInstant.parseToJsonElement(state.answer)
+                    .jsonObject["answers"]?.jsonObject
+            }.getOrNull()
+        } else {
+            null
+        }
+    }
+
+    // Parse questions from arguments
+    val questions = remember(arguments) {
+        runCatching {
+            arguments.jsonObject["questions"]?.jsonArray?.map { q ->
+                val obj = q.jsonObject
+                AskUserQuestion(
+                    id = obj["id"]?.jsonPrimitive?.contentOrNull ?: "",
+                    question = obj["question"]?.jsonPrimitive?.contentOrNull ?: "",
+                    options = obj["options"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList(),
+                    selectionType = obj["selection_type"]?.jsonPrimitive?.contentOrNull ?: "text"
+                )
+            } ?: emptyList()
+        }.getOrElse { emptyList() }
+    }
+
+    // Track answers for text/single questions
+    val answers = remember { mutableStateMapOf<String, String>() }
+    // Track selected options for multi questions
+    val multiAnswers = remember { mutableStateMapOf<String, Set<String>>() }
+
+    val firstQuestion = questions.firstOrNull()?.question ?: "..."
+
+    var expanded by remember { mutableStateOf(true) }
+    val workspace = workspaceColors()
+
+    ControlledChainOfThoughtStep(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        icon = {
+            if (loading) {
+                DotLoading(size = 10.dp)
+            } else {
+                Icon(
+                    imageVector = HugeIcons.BubbleChatQuestion,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        label = {
+            Text(
+                text = if (questions.size <= 1) firstQuestion else stringResource(
+                    R.string.chat_message_tool_ask_questions,
+                    questions.size
+                ),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.shimmer(isLoading = loading),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        content = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                questions.forEachIndexed { index, q ->
+                    if (index > 0) {
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
+                            thickness = 0.5.dp,
+                        )
+                    }
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = q.question,
+                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+
+                        if (isPending && onToolAnswer != null) {
+                            when (q.selectionType) {
+                                "single" -> {
+                                    if (q.options.isNotEmpty()) {
+                                        FlowRow(
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                                        ) {
+                                            q.options.forEach { option ->
+                                                AskOptionChip(
+                                                    selected = answers[q.id] == option,
+                                                    label = option,
+                                                    onClick = { answers[q.id] = option },
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                "multi" -> {
+                                    if (q.options.isNotEmpty()) {
+                                        FlowRow(
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                                        ) {
+                                            q.options.forEach { option ->
+                                                val selectedSet = multiAnswers[q.id] ?: emptySet()
+                                                AskOptionChip(
+                                                    selected = selectedSet.contains(option),
+                                                    label = option,
+                                                    onClick = {
+                                                        val current = selectedSet.toMutableSet()
+                                                        if (current.contains(option)) current.remove(option)
+                                                        else current.add(option)
+                                                        multiAnswers[q.id] = current
+                                                    },
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                else -> {
+                                    if (q.options.isNotEmpty()) {
+                                        FlowRow(
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                                        ) {
+                                            q.options.forEach { option ->
+                                                AskOptionChip(
+                                                    selected = answers[q.id] == option,
+                                                    label = option,
+                                                    onClick = { answers[q.id] = option },
+                                                )
+                                            }
+                                        }
+                                    }
+                                    OutlinedTextField(
+                                        value = answers[q.id] ?: "",
+                                        onValueChange = { answers[q.id] = it },
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textStyle = MaterialTheme.typography.bodyMedium,
+                                        placeholder = {
+                                            Text(
+                                                text = "在此输入回答…",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                                            )
+                                        },
+                                        singleLine = false,
+                                        minLines = 2,
+                                        maxLines = 6,
+                                        shape = RoundedCornerShape(12.dp),
+                                        colors = OutlinedTextFieldDefaults.colors(
+                                            unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                            focusedBorderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
+                                            unfocusedContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.4f),
+                                            focusedContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
+                                        ),
+                                    )
+                                }
+                            }
+                        } else if (isAnswered) {
+                            val answeredState = tool.approvalState as ToolApprovalState.Answered
+                            val answerJson = answeredAnswers?.get(q.id)
+                            val answerText = when {
+                                answerJson is JsonArray -> answerJson.mapNotNull { it.jsonPrimitiveOrNull?.contentOrNull }
+                                    .joinToString(" · ")
+                                answerJson != null -> answerJson.jsonPrimitiveOrNull?.contentOrNull
+                                    ?: answeredState.answer
+                                else -> answeredState.answer
+                            }
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(10.dp),
+                                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
+                                border = BorderStroke(
+                                    0.5.dp,
+                                    MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+                                ),
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+                                    verticalAlignment = Alignment.Top,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    Surface(
+                                        shape = RoundedCornerShape(4.dp),
+                                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                                    ) {
+                                        Text(
+                                            text = "A",
+                                            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                                            color = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                        )
+                                    }
+                                    Text(
+                                        text = answerText,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (isPending && onToolAnswer != null) {
+                    val anyAnswered = answers.values.any { it.isNotBlank() } ||
+                        multiAnswers.values.any { it.isNotEmpty() }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (anyAnswered) {
+                            Row(
+                                modifier = Modifier
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .clickable {
+                                        answers.clear()
+                                        multiAnswers.clear()
+                                    }
+                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                Icon(
+                                    imageVector = HugeIcons.Refresh01,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(12.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.65f),
+                                )
+                                Text(
+                                    text = "清空",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(8.dp))
+                        }
+                        Button(
+                            onClick = {
+                                val answerPayload = buildJsonObject {
+                                    put("answers", buildJsonObject {
+                                        questions.forEach { q ->
+                                            when (q.selectionType) {
+                                                "multi" -> put(
+                                                    q.id,
+                                                    buildJsonArray {
+                                                        multiAnswers[q.id].orEmpty().forEach { add(JsonPrimitive(it)) }
+                                                    }
+                                                )
+                                                else -> put(q.id, JsonPrimitive(answers[q.id] ?: ""))
+                                            }
+                                        }
+                                    })
+                                }
+                                onToolAnswer(tool.toolCallId, answerPayload.toString())
+                            },
+                            enabled = questions.all { q ->
+                                when (q.selectionType) {
+                                    "multi" -> !multiAnswers[q.id].isNullOrEmpty()
+                                    else -> !answers[q.id].isNullOrBlank()
+                                }
+                            },
+                            shape = RoundedCornerShape(20.dp),
+                            contentPadding = PaddingValues(horizontal = 18.dp, vertical = 8.dp),
+                        ) {
+                            Icon(
+                                imageVector = HugeIcons.Tick01,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Text(
+                                text = stringResource(R.string.chat_message_tool_submit),
+                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                                modifier = Modifier.padding(start = 6.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun AskOptionChip(
+    selected: Boolean,
+    label: String,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(20.dp)
+    Surface(
+        onClick = onClick,
+        shape = shape,
+        color = if (selected) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.surface.copy(alpha = 0.85f)
+        },
+        contentColor = if (selected) {
+            MaterialTheme.colorScheme.onPrimary
+        } else {
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
+        },
+        border = if (selected) {
+            null
+        } else {
+            BorderStroke(
+                width = 0.5.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f),
+            )
+        },
+        tonalElevation = 0.dp,
+        shadowElevation = if (selected) 1.dp else 0.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 13.dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+        ) {
+            if (selected) {
+                Icon(
+                    imageVector = HugeIcons.Tick01,
+                    contentDescription = null,
+                    modifier = Modifier.size(13.dp),
+                )
+            }
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
+                ),
+            )
+        }
+    }
+}
+
+private data class AskUserQuestion(
+    val id: String,
+    val question: String,
+    val options: List<String>,
+    val selectionType: String = "text", // "text" | "single" | "multi"
+)
+
+@Composable
+internal fun ToolDenyReasonDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit
+) {
+    var reason by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(R.string.chat_message_tool_deny_dialog_title))
+        },
+        text = {
+            OutlinedTextField(
+                value = reason,
+                onValueChange = { reason = it },
+                label = { Text(stringResource(R.string.chat_message_tool_deny_dialog_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = false,
+                minLines = 2,
+                maxLines = 4
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(reason) }) {
+                Text(stringResource(R.string.chat_message_tool_deny))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageCouncilStep.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageCouncilStep.kt
@@ -1,0 +1,723 @@
+package me.rerere.rikkahub.ui.components.message
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ScrollableTabRow
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.MagicWand01
+import me.rerere.rikkahub.data.agent.modelcouncil.ModelCouncilManager
+import me.rerere.rikkahub.data.agent.modelcouncil.ModelCouncilRolePresets
+import me.rerere.rikkahub.data.agent.subagent.SubAgentManager
+import me.rerere.rikkahub.data.agent.subagent.readSubAgentDisplayTextFromTranscript
+import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
+import me.rerere.rikkahub.utils.JsonInstant
+import org.koin.compose.koinInject
+import java.io.File
+
+/**
+ * Render a coalesced Model Council run: one card replaces the multiple model_council_* tool calls
+ * sharing one run_id. Tap → opens [ModelCouncilRunSheet] showing per-seat live streaming output
+ * in a tab layout.
+ */
+@Composable
+fun CouncilTaskStepView(
+    step: ThinkingStep.CouncilTaskStep,
+    loading: Boolean,
+) {
+    val manager: ModelCouncilManager = koinInject()
+    var showSheet by remember(step.runId) { mutableStateOf(false) }
+    val parsedStatus = parseLatestCouncilStatus(step.tools)
+    val isRunning = parsedStatus == ModelCouncilCardStatus.RUNNING
+    val phaseLabels = listOf("听证", "辩论", "权衡", "裁决")
+    var phaseIndex by remember(step.runId) { mutableIntStateOf(0) }
+    LaunchedEffect(step.runId, isRunning) {
+        if (!isRunning) return@LaunchedEffect
+        while (true) {
+            delay(PHASE_LABEL_INTERVAL_MS)
+            phaseIndex = (phaseIndex + 1) % phaseLabels.size
+        }
+    }
+    val currentPhase = if (isRunning) phaseLabels[phaseIndex.coerceIn(phaseLabels.indices)]
+        else phaseLabels.last()
+    val statusVerb = when (parsedStatus) {
+        ModelCouncilCardStatus.RUNNING -> "正在审议"
+        ModelCouncilCardStatus.COMPLETED -> "已完成"
+        ModelCouncilCardStatus.PARTIAL_FAILED -> "部分失败"
+        ModelCouncilCardStatus.FAILED -> "失败"
+        ModelCouncilCardStatus.CANCELLED -> "已取消"
+        ModelCouncilCardStatus.TIMED_OUT -> "超时"
+        ModelCouncilCardStatus.INTERRUPTED -> "已中断"
+    }
+    val title = if (isRunning) "@Council $statusVerb · $currentPhase" else "@Council $statusVerb"
+    val seatSubtitle = remember(step.runId, step.tools) {
+        val names = manager.snapshot(step.runId)?.seats
+            ?.map { it.name.ifBlank { ModelCouncilRolePresets.byName(it.role)?.name ?: it.role } }
+            ?.filter { it.isNotBlank() }
+            ?.takeIf { it.isNotEmpty() }
+            ?: extractCouncilSeatEntries(step.tools).map { it.label }
+        names.takeIf { it.isNotEmpty() }?.joinToString(" / ", prefix = "席位 · ")
+    }
+    AgentToolCallCapsule(
+        title = title,
+        toolName = "model_council",
+        icon = HugeIcons.MagicWand01,
+        kind = AgentToolKind.GENERIC,
+        status = parsedStatus.toAgentToolStatus(),
+        loading = loading && isRunning,
+        onClick = { showSheet = true },
+        approvalActions = null,
+        subtitle = seatSubtitle,
+    )
+
+    if (showSheet) {
+        ModelCouncilRunSheet(
+            step = step,
+            onDismiss = { showSheet = false },
+        )
+    }
+}
+
+private enum class ModelCouncilCardStatus {
+    RUNNING, COMPLETED, PARTIAL_FAILED, FAILED, CANCELLED, TIMED_OUT, INTERRUPTED
+}
+
+/** Walk model_council_* tools in reverse, find the most recent parsable `status`. */
+private fun parseLatestCouncilStatus(tools: List<UIMessagePart.Tool>): ModelCouncilCardStatus {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val statusStr = runCatching {
+            (JsonInstant.parseToJsonElement(outputText) as? JsonObject)?.get("status")
+                ?.let { it as? JsonPrimitive }?.contentOrNull
+        }.getOrNull() ?: continue
+        ModelCouncilCardStatus.entries.firstOrNull { it.name.equals(statusStr, ignoreCase = true) }
+            ?.let { return it }
+    }
+    return ModelCouncilCardStatus.RUNNING
+}
+
+private fun ModelCouncilCardStatus.toAgentToolStatus(): AgentToolStatus = when (this) {
+    ModelCouncilCardStatus.RUNNING -> AgentToolStatus.RUNNING
+    ModelCouncilCardStatus.COMPLETED,
+    ModelCouncilCardStatus.PARTIAL_FAILED -> AgentToolStatus.SUCCEEDED
+    ModelCouncilCardStatus.FAILED,
+    ModelCouncilCardStatus.TIMED_OUT,
+    ModelCouncilCardStatus.INTERRUPTED -> AgentToolStatus.FAILED
+    ModelCouncilCardStatus.CANCELLED -> AgentToolStatus.CANCELLED
+}
+
+/**
+ * Bottom sheet showing the council run's task + per-seat live streaming output, organized in
+ * tabs. Synthesizer pane is the default tab; each seat (in run order) gets its own tab. Falls
+ * back to extracting final text from tool result when the live flow is gone (process restart).
+ */
+@Composable
+private fun ModelCouncilRunSheet(
+    step: ThinkingStep.CouncilTaskStep,
+    onDismiss: () -> Unit,
+) {
+    val manager: ModelCouncilManager = koinInject()
+    val workspace = workspaceColors()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val anchor = step.anchor
+    val arguments = remember(anchor.input) { anchor.inputAsJson() }
+    val taskObjective = remember(arguments) {
+        runCatching {
+            (arguments.jsonObject["task"] as? JsonObject)?.get("objective")?.let { it as? JsonPrimitive }?.contentOrNull
+                ?: arguments.jsonObject["objective"]?.let { it as? JsonPrimitive }?.contentOrNull
+        }.getOrNull()
+    }
+
+    val parsedStatus = parseLatestCouncilStatus(step.tools)
+    val isRunning = parsedStatus == ModelCouncilCardStatus.RUNNING
+    val statusVerb = when (parsedStatus) {
+        ModelCouncilCardStatus.RUNNING -> "正在审议"
+        ModelCouncilCardStatus.COMPLETED -> "已完成"
+        ModelCouncilCardStatus.PARTIAL_FAILED -> "部分失败"
+        ModelCouncilCardStatus.FAILED -> "失败"
+        ModelCouncilCardStatus.CANCELLED -> "已取消"
+        ModelCouncilCardStatus.TIMED_OUT -> "超时"
+        ModelCouncilCardStatus.INTERRUPTED -> "已中断"
+    }
+
+    // Resolve seat list from the snapshot (preserves run order). Synthesizer is appended last.
+    val snapshot = remember(step.runId) { manager.snapshot(step.runId) }
+    val seatTabs = remember(step.runId, snapshot?.seats, step.tools) {
+        val seatEntries = snapshot?.seats?.map { seat ->
+            CouncilTabEntry(
+                key = seat.seatId,
+                label = seat.name.ifBlank { ModelCouncilRolePresets.byName(seat.role)?.name ?: seat.role },
+            )
+        }?.takeIf { it.isNotEmpty() } ?: extractCouncilSeatEntries(step.tools)
+        // Synthesizer pane is conceptually the "verdict"; show it first so the user sees the
+        // bottom-line answer immediately when the run finishes.
+        listOf(CouncilTabEntry(ModelCouncilManager.SYNTHESIZER_SEAT_KEY, "综合裁决")) + seatEntries
+    }
+
+    // While the run is still going, default to the FIRST seat tab (index 1) instead of the
+    // synthesizer (index 0) — the synthesizer has nothing to show until debate is over.
+    // After completion, jump to synthesizer (index 0) for the verdict.
+    val initialTab = if (isRunning && seatTabs.size > 1) 1 else 0
+    var selectedTab by remember(step.runId, isRunning) { mutableIntStateOf(initialTab) }
+    val safeSelected = selectedTab.coerceIn(0, (seatTabs.size - 1).coerceAtLeast(0))
+
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismiss,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.85f)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            // Header
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    imageVector = HugeIcons.MagicWand01,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = workspace.muted,
+                )
+                Text(
+                    text = "@Council",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = workspace.ink,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = statusVerb,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = workspace.muted,
+                )
+            }
+
+            taskObjective?.takeIf { it.isNotBlank() }?.let { objective ->
+                CouncilObjectiveCard(objective = objective)
+            }
+
+            if (seatTabs.isNotEmpty()) {
+                ScrollableTabRow(
+                    selectedTabIndex = safeSelected,
+                    edgePadding = 0.dp,
+                    containerColor = workspace.paper,
+                    contentColor = workspace.ink,
+                ) {
+                    seatTabs.forEachIndexed { index, tab ->
+                        Tab(
+                            selected = index == safeSelected,
+                            onClick = { selectedTab = index },
+                            text = {
+                                Text(
+                                    text = tab.label,
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(color = workspace.hairline)
+
+            // Active tab body — subscribe to the seat's live flow + auto-scroll while running.
+            val activeSeatKey = seatTabs.getOrNull(safeSelected)?.key
+            val seatFlow = remember(step.runId, activeSeatKey) {
+                activeSeatKey?.let { manager.liveTextFlow(step.runId, it) } ?: MutableStateFlow("")
+            }
+            val liveText by seatFlow.collectAsState()
+            val finalText = remember(step.tools, activeSeatKey) {
+                if (activeSeatKey == ModelCouncilManager.SYNTHESIZER_SEAT_KEY) {
+                    extractFinalCouncilSynthesisText(step.tools)
+                } else if (activeSeatKey != null) {
+                    extractFinalCouncilSeatText(step.tools, activeSeatKey)
+                } else ""
+            }
+            val displayTextSource = if (isRunning) {
+                liveText.ifBlank { finalText }
+            } else {
+                finalText.ifBlank { liveText }
+            }
+            val displayText = displayTextSource.cleanCouncilLineBreaks()
+            val activeModelLabel = remember(step.tools, activeSeatKey) {
+                activeSeatKey?.let { extractCouncilModelLabel(step.tools, it) }.orEmpty()
+            }
+            val scrollState = rememberScrollState()
+            var followBottom by remember(step.runId, activeSeatKey) { mutableStateOf(true) }
+            LaunchedEffect(scrollState, isRunning, activeSeatKey) {
+                snapshotFlow { scrollState.value to scrollState.maxValue }
+                    .collect { (value, maxValue) ->
+                        if (isRunning && value >= (maxValue - 8).coerceAtLeast(0)) {
+                            followBottom = true
+                        }
+                    }
+            }
+            // Scroll spec aligned with ChatList.scrollToTimelineBottom — tween 80ms,
+            // LinearEasing. Default spring's long settle holds isScrollInProgress and
+            // would gate off subsequent chunks (same regression shape 1.8.10 fixed
+            // on the main chat path).
+            LaunchedEffect(displayText, isRunning, activeSeatKey, followBottom) {
+                if (isRunning && followBottom) {
+                    scrollState.animateScrollTo(
+                        value = scrollState.maxValue,
+                        animationSpec = tween(durationMillis = 80, easing = LinearEasing),
+                    )
+                }
+            }
+            if (activeModelLabel.isNotBlank()) {
+                Text(
+                    text = activeModelLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = workspace.faint,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .pointerInput(isRunning, activeSeatKey) {
+                        awaitEachGesture {
+                            awaitFirstDown(requireUnconsumed = false)
+                            if (isRunning) followBottom = false
+                        }
+                    }
+                    .verticalScroll(scrollState),
+            ) {
+                if (displayText.isBlank()) {
+                    Text(
+                        text = if (isRunning) "等待此席位输出..." else "（无输出）",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = workspace.faint,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                } else {
+                    SelectionContainer(
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        CouncilRoundContent(
+                            content = displayText,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private data class CouncilTabEntry(val key: String, val label: String)
+
+private data class CouncilRoundSection(
+    val label: String?,
+    val content: String,
+)
+
+@Composable
+private fun CouncilRoundContent(
+    content: String,
+    modifier: Modifier = Modifier,
+) {
+    val sections = remember(content) { content.toCouncilRoundSections() }
+    val workspace = workspaceColors()
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        sections.forEach { section ->
+            section.label?.let { CouncilRoundDivider(label = it) }
+            if (section.content.isNotBlank()) {
+                MarkdownBlock(
+                    content = section.content,
+                    modifier = Modifier.fillMaxWidth(),
+                    style = MaterialTheme.typography.bodyMedium.copy(color = workspace.ink),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CouncilRoundDivider(label: String) {
+    val workspace = workspaceColors()
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(50),
+            color = workspace.blue.copy(alpha = 0.12f),
+            border = BorderStroke(1.dp, workspace.blue.copy(alpha = 0.24f)),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = workspace.blue,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+            )
+        }
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = workspace.blue.copy(alpha = 0.20f),
+        )
+    }
+}
+
+@Composable
+private fun CouncilObjectiveCard(objective: String) {
+    val workspace = workspaceColors()
+    val shouldCollapse = remember(objective) { objective.shouldCollapseCouncilObjective() }
+    var expanded by remember(objective) { mutableStateOf(!shouldCollapse) }
+    val objectiveScrollState = rememberScrollState()
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize()
+            .clickable(enabled = shouldCollapse) { expanded = !expanded },
+        shape = RoundedCornerShape(8.dp),
+        color = workspace.row,
+        border = BorderStroke(1.dp, workspace.hairline),
+    ) {
+        Column(
+            modifier = Modifier.padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "议题",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = workspace.faint,
+                    modifier = Modifier.weight(1f),
+                )
+                if (shouldCollapse) {
+                    Text(
+                        text = if (expanded) "收起" else "展开",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = workspace.blue,
+                    )
+                }
+            }
+            Text(
+                text = objective,
+                style = MaterialTheme.typography.bodySmall,
+                color = workspace.ink,
+                maxLines = if (expanded) Int.MAX_VALUE else COUNCIL_OBJECTIVE_COLLAPSED_LINES,
+                overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
+                modifier = if (expanded && shouldCollapse) {
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 220.dp)
+                        .verticalScroll(objectiveScrollState)
+                } else {
+                    Modifier.fillMaxWidth()
+                },
+            )
+        }
+    }
+}
+
+private fun String.shouldCollapseCouncilObjective(): Boolean {
+    val lineCount = lineSequence().count()
+    return length > COUNCIL_OBJECTIVE_COLLAPSE_CHARS || lineCount > COUNCIL_OBJECTIVE_COLLAPSE_LINES
+}
+
+private fun String.toCouncilRoundSections(): List<CouncilRoundSection> {
+    if (!contains(COUNCIL_ROUND_MARKER_TEXT)) {
+        return listOf(CouncilRoundSection(label = null, content = this))
+    }
+    val sections = mutableListOf<CouncilRoundSection>()
+    var label: String? = null
+    val body = StringBuilder()
+
+    fun flush() {
+        val content = body.toString().trim('\n')
+        if (label != null || content.isNotBlank()) {
+            sections += CouncilRoundSection(label = label, content = content)
+        }
+        body.clear()
+    }
+
+    lineSequence().forEach { line ->
+        val match = COUNCIL_ROUND_MARKER.matchEntire(line.trim())
+        if (match != null) {
+            flush()
+            label = match.groupValues[1].replace(Regex("""\s+"""), " ")
+        } else {
+            body.appendLine(line)
+        }
+    }
+    flush()
+
+    return sections.ifEmpty { listOf(CouncilRoundSection(label = null, content = this)) }
+}
+
+private const val COUNCIL_OBJECTIVE_COLLAPSED_LINES = 3
+private const val COUNCIL_OBJECTIVE_COLLAPSE_LINES = 5
+private const val COUNCIL_OBJECTIVE_COLLAPSE_CHARS = 180
+private const val COUNCIL_ROUND_MARKER_TEXT = "--- 第"
+private val COUNCIL_ROUND_MARKER = Regex("""---\s*(第\s*\d+\s*轮)\s*---""")
+
+/** Pull the synthesizer's final text from the latest read/wait result (`result.finalRecommendation`). */
+private fun extractFinalCouncilSynthesisText(tools: List<UIMessagePart.Tool>): String {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val parsed = runCatching {
+            JsonInstant.parseToJsonElement(outputText) as? JsonObject
+        }.getOrNull() ?: continue
+        val result = parsed.payloadObject("result") ?: continue
+        val recommendation = ((result["final_recommendation"] as? JsonPrimitive)?.contentOrNull)
+            ?.takeIf { it.isNotBlank() }
+            ?: ((result["error"] as? JsonPrimitive)?.contentOrNull)
+        if (!recommendation.isNullOrBlank()) return recommendation
+    }
+    return ""
+}
+
+/** Pull the provider/model label for a council seat or synthesizer from the latest payload. */
+private fun extractCouncilModelLabel(tools: List<UIMessagePart.Tool>, seatId: String): String {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val parsed = runCatching {
+            JsonInstant.parseToJsonElement(outputText) as? JsonObject
+        }.getOrNull() ?: continue
+        val labels = parsed["seat_model_labels"] as? JsonObject
+        val direct = (labels?.get(seatId) as? JsonPrimitive)?.contentOrNull
+        if (!direct.isNullOrBlank()) return direct
+
+        val parsedTurns = parsed.payloadArray("turns") ?: continue
+        parsedTurns.forEach { turnElement ->
+            val turn = turnElement as? JsonObject ?: return@forEach
+            val tSeatId = (turn["seat_id"] as? JsonPrimitive)?.contentOrNull
+            if (tSeatId != seatId) return@forEach
+            val providerName = (turn["provider_name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+            val modelName = (turn["model_name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+            val label = listOf(providerName, modelName)
+                .filter { it.isNotBlank() }
+                .joinToString(" / ")
+            if (label.isNotBlank()) return label
+        }
+    }
+    return ""
+}
+
+private fun extractCouncilSeatEntries(tools: List<UIMessagePart.Tool>): List<CouncilTabEntry> {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val parsed = runCatching {
+            JsonInstant.parseToJsonElement(outputText) as? JsonObject
+        }.getOrNull() ?: continue
+        val parsedTurns = parsed.payloadArray("turns") ?: continue
+        val entries = linkedMapOf<String, String>()
+        parsedTurns.forEach { turnElement ->
+            val turn = turnElement as? JsonObject ?: return@forEach
+            val seatId = (turn["seat_id"] as? JsonPrimitive)?.contentOrNull
+                ?.takeIf { it.isNotBlank() }
+                ?: return@forEach
+            val name = (turn["seat_name"] as? JsonPrimitive)?.contentOrNull
+                ?.takeIf { it.isNotBlank() }
+                ?: return@forEach
+            entries.putIfAbsent(seatId, name)
+        }
+        if (entries.isNotEmpty()) {
+            return entries.map { (seatId, name) -> CouncilTabEntry(key = seatId, label = name) }
+        }
+    }
+    return emptyList()
+}
+
+/**
+ * Pull a specific seat's content across ALL rounds from the latest tool result, joined the same
+ * way the live flow renders them (with `--- 第 N 轮 ---` separators between rounds 2+). Walking
+ * tools in reverse means we pick the most recent (richest) turns array; within it, all matching
+ * turns are kept in original order.
+ */
+private fun extractFinalCouncilSeatText(tools: List<UIMessagePart.Tool>, seatId: String): String {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val parsed = runCatching {
+            JsonInstant.parseToJsonElement(outputText) as? JsonObject
+        }.getOrNull() ?: continue
+        val parsedTurns = parsed.payloadArray("turns") ?: continue
+        val matching = parsedTurns.mapNotNull { turnElement ->
+            val turn = turnElement as? JsonObject ?: return@mapNotNull null
+            val tSeatId = (turn["seat_id"] as? JsonPrimitive)?.contentOrNull
+            if (tSeatId != seatId) return@mapNotNull null
+            val round = (turn["round"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull() ?: 1
+            val warnings = (turn["warnings"] as? JsonArray)?.mapNotNull { warning ->
+                (warning as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+            }.orEmpty()
+            val content = (turn["content"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
+                ?: (turn["error"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }?.let { "失败：$it" }
+                ?: return@mapNotNull null
+            val text = buildString {
+                warnings.forEach { warning -> appendLine("提示：$warning") }
+                if (warnings.isNotEmpty()) appendLine()
+                append(content)
+            }
+            round to text
+        }.sortedBy { it.first }
+        if (matching.isNotEmpty()) {
+            return matching.joinToString("\n\n") { (round, content) ->
+                "--- 第 $round 轮 ---\n\n$content"
+            }
+        }
+    }
+    return ""
+}
+
+internal fun JsonObject.payloadObject(name: String): JsonObject? {
+    val value = this[name] ?: return null
+    return (value as? JsonObject)
+        ?: (value as? JsonPrimitive)?.contentOrNull?.let { raw ->
+            runCatching { JsonInstant.parseToJsonElement(raw) as? JsonObject }.getOrNull()
+        }
+}
+
+private fun JsonObject.payloadArray(name: String): JsonArray? {
+    val value = this[name] ?: return null
+    return (value as? JsonArray)
+        ?: (value as? JsonPrimitive)?.contentOrNull?.let { raw ->
+            runCatching { JsonInstant.parseToJsonElement(raw).jsonArray }.getOrNull()
+        }
+}
+
+/**
+ * Pull the canonical final-text field from the latest tool result.
+ *
+ * Note: [me.rerere.rikkahub.data.agent.subagent.SubAgentManager.runToPayload] encodes the
+ * `SubAgentResult` as a **JSON-encoded string field** (calls `json.encodeToString(result)` and
+ * stores the resulting string), not a nested object. So `payload["result"]` is a
+ * `JsonPrimitive` carrying serialized JSON text — must be re-parsed before reading `summary`.
+ * Every cast uses `as?` to avoid `Element X is not a JsonObject` crashes on partial / shaped-
+ * differently outputs.
+ */
+internal fun extractFinalSubAgentText(tools: List<UIMessagePart.Tool>): String {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val parsed = runCatching {
+            JsonInstant.parseToJsonElement(outputText) as? JsonObject
+        }.getOrNull() ?: continue
+        val resultStr = (parsed["result"] as? JsonPrimitive)?.contentOrNull
+        val nestedSummary = resultStr?.let { rs ->
+            runCatching {
+                ((JsonInstant.parseToJsonElement(rs) as? JsonObject)?.get("summary")
+                    as? JsonPrimitive)?.contentOrNull
+            }.getOrNull()
+        }
+        val summary = nestedSummary
+            ?: (parsed["summary"] as? JsonPrimitive)?.contentOrNull
+        if (!summary.isNullOrBlank()) return summary
+    }
+    return ""
+}
+
+internal suspend fun extractSubAgentDisplayTextFromTranscript(
+    tools: List<UIMessagePart.Tool>,
+    runRoot: File,
+): String =
+    withContext(Dispatchers.IO) {
+        val transcriptPath = tools.asReversed().firstNotNullOfOrNull { tool ->
+            val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+                ?: return@firstNotNullOfOrNull null
+            runCatching {
+                val parsed = JsonInstant.parseToJsonElement(outputText) as? JsonObject
+                    ?: return@runCatching null
+                val explicitPath = (parsed["transcript_path"] as? JsonPrimitive)?.contentOrNull
+                explicitPath ?: (parsed["run_id"] as? JsonPrimitive)?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { runId -> File(runRoot, "$runId.jsonl").absolutePath }
+            }.getOrNull()
+        } ?: return@withContext ""
+
+        readSubAgentDisplayTextFromTranscript(transcriptPath, runRoot)
+    }
+
+/**
+ * Fix legacy council text where [UIMessage.toText] joined streaming deltas with "\n" separators,
+ * producing single-character lines like "根据\n常见\n控\n糖\n...". Collapses spurious line breaks
+ * while preserving intentional paragraph breaks (double newlines) and Markdown structure.
+ */
+private fun String.cleanCouncilLineBreaks(): String {
+    if (!contains('\n')) return this
+    val lines = lines()
+    val shortLineRatio = lines.count { it.trim().length in 1..3 }.toFloat() / lines.size.coerceAtLeast(1)
+    if (shortLineRatio < 0.35f) return this
+    return replace(Regex("""(?<!\n)\n(?!\n)""")) { match ->
+        val before = getOrNull(match.range.first - 1)
+        val after = getOrNull(match.range.last + 1)
+        if (before in listOf(':', '-', '。', '！', '？', '.', '!', '?') || after == '#' || after == '-' || after == '*') "\n"
+        else ""
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageSubAgentStep.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageSubAgentStep.kt
@@ -1,0 +1,376 @@
+package me.rerere.rikkahub.ui.components.message
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.common.http.jsonObjectOrNull
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.MagicWand01
+import me.rerere.rikkahub.data.agent.subagent.SubAgentDefinitions
+import me.rerere.rikkahub.data.agent.subagent.SubAgentManager
+import me.rerere.rikkahub.data.agent.subagent.SubAgentRunStatus
+import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
+import me.rerere.rikkahub.utils.JsonInstant
+import org.koin.compose.koinInject
+import java.io.File
+
+/**
+ * Render a coalesced subagent task: one card replaces the multiple subagent_* tool calls
+ * (start / wait / read / cancel) that share a run_id.
+ *
+ * Status is derived from the parsed `status` field of the latest wait/read output (most
+ * authoritative view of the subagent's actual state); falls back to RUNNING if no result
+ * has arrived yet. While running, cycles through the role's [phaseLabels] every few seconds
+ * to give a sense of progression. Phase 5 wires the click to an expandable run sheet.
+ */
+@Composable
+fun SubAgentTaskStepView(
+    step: ThinkingStep.SubAgentTaskStep,
+    loading: Boolean,
+) {
+    var showSheet by remember(step.runId) { mutableStateOf(false) }
+    val anchor = step.anchor
+    val arguments = remember(anchor.input) { anchor.inputAsJson() }
+    val subagentId = arguments.getStringContent("subagent_id") ?: "subagent"
+    val def = remember(subagentId) { SubAgentDefinitions.find(subagentId) }
+    val customName = arguments.jsonObjectOrNull
+        ?.payloadObject("custom_subagent")
+        ?.getStringContent("name")
+        ?.takeIf { it.isNotBlank() }
+    val displayName = extractLatestSubAgentName(step.tools)
+        ?: customName
+        ?: def?.name
+        ?: subagentId
+
+    // coalesceSubAgentSteps rebuilds step.tools each render even when contents are identical,
+    // so remember(step.tools) wouldn't actually memoize — drop the wrap; the parse is cheap.
+    val parsedStatus = parseLatestSubAgentStatus(step.tools)
+    val isRunning = parsedStatus == SubAgentRunStatus.RUNNING
+
+    val phaseLabels = def?.phaseLabels.orEmpty()
+    // Reset cycle when role's phaseLabels list changes (mid-run edits to a custom role would
+    // otherwise leave phaseIndex pointing past the new list's end).
+    var phaseIndex by remember(step.runId, phaseLabels) { mutableIntStateOf(0) }
+    LaunchedEffect(step.runId, isRunning, phaseLabels.size) {
+        if (!isRunning || phaseLabels.size <= 1) return@LaunchedEffect
+        while (true) {
+            delay(PHASE_LABEL_INTERVAL_MS)
+            phaseIndex = (phaseIndex + 1) % phaseLabels.size
+        }
+    }
+    val currentPhase = when {
+        phaseLabels.isEmpty() -> ""
+        isRunning -> phaseLabels[phaseIndex.coerceIn(phaseLabels.indices)]
+        else -> phaseLabels.last()
+    }
+
+    val statusVerb = when (parsedStatus) {
+        SubAgentRunStatus.RUNNING -> "正在工作"
+        SubAgentRunStatus.COMPLETED -> "已完成"
+        SubAgentRunStatus.FAILED -> "失败"
+        SubAgentRunStatus.CANCELLED -> "已取消"
+        SubAgentRunStatus.TIMED_OUT -> "超时"
+        SubAgentRunStatus.APPROVAL_REQUIRED -> "等待审批"
+        SubAgentRunStatus.INTERRUPTED -> "已中断"
+    }
+    val title = if (isRunning && currentPhase.isNotBlank()) {
+        "@$displayName $statusVerb · $currentPhase"
+    } else {
+        "@$displayName $statusVerb"
+    }
+
+    AgentToolCallCapsule(
+        title = title,
+        toolName = "subagent_task",
+        icon = HugeIcons.MagicWand01,
+        kind = AgentToolKind.GENERIC,
+        status = parsedStatus.toAgentToolStatus(),
+        loading = loading && isRunning,
+        onClick = { showSheet = true },
+        approvalActions = null,
+    )
+
+    if (showSheet) {
+        // Sheet derives its own status — sheet may outlive the outer card's recomposition
+        // (e.g. card scrolled offscreen in a LazyColumn while sheet is still open), so we
+        // can't rely on parent-passed verb staying fresh.
+        SubAgentRunSheet(
+            step = step,
+            displayName = displayName,
+            onDismiss = { showSheet = false },
+        )
+    }
+}
+
+internal const val PHASE_LABEL_INTERVAL_MS = 5_000L
+
+/**
+ * Walk the subagent_* tools in reverse order and pick the most recent parsable `status` from
+ * the result payload. Returns RUNNING if no result has been observed yet (initial state).
+ */
+private fun parseLatestSubAgentStatus(tools: List<UIMessagePart.Tool>): SubAgentRunStatus {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        // Use `as?` casts (same defensive pattern as parseLatestCouncilStatus) — runCatching
+        // caught the throws before, but the cast version is clearer about intent and fails open.
+        val statusStr = runCatching {
+            (JsonInstant.parseToJsonElement(outputText) as? JsonObject)?.get("status")
+                ?.let { it as? JsonPrimitive }?.contentOrNull
+        }.getOrNull() ?: continue
+        SubAgentRunStatus.entries.firstOrNull { it.name.equals(statusStr, ignoreCase = true) }
+            ?.let { return it }
+    }
+    return SubAgentRunStatus.RUNNING
+}
+
+private fun extractLatestSubAgentName(tools: List<UIMessagePart.Tool>): String? {
+    for (tool in tools.asReversed()) {
+        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
+            ?: continue
+        val parsed = runCatching {
+            JsonInstant.parseToJsonElement(outputText) as? JsonObject
+        }.getOrNull() ?: continue
+        val name = parsed.getStringContent("subagent_name")
+        if (!name.isNullOrBlank()) return name
+    }
+    return null
+}
+
+private fun SubAgentRunStatus.toAgentToolStatus(): AgentToolStatus = when (this) {
+    SubAgentRunStatus.RUNNING -> AgentToolStatus.RUNNING
+    SubAgentRunStatus.APPROVAL_REQUIRED -> AgentToolStatus.WAITING_FOR_PERMISSION
+    SubAgentRunStatus.COMPLETED -> AgentToolStatus.SUCCEEDED
+    SubAgentRunStatus.FAILED,
+    SubAgentRunStatus.TIMED_OUT,
+    SubAgentRunStatus.INTERRUPTED -> AgentToolStatus.FAILED
+    SubAgentRunStatus.CANCELLED -> AgentToolStatus.CANCELLED
+}
+
+/**
+ * Bottom sheet showing the subagent's full task spec and live streaming output. Subscribes to
+ * [SubAgentManager.liveTextFlow] so the body updates token-by-token as the run progresses.
+ *
+ * Fallback: if the live flow is empty (e.g. app was killed and the conversation reopened later,
+ * so the manager no longer holds a flow for this run), pull the final summary out of the latest
+ * subagent_wait/read tool result. Best-effort — if neither has anything we just show "等待输出".
+ */
+@Composable
+private fun SubAgentRunSheet(
+    step: ThinkingStep.SubAgentTaskStep,
+    displayName: String,
+    onDismiss: () -> Unit,
+) {
+    val manager: SubAgentManager = koinInject()
+    val context = LocalContext.current
+    val workspace = workspaceColors()
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val anchor = step.anchor
+    val arguments = remember(anchor.input) { anchor.inputAsJson() }
+    val taskObjective = remember(arguments) {
+        runCatching {
+            arguments.jsonObject["task"]?.jsonObject?.get("objective")?.jsonPrimitive?.contentOrNull
+        }.getOrNull()
+    }
+
+    // Re-derive status here (instead of receiving from parent) so the sheet stays correct even
+    // when the outer card is offscreen and not recomposing.
+    val parsedStatus = parseLatestSubAgentStatus(step.tools)
+    val isRunning = parsedStatus == SubAgentRunStatus.RUNNING
+    val statusVerb = when (parsedStatus) {
+        SubAgentRunStatus.RUNNING -> "正在工作"
+        SubAgentRunStatus.COMPLETED -> "已完成"
+        SubAgentRunStatus.FAILED -> "失败"
+        SubAgentRunStatus.CANCELLED -> "已取消"
+        SubAgentRunStatus.TIMED_OUT -> "超时"
+        SubAgentRunStatus.APPROVAL_REQUIRED -> "等待审批"
+        SubAgentRunStatus.INTERRUPTED -> "已中断"
+    }
+
+    // Live flow may be null when the manager has no record of this run (process restart, eviction).
+    // In that case create an empty fallback flow so collectAsState works.
+    val liveFlow = remember(step.runId) { manager.liveTextFlow(step.runId) ?: MutableStateFlow("") }
+    val liveText by liveFlow.collectAsState()
+    val snapshotRun = manager.snapshot(step.runId)
+    val snapshotText = snapshotRun?.displayText.orEmpty()
+    var transcriptText by remember(step.runId) { mutableStateOf("") }
+    val finalText = extractFinalSubAgentText(step.tools)
+    LaunchedEffect(step.runId, parsedStatus, liveText, snapshotText) {
+        val mayBeStaleRunningAfterRestart = isRunning && snapshotRun == null
+        if ((!isRunning || mayBeStaleRunningAfterRestart) &&
+            liveText.isBlank() &&
+            snapshotText.isBlank() &&
+            transcriptText.isBlank()
+        ) {
+            transcriptText = extractSubAgentDisplayTextFromTranscript(
+                tools = step.tools,
+                runRoot = File(context.filesDir, "amberagent/subagents/runs"),
+            )
+        }
+    }
+    val displayText = liveText.ifBlank { snapshotText.ifBlank { transcriptText.ifBlank { finalText } } }
+
+    val scrollState = rememberScrollState()
+    var followBottom by remember(step.runId) { mutableStateOf(true) }
+    LaunchedEffect(scrollState, isRunning) {
+        snapshotFlow { scrollState.value to scrollState.maxValue }
+            .collect { (value, maxValue) ->
+                if (isRunning && value >= (maxValue - 8).coerceAtLeast(0)) {
+                    followBottom = true
+                }
+            }
+    }
+    // Auto-follow only while the run is active. Once it finishes the user can scroll up freely
+    // without being yanked back to the bottom.
+    //
+    // Scroll spec mirrors ChatList.scrollToTimelineBottom (tween 80ms + LinearEasing).
+    // Default spring on ScrollState.animateScrollTo holds isScrollInProgress true for
+    // ~1s after the destination is reached, which gates off the next chunk's scroll
+    // — same shape of bug as 1.8.9's main-chat scroll regression.
+    LaunchedEffect(displayText, isRunning, followBottom) {
+        if (isRunning && followBottom) {
+            scrollState.animateScrollTo(
+                value = scrollState.maxValue,
+                animationSpec = tween(durationMillis = 80, easing = LinearEasing),
+            )
+        }
+    }
+
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismiss,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.85f)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .pointerInput(isRunning) {
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false)
+                        if (isRunning) followBottom = false
+                    }
+                }
+                .verticalScroll(scrollState),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Header
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    imageVector = HugeIcons.MagicWand01,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = workspace.muted,
+                )
+                Text(
+                    text = "@$displayName",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = workspace.ink,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = statusVerb,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = workspace.muted,
+                )
+            }
+
+            taskObjective?.takeIf { it.isNotBlank() }?.let { objective ->
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(8.dp),
+                    color = workspace.row,
+                    border = BorderStroke(1.dp, workspace.hairline),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(
+                            text = "任务",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = workspace.faint,
+                        )
+                        Text(
+                            text = objective,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = workspace.ink,
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(color = workspace.hairline)
+
+            // Live / final text body — render as Markdown so headings, bold, lists, code,
+            // hashtags-as-text etc. all show properly. Falls back to plain "waiting" text when
+            // nothing has streamed in yet.
+            if (displayText.isBlank()) {
+                Text(
+                    text = "等待输出...",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = workspace.faint,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            } else {
+                SelectionContainer {
+                    MarkdownBlock(
+                        content = displayText,
+                        modifier = Modifier.fillMaxWidth(),
+                        style = MaterialTheme.typography.bodyMedium.copy(color = workspace.ink),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageToolPreviewSheet.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageToolPreviewSheet.kt
@@ -1,0 +1,397 @@
+package me.rerere.rikkahub.ui.components.message
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastForEach
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.highlight.HighlightText
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.Delete01
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.data.repository.MemoryRepository
+import me.rerere.rikkahub.ui.components.richtext.HighlightCodeBlock
+import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
+import me.rerere.rikkahub.ui.components.richtext.ZoomableAsyncImage
+import me.rerere.rikkahub.ui.components.ui.Favicon
+import me.rerere.rikkahub.ui.components.ui.FormItem
+import me.rerere.rikkahub.utils.JsonInstant
+import me.rerere.rikkahub.utils.JsonInstantPretty
+import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
+import me.rerere.rikkahub.utils.openUrl
+import org.koin.compose.koinInject
+
+@Composable
+internal fun ToolCallPreviewSheet(
+    toolName: String,
+    arguments: JsonElement,
+    content: JsonElement?,
+    output: List<UIMessagePart>,
+    onDismissRequest: () -> Unit = {}
+) {
+    val memoryRepo: MemoryRepository = koinInject()
+    val scope = rememberCoroutineScope()
+
+    val memoryAction = arguments.getStringContent("action")
+    val isMemoryOperation = toolName == ToolNames.MEMORY &&
+        memoryAction in listOf(MemoryActions.CREATE, MemoryActions.EDIT)
+    val memoryId = (content as? JsonObject)?.get("id")?.jsonPrimitiveOrNull?.intOrNull
+
+    ModalBottomSheet(
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        onDismissRequest = onDismissRequest,
+        content = {
+            when {
+                content == null -> GenericToolPreview(
+                    toolName = toolName,
+                    arguments = arguments,
+                    output = emptyList(),
+                    isMemoryOperation = false,
+                    memoryId = null,
+                    memoryRepo = memoryRepo,
+                    scope = scope,
+                    onDismissRequest = onDismissRequest
+                )
+
+                toolName == ToolNames.SEARCH_WEB -> SearchWebPreview(
+                    arguments = arguments,
+                    content = content,
+                )
+
+                toolName == ToolNames.SCRAPE_WEB -> ScrapeWebPreview(content = content)
+                else -> GenericToolPreview(
+                    toolName = toolName,
+                    arguments = arguments,
+                    output = output,
+                    isMemoryOperation = isMemoryOperation,
+                    memoryId = memoryId,
+                    memoryRepo = memoryRepo,
+                    scope = scope,
+                    onDismissRequest = onDismissRequest
+                )
+            }
+        },
+    )
+}
+
+@Composable
+private fun SearchWebPreview(
+    arguments: JsonElement,
+    content: JsonElement,
+) {
+    val context = LocalContext.current
+    val items = content.jsonObject["items"]?.jsonArray ?: emptyList()
+    val answer = content.getStringContent("answer")
+    val query = arguments.getStringContent("query") ?: ""
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxHeight(0.8f)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        item {
+            Text(stringResource(R.string.chat_message_tool_search_prefix, query))
+        }
+
+        if (answer != null) {
+            item {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    )
+                ) {
+                    MarkdownBlock(
+                        content = answer,
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .fillMaxWidth(),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+        }
+
+        // Top-level image thumbnails (from available_images)
+        val topImages = content.jsonObject["available_images"]
+            ?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?.take(5)
+            .orEmpty()
+        if (topImages.isNotEmpty()) {
+            item {
+                Text(
+                    text = "相关图片 (${topImages.size})",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                )
+            }
+            item {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    topImages.forEach { imgUrl ->
+                        ZoomableAsyncImage(
+                            model = imgUrl,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .height(64.dp)
+                                .widthIn(max = 100.dp)
+                                .clip(RoundedCornerShape(8.dp)),
+                        )
+                    }
+                }
+            }
+        }
+
+        if (items.isNotEmpty()) {
+            items(items) { item ->
+                val url = item.getStringContent("url") ?: return@items
+                val title = item.getStringContent("title") ?: return@items
+                val text = item.getStringContent("text") ?: return@items
+                val itemImages = runCatching {
+                    item.jsonObject["images"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                }.getOrNull().orEmpty()
+
+                Card(
+                    onClick = { context.openUrl(url) },
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp, horizontal = 16.dp),
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Favicon(
+                                url = url,
+                                modifier = Modifier.size(24.dp)
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(text = title, maxLines = 1)
+                                Text(
+                                    text = text,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                                Text(
+                                    text = url,
+                                    maxLines = 1,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                                )
+                            }
+                        }
+                        // Per-item images
+                        if (itemImages.isNotEmpty()) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                modifier = Modifier.padding(top = 6.dp),
+                            ) {
+                                itemImages.take(2).forEach { imgUrl ->
+                                    ZoomableAsyncImage(
+                                        model = imgUrl,
+                                        contentDescription = null,
+                                        modifier = Modifier
+                                            .height(56.dp)
+                                            .widthIn(max = 80.dp)
+                                            .clip(RoundedCornerShape(6.dp)),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            item {
+                HighlightText(
+                    code = JsonInstantPretty.encodeToString(content),
+                    language = "json",
+                    fontSize = 12.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScrapeWebPreview(content: JsonElement) {
+    val urls = content.jsonObject["urls"]?.jsonArray ?: emptyList()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxHeight(0.8f)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        item {
+            Text(
+                text = stringResource(
+                    R.string.chat_message_tool_scrape_prefix,
+                    urls.joinToString(", ") { it.getStringContent("url") ?: "" }
+                )
+            )
+        }
+
+        items(urls) { url ->
+            val urlObject = url.jsonObject
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = urlObject["url"]?.jsonPrimitive?.content ?: "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Card {
+                    MarkdownBlock(
+                        content = urlObject["content"]?.jsonPrimitive?.content ?: "",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GenericToolPreview(
+    toolName: String,
+    arguments: JsonElement,
+    output: List<UIMessagePart>,
+    isMemoryOperation: Boolean,
+    memoryId: Int?,
+    memoryRepo: MemoryRepository,
+    scope: kotlinx.coroutines.CoroutineScope,
+    onDismissRequest: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight(0.8f)
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.chat_message_tool_call_title),
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center
+            )
+
+            if (isMemoryOperation && memoryId != null) {
+                IconButton(
+                    onClick = {
+                        scope.launch {
+                            memoryRepo.deleteMemory(memoryId)
+                            onDismissRequest()
+                        }
+                    }
+                ) {
+                    Icon(
+                        imageVector = HugeIcons.Delete01,
+                        contentDescription = "Delete memory"
+                    )
+                }
+            }
+        }
+        FormItem(
+            label = {
+                Text(stringResource(R.string.chat_message_tool_call_label, toolName))
+            }
+        ) {
+            HighlightCodeBlock(
+                code = JsonInstantPretty.encodeToString(arguments),
+                language = "json",
+                style = TextStyle(fontSize = 10.sp, lineHeight = 12.sp),
+                forceAutoWrap = true,
+            )
+        }
+        if (output.isNotEmpty()) {
+            FormItem(
+                label = {
+                    Text(stringResource(R.string.chat_message_tool_call_result))
+                }
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    output.fastForEach { part ->
+                        when (part) {
+                            is UIMessagePart.Text -> HighlightCodeBlock(
+                                code = runCatching {
+                                    JsonInstantPretty.encodeToString(
+                                        JsonInstant.parseToJsonElement(part.text)
+                                    )
+                                }.getOrElse { part.text },
+                                language = "json",
+                                style = TextStyle(fontSize = 10.sp, lineHeight = 12.sp),
+                                forceAutoWrap = true,
+                            )
+
+                            is UIMessagePart.Image -> ZoomableAsyncImage(
+                                model = part.url,
+                                contentDescription = null,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+
+                            else -> {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -37,8 +36,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.ScrollableTabRow
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
@@ -61,24 +58,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -107,12 +100,9 @@ import me.rerere.hugeicons.stroke.VolumeHigh
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.event.AppEvent
 import me.rerere.rikkahub.data.event.AppEventBus
-import me.rerere.rikkahub.data.agent.modelcouncil.ModelCouncilManager
-import me.rerere.rikkahub.data.agent.modelcouncil.ModelCouncilRolePresets
 import me.rerere.rikkahub.data.agent.subagent.SubAgentDefinitions
 import me.rerere.rikkahub.data.agent.subagent.SubAgentManager
 import me.rerere.rikkahub.data.agent.subagent.SubAgentRunStatus
-import me.rerere.rikkahub.data.agent.subagent.readSubAgentDisplayTextFromTranscript
 import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
 import me.rerere.rikkahub.ui.components.richtext.ZoomableAsyncImage
 import me.rerere.rikkahub.ui.components.ui.ChainOfThoughtScope
@@ -139,7 +129,7 @@ internal object ToolNames {
     const val USE_SKILL = "use_skill"
 }
 
-private enum class AgentToolStatus {
+internal enum class AgentToolStatus {
     RUNNING,
     WAITING_FOR_PERMISSION,
     SUCCEEDED,
@@ -147,7 +137,7 @@ private enum class AgentToolStatus {
     CANCELLED,
 }
 
-private enum class AgentToolKind {
+internal enum class AgentToolKind {
     FILE,
     TERMINAL,
     MCP,
@@ -369,7 +359,7 @@ private fun ToolStatusPill(
 }
 
 @Composable
-private fun AgentToolCallCapsule(
+internal fun AgentToolCallCapsule(
     title: String,
     toolName: String,
     icon: ImageVector,
@@ -961,7 +951,7 @@ fun SubAgentTaskStepView(
     }
 }
 
-private const val PHASE_LABEL_INTERVAL_MS = 5_000L
+internal const val PHASE_LABEL_INTERVAL_MS = 5_000L
 
 /**
  * Walk the subagent_* tools in reverse order and pick the most recent parsable `status` from
@@ -1186,660 +1176,5 @@ private fun SubAgentRunSheet(
                 }
             }
         }
-    }
-}
-
-/**
- * Render a coalesced Model Council run: one card replaces the multiple model_council_* tool calls
- * sharing one run_id. Tap → opens [ModelCouncilRunSheet] showing per-seat live streaming output
- * in a tab layout.
- */
-@Composable
-fun CouncilTaskStepView(
-    step: ThinkingStep.CouncilTaskStep,
-    loading: Boolean,
-) {
-    val manager: ModelCouncilManager = koinInject()
-    var showSheet by remember(step.runId) { mutableStateOf(false) }
-    val parsedStatus = parseLatestCouncilStatus(step.tools)
-    val isRunning = parsedStatus == ModelCouncilCardStatus.RUNNING
-    val phaseLabels = listOf("听证", "辩论", "权衡", "裁决")
-    var phaseIndex by remember(step.runId) { mutableIntStateOf(0) }
-    LaunchedEffect(step.runId, isRunning) {
-        if (!isRunning) return@LaunchedEffect
-        while (true) {
-            delay(PHASE_LABEL_INTERVAL_MS)
-            phaseIndex = (phaseIndex + 1) % phaseLabels.size
-        }
-    }
-    val currentPhase = if (isRunning) phaseLabels[phaseIndex.coerceIn(phaseLabels.indices)]
-        else phaseLabels.last()
-    val statusVerb = when (parsedStatus) {
-        ModelCouncilCardStatus.RUNNING -> "正在审议"
-        ModelCouncilCardStatus.COMPLETED -> "已完成"
-        ModelCouncilCardStatus.PARTIAL_FAILED -> "部分失败"
-        ModelCouncilCardStatus.FAILED -> "失败"
-        ModelCouncilCardStatus.CANCELLED -> "已取消"
-        ModelCouncilCardStatus.TIMED_OUT -> "超时"
-        ModelCouncilCardStatus.INTERRUPTED -> "已中断"
-    }
-    val title = if (isRunning) "@Council $statusVerb · $currentPhase" else "@Council $statusVerb"
-    val seatSubtitle = remember(step.runId, step.tools) {
-        val names = manager.snapshot(step.runId)?.seats
-            ?.map { it.name.ifBlank { ModelCouncilRolePresets.byName(it.role)?.name ?: it.role } }
-            ?.filter { it.isNotBlank() }
-            ?.takeIf { it.isNotEmpty() }
-            ?: extractCouncilSeatEntries(step.tools).map { it.label }
-        names.takeIf { it.isNotEmpty() }?.joinToString(" / ", prefix = "席位 · ")
-    }
-    AgentToolCallCapsule(
-        title = title,
-        toolName = "model_council",
-        icon = HugeIcons.MagicWand01,
-        kind = AgentToolKind.GENERIC,
-        status = parsedStatus.toAgentToolStatus(),
-        loading = loading && isRunning,
-        onClick = { showSheet = true },
-        approvalActions = null,
-        subtitle = seatSubtitle,
-    )
-
-    if (showSheet) {
-        ModelCouncilRunSheet(
-            step = step,
-            onDismiss = { showSheet = false },
-        )
-    }
-}
-
-private enum class ModelCouncilCardStatus {
-    RUNNING, COMPLETED, PARTIAL_FAILED, FAILED, CANCELLED, TIMED_OUT, INTERRUPTED
-}
-
-/** Walk model_council_* tools in reverse, find the most recent parsable `status`. */
-private fun parseLatestCouncilStatus(tools: List<UIMessagePart.Tool>): ModelCouncilCardStatus {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val statusStr = runCatching {
-            (JsonInstant.parseToJsonElement(outputText) as? JsonObject)?.get("status")
-                ?.let { it as? JsonPrimitive }?.contentOrNull
-        }.getOrNull() ?: continue
-        ModelCouncilCardStatus.entries.firstOrNull { it.name.equals(statusStr, ignoreCase = true) }
-            ?.let { return it }
-    }
-    return ModelCouncilCardStatus.RUNNING
-}
-
-private fun ModelCouncilCardStatus.toAgentToolStatus(): AgentToolStatus = when (this) {
-    ModelCouncilCardStatus.RUNNING -> AgentToolStatus.RUNNING
-    ModelCouncilCardStatus.COMPLETED,
-    ModelCouncilCardStatus.PARTIAL_FAILED -> AgentToolStatus.SUCCEEDED
-    ModelCouncilCardStatus.FAILED,
-    ModelCouncilCardStatus.TIMED_OUT,
-    ModelCouncilCardStatus.INTERRUPTED -> AgentToolStatus.FAILED
-    ModelCouncilCardStatus.CANCELLED -> AgentToolStatus.CANCELLED
-}
-
-/**
- * Bottom sheet showing the council run's task + per-seat live streaming output, organized in
- * tabs. Synthesizer pane is the default tab; each seat (in run order) gets its own tab. Falls
- * back to extracting final text from tool result when the live flow is gone (process restart).
- */
-@Composable
-private fun ModelCouncilRunSheet(
-    step: ThinkingStep.CouncilTaskStep,
-    onDismiss: () -> Unit,
-) {
-    val manager: ModelCouncilManager = koinInject()
-    val workspace = workspaceColors()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    val anchor = step.anchor
-    val arguments = remember(anchor.input) { anchor.inputAsJson() }
-    val taskObjective = remember(arguments) {
-        runCatching {
-            (arguments.jsonObject["task"] as? JsonObject)?.get("objective")?.let { it as? JsonPrimitive }?.contentOrNull
-                ?: arguments.jsonObject["objective"]?.let { it as? JsonPrimitive }?.contentOrNull
-        }.getOrNull()
-    }
-
-    val parsedStatus = parseLatestCouncilStatus(step.tools)
-    val isRunning = parsedStatus == ModelCouncilCardStatus.RUNNING
-    val statusVerb = when (parsedStatus) {
-        ModelCouncilCardStatus.RUNNING -> "正在审议"
-        ModelCouncilCardStatus.COMPLETED -> "已完成"
-        ModelCouncilCardStatus.PARTIAL_FAILED -> "部分失败"
-        ModelCouncilCardStatus.FAILED -> "失败"
-        ModelCouncilCardStatus.CANCELLED -> "已取消"
-        ModelCouncilCardStatus.TIMED_OUT -> "超时"
-        ModelCouncilCardStatus.INTERRUPTED -> "已中断"
-    }
-
-    // Resolve seat list from the snapshot (preserves run order). Synthesizer is appended last.
-    val snapshot = remember(step.runId) { manager.snapshot(step.runId) }
-    val seatTabs = remember(step.runId, snapshot?.seats, step.tools) {
-        val seatEntries = snapshot?.seats?.map { seat ->
-            CouncilTabEntry(
-                key = seat.seatId,
-                label = seat.name.ifBlank { ModelCouncilRolePresets.byName(seat.role)?.name ?: seat.role },
-            )
-        }?.takeIf { it.isNotEmpty() } ?: extractCouncilSeatEntries(step.tools)
-        // Synthesizer pane is conceptually the "verdict"; show it first so the user sees the
-        // bottom-line answer immediately when the run finishes.
-        listOf(CouncilTabEntry(ModelCouncilManager.SYNTHESIZER_SEAT_KEY, "综合裁决")) + seatEntries
-    }
-
-    // While the run is still going, default to the FIRST seat tab (index 1) instead of the
-    // synthesizer (index 0) — the synthesizer has nothing to show until debate is over.
-    // After completion, jump to synthesizer (index 0) for the verdict.
-    val initialTab = if (isRunning && seatTabs.size > 1) 1 else 0
-    var selectedTab by remember(step.runId, isRunning) { mutableIntStateOf(initialTab) }
-    val safeSelected = selectedTab.coerceIn(0, (seatTabs.size - 1).coerceAtLeast(0))
-
-    ModalBottomSheet(
-        sheetState = sheetState,
-        onDismissRequest = onDismiss,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(0.85f)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            // Header
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(
-                    imageVector = HugeIcons.MagicWand01,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = workspace.muted,
-                )
-                Text(
-                    text = "@Council",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = workspace.ink,
-                )
-                Spacer(Modifier.weight(1f))
-                Text(
-                    text = statusVerb,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = workspace.muted,
-                )
-            }
-
-            taskObjective?.takeIf { it.isNotBlank() }?.let { objective ->
-                CouncilObjectiveCard(objective = objective)
-            }
-
-            if (seatTabs.isNotEmpty()) {
-                ScrollableTabRow(
-                    selectedTabIndex = safeSelected,
-                    edgePadding = 0.dp,
-                    containerColor = workspace.paper,
-                    contentColor = workspace.ink,
-                ) {
-                    seatTabs.forEachIndexed { index, tab ->
-                        Tab(
-                            selected = index == safeSelected,
-                            onClick = { selectedTab = index },
-                            text = {
-                                Text(
-                                    text = tab.label,
-                                    style = MaterialTheme.typography.labelMedium,
-                                )
-                            },
-                        )
-                    }
-                }
-            }
-
-            HorizontalDivider(color = workspace.hairline)
-
-            // Active tab body — subscribe to the seat's live flow + auto-scroll while running.
-            val activeSeatKey = seatTabs.getOrNull(safeSelected)?.key
-            val seatFlow = remember(step.runId, activeSeatKey) {
-                activeSeatKey?.let { manager.liveTextFlow(step.runId, it) } ?: MutableStateFlow("")
-            }
-            val liveText by seatFlow.collectAsState()
-            val finalText = remember(step.tools, activeSeatKey) {
-                if (activeSeatKey == ModelCouncilManager.SYNTHESIZER_SEAT_KEY) {
-                    extractFinalCouncilSynthesisText(step.tools)
-                } else if (activeSeatKey != null) {
-                    extractFinalCouncilSeatText(step.tools, activeSeatKey)
-                } else ""
-            }
-            val displayTextSource = if (isRunning) {
-                liveText.ifBlank { finalText }
-            } else {
-                finalText.ifBlank { liveText }
-            }
-            val displayText = displayTextSource.cleanCouncilLineBreaks()
-            val activeModelLabel = remember(step.tools, activeSeatKey) {
-                activeSeatKey?.let { extractCouncilModelLabel(step.tools, it) }.orEmpty()
-            }
-            val scrollState = rememberScrollState()
-            var followBottom by remember(step.runId, activeSeatKey) { mutableStateOf(true) }
-            LaunchedEffect(scrollState, isRunning, activeSeatKey) {
-                snapshotFlow { scrollState.value to scrollState.maxValue }
-                    .collect { (value, maxValue) ->
-                        if (isRunning && value >= (maxValue - 8).coerceAtLeast(0)) {
-                            followBottom = true
-                        }
-                    }
-            }
-            // Scroll spec aligned with ChatList.scrollToTimelineBottom — tween 80ms,
-            // LinearEasing. Default spring's long settle holds isScrollInProgress and
-            // would gate off subsequent chunks (same regression shape 1.8.10 fixed
-            // on the main chat path).
-            LaunchedEffect(displayText, isRunning, activeSeatKey, followBottom) {
-                if (isRunning && followBottom) {
-                    scrollState.animateScrollTo(
-                        value = scrollState.maxValue,
-                        animationSpec = tween(durationMillis = 80, easing = LinearEasing),
-                    )
-                }
-            }
-            if (activeModelLabel.isNotBlank()) {
-                Text(
-                    text = activeModelLabel,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = workspace.faint,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .pointerInput(isRunning, activeSeatKey) {
-                        awaitEachGesture {
-                            awaitFirstDown(requireUnconsumed = false)
-                            if (isRunning) followBottom = false
-                        }
-                    }
-                    .verticalScroll(scrollState),
-            ) {
-                if (displayText.isBlank()) {
-                    Text(
-                        text = if (isRunning) "等待此席位输出..." else "（无输出）",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = workspace.faint,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                } else {
-                    SelectionContainer(
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        CouncilRoundContent(
-                            content = displayText,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-private data class CouncilTabEntry(val key: String, val label: String)
-
-private data class CouncilRoundSection(
-    val label: String?,
-    val content: String,
-)
-
-@Composable
-private fun CouncilRoundContent(
-    content: String,
-    modifier: Modifier = Modifier,
-) {
-    val sections = remember(content) { content.toCouncilRoundSections() }
-    val workspace = workspaceColors()
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        sections.forEach { section ->
-            section.label?.let { CouncilRoundDivider(label = it) }
-            if (section.content.isNotBlank()) {
-                MarkdownBlock(
-                    content = section.content,
-                    modifier = Modifier.fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyMedium.copy(color = workspace.ink),
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CouncilRoundDivider(label: String) {
-    val workspace = workspaceColors()
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Surface(
-            shape = RoundedCornerShape(50),
-            color = workspace.blue.copy(alpha = 0.12f),
-            border = BorderStroke(1.dp, workspace.blue.copy(alpha = 0.24f)),
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = workspace.blue,
-                fontWeight = FontWeight.Medium,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-            )
-        }
-        HorizontalDivider(
-            modifier = Modifier.weight(1f),
-            color = workspace.blue.copy(alpha = 0.20f),
-        )
-    }
-}
-
-@Composable
-private fun CouncilObjectiveCard(objective: String) {
-    val workspace = workspaceColors()
-    val shouldCollapse = remember(objective) { objective.shouldCollapseCouncilObjective() }
-    var expanded by remember(objective) { mutableStateOf(!shouldCollapse) }
-    val objectiveScrollState = rememberScrollState()
-
-    Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .animateContentSize()
-            .clickable(enabled = shouldCollapse) { expanded = !expanded },
-        shape = RoundedCornerShape(8.dp),
-        color = workspace.row,
-        border = BorderStroke(1.dp, workspace.hairline),
-    ) {
-        Column(
-            modifier = Modifier.padding(10.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = "议题",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = workspace.faint,
-                    modifier = Modifier.weight(1f),
-                )
-                if (shouldCollapse) {
-                    Text(
-                        text = if (expanded) "收起" else "展开",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = workspace.blue,
-                    )
-                }
-            }
-            Text(
-                text = objective,
-                style = MaterialTheme.typography.bodySmall,
-                color = workspace.ink,
-                maxLines = if (expanded) Int.MAX_VALUE else COUNCIL_OBJECTIVE_COLLAPSED_LINES,
-                overflow = if (expanded) TextOverflow.Clip else TextOverflow.Ellipsis,
-                modifier = if (expanded && shouldCollapse) {
-                    Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 220.dp)
-                        .verticalScroll(objectiveScrollState)
-                } else {
-                    Modifier.fillMaxWidth()
-                },
-            )
-        }
-    }
-}
-
-private fun String.shouldCollapseCouncilObjective(): Boolean {
-    val lineCount = lineSequence().count()
-    return length > COUNCIL_OBJECTIVE_COLLAPSE_CHARS || lineCount > COUNCIL_OBJECTIVE_COLLAPSE_LINES
-}
-
-private fun String.toCouncilRoundSections(): List<CouncilRoundSection> {
-    if (!contains(COUNCIL_ROUND_MARKER_TEXT)) {
-        return listOf(CouncilRoundSection(label = null, content = this))
-    }
-    val sections = mutableListOf<CouncilRoundSection>()
-    var label: String? = null
-    val body = StringBuilder()
-
-    fun flush() {
-        val content = body.toString().trim('\n')
-        if (label != null || content.isNotBlank()) {
-            sections += CouncilRoundSection(label = label, content = content)
-        }
-        body.clear()
-    }
-
-    lineSequence().forEach { line ->
-        val match = COUNCIL_ROUND_MARKER.matchEntire(line.trim())
-        if (match != null) {
-            flush()
-            label = match.groupValues[1].replace(Regex("""\s+"""), " ")
-        } else {
-            body.appendLine(line)
-        }
-    }
-    flush()
-
-    return sections.ifEmpty { listOf(CouncilRoundSection(label = null, content = this)) }
-}
-
-private const val COUNCIL_OBJECTIVE_COLLAPSED_LINES = 3
-private const val COUNCIL_OBJECTIVE_COLLAPSE_LINES = 5
-private const val COUNCIL_OBJECTIVE_COLLAPSE_CHARS = 180
-private const val COUNCIL_ROUND_MARKER_TEXT = "--- 第"
-private val COUNCIL_ROUND_MARKER = Regex("""---\s*(第\s*\d+\s*轮)\s*---""")
-
-/** Pull the synthesizer's final text from the latest read/wait result (`result.finalRecommendation`). */
-private fun extractFinalCouncilSynthesisText(tools: List<UIMessagePart.Tool>): String {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val parsed = runCatching {
-            JsonInstant.parseToJsonElement(outputText) as? JsonObject
-        }.getOrNull() ?: continue
-        val result = parsed.payloadObject("result") ?: continue
-        val recommendation = ((result["final_recommendation"] as? JsonPrimitive)?.contentOrNull)
-            ?.takeIf { it.isNotBlank() }
-            ?: ((result["error"] as? JsonPrimitive)?.contentOrNull)
-        if (!recommendation.isNullOrBlank()) return recommendation
-    }
-    return ""
-}
-
-/** Pull the provider/model label for a council seat or synthesizer from the latest payload. */
-private fun extractCouncilModelLabel(tools: List<UIMessagePart.Tool>, seatId: String): String {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val parsed = runCatching {
-            JsonInstant.parseToJsonElement(outputText) as? JsonObject
-        }.getOrNull() ?: continue
-        val labels = parsed["seat_model_labels"] as? JsonObject
-        val direct = (labels?.get(seatId) as? JsonPrimitive)?.contentOrNull
-        if (!direct.isNullOrBlank()) return direct
-
-        val parsedTurns = parsed.payloadArray("turns") ?: continue
-        parsedTurns.forEach { turnElement ->
-            val turn = turnElement as? JsonObject ?: return@forEach
-            val tSeatId = (turn["seat_id"] as? JsonPrimitive)?.contentOrNull
-            if (tSeatId != seatId) return@forEach
-            val providerName = (turn["provider_name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
-            val modelName = (turn["model_name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
-            val label = listOf(providerName, modelName)
-                .filter { it.isNotBlank() }
-                .joinToString(" / ")
-            if (label.isNotBlank()) return label
-        }
-    }
-    return ""
-}
-
-private fun extractCouncilSeatEntries(tools: List<UIMessagePart.Tool>): List<CouncilTabEntry> {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val parsed = runCatching {
-            JsonInstant.parseToJsonElement(outputText) as? JsonObject
-        }.getOrNull() ?: continue
-        val parsedTurns = parsed.payloadArray("turns") ?: continue
-        val entries = linkedMapOf<String, String>()
-        parsedTurns.forEach { turnElement ->
-            val turn = turnElement as? JsonObject ?: return@forEach
-            val seatId = (turn["seat_id"] as? JsonPrimitive)?.contentOrNull
-                ?.takeIf { it.isNotBlank() }
-                ?: return@forEach
-            val name = (turn["seat_name"] as? JsonPrimitive)?.contentOrNull
-                ?.takeIf { it.isNotBlank() }
-                ?: return@forEach
-            entries.putIfAbsent(seatId, name)
-        }
-        if (entries.isNotEmpty()) {
-            return entries.map { (seatId, name) -> CouncilTabEntry(key = seatId, label = name) }
-        }
-    }
-    return emptyList()
-}
-
-/**
- * Pull a specific seat's content across ALL rounds from the latest tool result, joined the same
- * way the live flow renders them (with `--- 第 N 轮 ---` separators between rounds 2+). Walking
- * tools in reverse means we pick the most recent (richest) turns array; within it, all matching
- * turns are kept in original order.
- */
-private fun extractFinalCouncilSeatText(tools: List<UIMessagePart.Tool>, seatId: String): String {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val parsed = runCatching {
-            JsonInstant.parseToJsonElement(outputText) as? JsonObject
-        }.getOrNull() ?: continue
-        val parsedTurns = parsed.payloadArray("turns") ?: continue
-        val matching = parsedTurns.mapNotNull { turnElement ->
-            val turn = turnElement as? JsonObject ?: return@mapNotNull null
-            val tSeatId = (turn["seat_id"] as? JsonPrimitive)?.contentOrNull
-            if (tSeatId != seatId) return@mapNotNull null
-            val round = (turn["round"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull() ?: 1
-            val warnings = (turn["warnings"] as? JsonArray)?.mapNotNull { warning ->
-                (warning as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
-            }.orEmpty()
-            val content = (turn["content"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
-                ?: (turn["error"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }?.let { "失败：$it" }
-                ?: return@mapNotNull null
-            val text = buildString {
-                warnings.forEach { warning -> appendLine("提示：$warning") }
-                if (warnings.isNotEmpty()) appendLine()
-                append(content)
-            }
-            round to text
-        }.sortedBy { it.first }
-        if (matching.isNotEmpty()) {
-            return matching.joinToString("\n\n") { (round, content) ->
-                "--- 第 $round 轮 ---\n\n$content"
-            }
-        }
-    }
-    return ""
-}
-
-private fun JsonObject.payloadObject(name: String): JsonObject? {
-    val value = this[name] ?: return null
-    return (value as? JsonObject)
-        ?: (value as? JsonPrimitive)?.contentOrNull?.let { raw ->
-            runCatching { JsonInstant.parseToJsonElement(raw) as? JsonObject }.getOrNull()
-        }
-}
-
-private fun JsonObject.payloadArray(name: String): JsonArray? {
-    val value = this[name] ?: return null
-    return (value as? JsonArray)
-        ?: (value as? JsonPrimitive)?.contentOrNull?.let { raw ->
-            runCatching { JsonInstant.parseToJsonElement(raw).jsonArray }.getOrNull()
-        }
-}
-
-/**
- * Pull the canonical final-text field from the latest tool result.
- *
- * Note: [me.rerere.rikkahub.data.agent.subagent.SubAgentManager.runToPayload] encodes the
- * `SubAgentResult` as a **JSON-encoded string field** (calls `json.encodeToString(result)` and
- * stores the resulting string), not a nested object. So `payload["result"]` is a
- * `JsonPrimitive` carrying serialized JSON text — must be re-parsed before reading `summary`.
- * Every cast uses `as?` to avoid `Element X is not a JsonObject` crashes on partial / shaped-
- * differently outputs.
- */
-private fun extractFinalSubAgentText(tools: List<UIMessagePart.Tool>): String {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val parsed = runCatching {
-            JsonInstant.parseToJsonElement(outputText) as? JsonObject
-        }.getOrNull() ?: continue
-        val resultStr = (parsed["result"] as? JsonPrimitive)?.contentOrNull
-        val nestedSummary = resultStr?.let { rs ->
-            runCatching {
-                ((JsonInstant.parseToJsonElement(rs) as? JsonObject)?.get("summary")
-                    as? JsonPrimitive)?.contentOrNull
-            }.getOrNull()
-        }
-        val summary = nestedSummary
-            ?: (parsed["summary"] as? JsonPrimitive)?.contentOrNull
-        if (!summary.isNullOrBlank()) return summary
-    }
-    return ""
-}
-
-private suspend fun extractSubAgentDisplayTextFromTranscript(
-    tools: List<UIMessagePart.Tool>,
-    runRoot: File,
-): String =
-    withContext(Dispatchers.IO) {
-        val transcriptPath = tools.asReversed().firstNotNullOfOrNull { tool ->
-            val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-                ?: return@firstNotNullOfOrNull null
-            runCatching {
-                val parsed = JsonInstant.parseToJsonElement(outputText) as? JsonObject
-                    ?: return@runCatching null
-                val explicitPath = (parsed["transcript_path"] as? JsonPrimitive)?.contentOrNull
-                explicitPath ?: (parsed["run_id"] as? JsonPrimitive)?.contentOrNull
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let { runId -> File(runRoot, "$runId.jsonl").absolutePath }
-            }.getOrNull()
-        } ?: return@withContext ""
-
-        readSubAgentDisplayTextFromTranscript(transcriptPath, runRoot)
-    }
-
-/**
- * Fix legacy council text where [UIMessage.toText] joined streaming deltas with "\n" separators,
- * producing single-character lines like "根据\n常见\n控\n糖\n...". Collapses spurious line breaks
- * while preserving intentional paragraph breaks (double newlines) and Markdown structure.
- */
-private fun String.cleanCouncilLineBreaks(): String {
-    if (!contains('\n')) return this
-    val lines = lines()
-    val shortLineRatio = lines.count { it.trim().length in 1..3 }.toFloat() / lines.size.coerceAtLeast(1)
-    if (shortLineRatio < 0.35f) return this
-    return replace(Regex("""(?<!\n)\n(?!\n)""")) { match ->
-        val before = getOrNull(match.range.first - 1)
-        val after = getOrNull(match.range.last + 1)
-        if (before in listOf(':', '-', '。', '！', '？', '.', '!', '?') || after == '#' || after == '-' || after == '*') "\n"
-        else ""
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -5,18 +5,13 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -25,51 +20,35 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
@@ -100,10 +79,6 @@ import me.rerere.hugeicons.stroke.VolumeHigh
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.event.AppEvent
 import me.rerere.rikkahub.data.event.AppEventBus
-import me.rerere.rikkahub.data.agent.subagent.SubAgentDefinitions
-import me.rerere.rikkahub.data.agent.subagent.SubAgentManager
-import me.rerere.rikkahub.data.agent.subagent.SubAgentRunStatus
-import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
 import me.rerere.rikkahub.ui.components.richtext.ZoomableAsyncImage
 import me.rerere.rikkahub.ui.components.ui.ChainOfThoughtScope
 import me.rerere.rikkahub.ui.components.ui.FaviconRow
@@ -116,7 +91,6 @@ import me.rerere.rikkahub.ui.modifier.shimmer
 import me.rerere.rikkahub.utils.JsonInstant
 import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
 import org.koin.compose.koinInject
-import java.io.File
 
 internal object ToolNames {
     const val MEMORY = "memory_tool"
@@ -860,321 +834,5 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
             output = tool.output,
             onDismissRequest = { showResult = false }
         )
-    }
-}
-
-/**
- * Render a coalesced subagent task: one card replaces the multiple subagent_* tool calls
- * (start / wait / read / cancel) that share a run_id.
- *
- * Status is derived from the parsed `status` field of the latest wait/read output (most
- * authoritative view of the subagent's actual state); falls back to RUNNING if no result
- * has arrived yet. While running, cycles through the role's [phaseLabels] every few seconds
- * to give a sense of progression. Phase 5 wires the click to an expandable run sheet.
- */
-@Composable
-fun SubAgentTaskStepView(
-    step: ThinkingStep.SubAgentTaskStep,
-    loading: Boolean,
-) {
-    var showSheet by remember(step.runId) { mutableStateOf(false) }
-    val anchor = step.anchor
-    val arguments = remember(anchor.input) { anchor.inputAsJson() }
-    val subagentId = arguments.getStringContent("subagent_id") ?: "subagent"
-    val def = remember(subagentId) { SubAgentDefinitions.find(subagentId) }
-    val customName = arguments.jsonObjectOrNull
-        ?.payloadObject("custom_subagent")
-        ?.getStringContent("name")
-        ?.takeIf { it.isNotBlank() }
-    val displayName = extractLatestSubAgentName(step.tools)
-        ?: customName
-        ?: def?.name
-        ?: subagentId
-
-    // coalesceSubAgentSteps rebuilds step.tools each render even when contents are identical,
-    // so remember(step.tools) wouldn't actually memoize — drop the wrap; the parse is cheap.
-    val parsedStatus = parseLatestSubAgentStatus(step.tools)
-    val isRunning = parsedStatus == SubAgentRunStatus.RUNNING
-
-    val phaseLabels = def?.phaseLabels.orEmpty()
-    // Reset cycle when role's phaseLabels list changes (mid-run edits to a custom role would
-    // otherwise leave phaseIndex pointing past the new list's end).
-    var phaseIndex by remember(step.runId, phaseLabels) { mutableIntStateOf(0) }
-    LaunchedEffect(step.runId, isRunning, phaseLabels.size) {
-        if (!isRunning || phaseLabels.size <= 1) return@LaunchedEffect
-        while (true) {
-            delay(PHASE_LABEL_INTERVAL_MS)
-            phaseIndex = (phaseIndex + 1) % phaseLabels.size
-        }
-    }
-    val currentPhase = when {
-        phaseLabels.isEmpty() -> ""
-        isRunning -> phaseLabels[phaseIndex.coerceIn(phaseLabels.indices)]
-        else -> phaseLabels.last()
-    }
-
-    val statusVerb = when (parsedStatus) {
-        SubAgentRunStatus.RUNNING -> "正在工作"
-        SubAgentRunStatus.COMPLETED -> "已完成"
-        SubAgentRunStatus.FAILED -> "失败"
-        SubAgentRunStatus.CANCELLED -> "已取消"
-        SubAgentRunStatus.TIMED_OUT -> "超时"
-        SubAgentRunStatus.APPROVAL_REQUIRED -> "等待审批"
-        SubAgentRunStatus.INTERRUPTED -> "已中断"
-    }
-    val title = if (isRunning && currentPhase.isNotBlank()) {
-        "@$displayName $statusVerb · $currentPhase"
-    } else {
-        "@$displayName $statusVerb"
-    }
-
-    AgentToolCallCapsule(
-        title = title,
-        toolName = "subagent_task",
-        icon = HugeIcons.MagicWand01,
-        kind = AgentToolKind.GENERIC,
-        status = parsedStatus.toAgentToolStatus(),
-        loading = loading && isRunning,
-        onClick = { showSheet = true },
-        approvalActions = null,
-    )
-
-    if (showSheet) {
-        // Sheet derives its own status — sheet may outlive the outer card's recomposition
-        // (e.g. card scrolled offscreen in a LazyColumn while sheet is still open), so we
-        // can't rely on parent-passed verb staying fresh.
-        SubAgentRunSheet(
-            step = step,
-            displayName = displayName,
-            onDismiss = { showSheet = false },
-        )
-    }
-}
-
-internal const val PHASE_LABEL_INTERVAL_MS = 5_000L
-
-/**
- * Walk the subagent_* tools in reverse order and pick the most recent parsable `status` from
- * the result payload. Returns RUNNING if no result has been observed yet (initial state).
- */
-private fun parseLatestSubAgentStatus(tools: List<UIMessagePart.Tool>): SubAgentRunStatus {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        // Use `as?` casts (same defensive pattern as parseLatestCouncilStatus) — runCatching
-        // caught the throws before, but the cast version is clearer about intent and fails open.
-        val statusStr = runCatching {
-            (JsonInstant.parseToJsonElement(outputText) as? JsonObject)?.get("status")
-                ?.let { it as? JsonPrimitive }?.contentOrNull
-        }.getOrNull() ?: continue
-        SubAgentRunStatus.entries.firstOrNull { it.name.equals(statusStr, ignoreCase = true) }
-            ?.let { return it }
-    }
-    return SubAgentRunStatus.RUNNING
-}
-
-private fun extractLatestSubAgentName(tools: List<UIMessagePart.Tool>): String? {
-    for (tool in tools.asReversed()) {
-        val outputText = tool.output.filterIsInstance<UIMessagePart.Text>().firstOrNull()?.text
-            ?: continue
-        val parsed = runCatching {
-            JsonInstant.parseToJsonElement(outputText) as? JsonObject
-        }.getOrNull() ?: continue
-        val name = parsed.getStringContent("subagent_name")
-        if (!name.isNullOrBlank()) return name
-    }
-    return null
-}
-
-private fun SubAgentRunStatus.toAgentToolStatus(): AgentToolStatus = when (this) {
-    SubAgentRunStatus.RUNNING -> AgentToolStatus.RUNNING
-    SubAgentRunStatus.APPROVAL_REQUIRED -> AgentToolStatus.WAITING_FOR_PERMISSION
-    SubAgentRunStatus.COMPLETED -> AgentToolStatus.SUCCEEDED
-    SubAgentRunStatus.FAILED,
-    SubAgentRunStatus.TIMED_OUT,
-    SubAgentRunStatus.INTERRUPTED -> AgentToolStatus.FAILED
-    SubAgentRunStatus.CANCELLED -> AgentToolStatus.CANCELLED
-}
-
-/**
- * Bottom sheet showing the subagent's full task spec and live streaming output. Subscribes to
- * [SubAgentManager.liveTextFlow] so the body updates token-by-token as the run progresses.
- *
- * Fallback: if the live flow is empty (e.g. app was killed and the conversation reopened later,
- * so the manager no longer holds a flow for this run), pull the final summary out of the latest
- * subagent_wait/read tool result. Best-effort — if neither has anything we just show "等待输出".
- */
-@Composable
-private fun SubAgentRunSheet(
-    step: ThinkingStep.SubAgentTaskStep,
-    displayName: String,
-    onDismiss: () -> Unit,
-) {
-    val manager: SubAgentManager = koinInject()
-    val context = LocalContext.current
-    val workspace = workspaceColors()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
-    val anchor = step.anchor
-    val arguments = remember(anchor.input) { anchor.inputAsJson() }
-    val taskObjective = remember(arguments) {
-        runCatching {
-            arguments.jsonObject["task"]?.jsonObject?.get("objective")?.jsonPrimitive?.contentOrNull
-        }.getOrNull()
-    }
-
-    // Re-derive status here (instead of receiving from parent) so the sheet stays correct even
-    // when the outer card is offscreen and not recomposing.
-    val parsedStatus = parseLatestSubAgentStatus(step.tools)
-    val isRunning = parsedStatus == SubAgentRunStatus.RUNNING
-    val statusVerb = when (parsedStatus) {
-        SubAgentRunStatus.RUNNING -> "正在工作"
-        SubAgentRunStatus.COMPLETED -> "已完成"
-        SubAgentRunStatus.FAILED -> "失败"
-        SubAgentRunStatus.CANCELLED -> "已取消"
-        SubAgentRunStatus.TIMED_OUT -> "超时"
-        SubAgentRunStatus.APPROVAL_REQUIRED -> "等待审批"
-        SubAgentRunStatus.INTERRUPTED -> "已中断"
-    }
-
-    // Live flow may be null when the manager has no record of this run (process restart, eviction).
-    // In that case create an empty fallback flow so collectAsState works.
-    val liveFlow = remember(step.runId) { manager.liveTextFlow(step.runId) ?: MutableStateFlow("") }
-    val liveText by liveFlow.collectAsState()
-    val snapshotRun = manager.snapshot(step.runId)
-    val snapshotText = snapshotRun?.displayText.orEmpty()
-    var transcriptText by remember(step.runId) { mutableStateOf("") }
-    val finalText = extractFinalSubAgentText(step.tools)
-    LaunchedEffect(step.runId, parsedStatus, liveText, snapshotText) {
-        val mayBeStaleRunningAfterRestart = isRunning && snapshotRun == null
-        if ((!isRunning || mayBeStaleRunningAfterRestart) &&
-            liveText.isBlank() &&
-            snapshotText.isBlank() &&
-            transcriptText.isBlank()
-        ) {
-            transcriptText = extractSubAgentDisplayTextFromTranscript(
-                tools = step.tools,
-                runRoot = File(context.filesDir, "amberagent/subagents/runs"),
-            )
-        }
-    }
-    val displayText = liveText.ifBlank { snapshotText.ifBlank { transcriptText.ifBlank { finalText } } }
-
-    val scrollState = rememberScrollState()
-    var followBottom by remember(step.runId) { mutableStateOf(true) }
-    LaunchedEffect(scrollState, isRunning) {
-        snapshotFlow { scrollState.value to scrollState.maxValue }
-            .collect { (value, maxValue) ->
-                if (isRunning && value >= (maxValue - 8).coerceAtLeast(0)) {
-                    followBottom = true
-                }
-            }
-    }
-    // Auto-follow only while the run is active. Once it finishes the user can scroll up freely
-    // without being yanked back to the bottom.
-    //
-    // Scroll spec mirrors ChatList.scrollToTimelineBottom (tween 80ms + LinearEasing).
-    // Default spring on ScrollState.animateScrollTo holds isScrollInProgress true for
-    // ~1s after the destination is reached, which gates off the next chunk's scroll
-    // — same shape of bug as 1.8.9's main-chat scroll regression.
-    LaunchedEffect(displayText, isRunning, followBottom) {
-        if (isRunning && followBottom) {
-            scrollState.animateScrollTo(
-                value = scrollState.maxValue,
-                animationSpec = tween(durationMillis = 80, easing = LinearEasing),
-            )
-        }
-    }
-
-    ModalBottomSheet(
-        sheetState = sheetState,
-        onDismissRequest = onDismiss,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(0.85f)
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .pointerInput(isRunning) {
-                    awaitEachGesture {
-                        awaitFirstDown(requireUnconsumed = false)
-                        if (isRunning) followBottom = false
-                    }
-                }
-                .verticalScroll(scrollState),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            // Header
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(
-                    imageVector = HugeIcons.MagicWand01,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                    tint = workspace.muted,
-                )
-                Text(
-                    text = "@$displayName",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = workspace.ink,
-                )
-                Spacer(Modifier.weight(1f))
-                Text(
-                    text = statusVerb,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = workspace.muted,
-                )
-            }
-
-            taskObjective?.takeIf { it.isNotBlank() }?.let { objective ->
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(8.dp),
-                    color = workspace.row,
-                    border = BorderStroke(1.dp, workspace.hairline),
-                ) {
-                    Column(
-                        modifier = Modifier.padding(10.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        Text(
-                            text = "任务",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = workspace.faint,
-                        )
-                        Text(
-                            text = objective,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = workspace.ink,
-                        )
-                    }
-                }
-            }
-
-            HorizontalDivider(color = workspace.hairline)
-
-            // Live / final text body — render as Markdown so headings, bold, lists, code,
-            // hashtags-as-text etc. all show properly. Falls back to plain "waiting" text when
-            // nothing has streamed in yet.
-            if (displayText.isBlank()) {
-                Text(
-                    text = "等待输出...",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = workspace.faint,
-                    modifier = Modifier.padding(top = 8.dp),
-                )
-            } else {
-                SelectionContainer {
-                    MarkdownBlock(
-                        content = displayText,
-                        modifier = Modifier.fillMaxWidth(),
-                        style = MaterialTheme.typography.bodyMedium.copy(color = workspace.ink),
-                    )
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -36,9 +34,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
@@ -49,17 +44,13 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -85,11 +76,9 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -127,7 +116,6 @@ import me.rerere.rikkahub.data.agent.subagent.readSubAgentDisplayTextFromTranscr
 import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
 import me.rerere.rikkahub.ui.components.richtext.ZoomableAsyncImage
 import me.rerere.rikkahub.ui.components.ui.ChainOfThoughtScope
-import me.rerere.rikkahub.ui.components.ui.DotLoading
 import me.rerere.rikkahub.ui.components.ui.FaviconRow
 import me.rerere.rikkahub.ui.components.ui.WorkspaceIconButton
 import me.rerere.rikkahub.ui.components.ui.WorkspaceLeadingIcon
@@ -883,403 +871,6 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
             onDismissRequest = { showResult = false }
         )
     }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun ChainOfThoughtScope.AskUserToolStep(
-    tool: UIMessagePart.Tool,
-    loading: Boolean,
-    onToolAnswer: ((toolCallId: String, answer: String) -> Unit)?,
-) {
-    val isPending = tool.approvalState is ToolApprovalState.Pending
-    val isAnswered = tool.approvalState is ToolApprovalState.Answered
-    val arguments = remember(tool.input) { tool.inputAsJson() }
-    val answeredAnswers = remember(tool.approvalState) {
-        val state = tool.approvalState
-        if (state is ToolApprovalState.Answered) {
-            runCatching {
-                JsonInstant.parseToJsonElement(state.answer)
-                    .jsonObject["answers"]?.jsonObject
-            }.getOrNull()
-        } else {
-            null
-        }
-    }
-
-    // Parse questions from arguments
-    val questions = remember(arguments) {
-        runCatching {
-            arguments.jsonObject["questions"]?.jsonArray?.map { q ->
-                val obj = q.jsonObject
-                AskUserQuestion(
-                    id = obj["id"]?.jsonPrimitive?.contentOrNull ?: "",
-                    question = obj["question"]?.jsonPrimitive?.contentOrNull ?: "",
-                    options = obj["options"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList(),
-                    selectionType = obj["selection_type"]?.jsonPrimitive?.contentOrNull ?: "text"
-                )
-            } ?: emptyList()
-        }.getOrElse { emptyList() }
-    }
-
-    // Track answers for text/single questions
-    val answers = remember { mutableStateMapOf<String, String>() }
-    // Track selected options for multi questions
-    val multiAnswers = remember { mutableStateMapOf<String, Set<String>>() }
-
-    val firstQuestion = questions.firstOrNull()?.question ?: "..."
-
-    var expanded by remember { mutableStateOf(true) }
-    val workspace = workspaceColors()
-
-    ControlledChainOfThoughtStep(
-        expanded = expanded,
-        onExpandedChange = { expanded = it },
-        icon = {
-            if (loading) {
-                DotLoading(size = 10.dp)
-            } else {
-                Icon(
-                    imageVector = HugeIcons.BubbleChatQuestion,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-            }
-        },
-        label = {
-            Text(
-                text = if (questions.size <= 1) firstQuestion else stringResource(
-                    R.string.chat_message_tool_ask_questions,
-                    questions.size
-                ),
-                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Medium),
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.shimmer(isLoading = loading),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        content = {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(14.dp),
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                questions.forEachIndexed { index, q ->
-                    if (index > 0) {
-                        HorizontalDivider(
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
-                            thickness = 0.5.dp,
-                        )
-                    }
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Text(
-                            text = q.question,
-                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-
-                        if (isPending && onToolAnswer != null) {
-                            when (q.selectionType) {
-                                "single" -> {
-                                    if (q.options.isNotEmpty()) {
-                                        FlowRow(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                                        ) {
-                                            q.options.forEach { option ->
-                                                AskOptionChip(
-                                                    selected = answers[q.id] == option,
-                                                    label = option,
-                                                    onClick = { answers[q.id] = option },
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                                "multi" -> {
-                                    if (q.options.isNotEmpty()) {
-                                        FlowRow(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                                        ) {
-                                            q.options.forEach { option ->
-                                                val selectedSet = multiAnswers[q.id] ?: emptySet()
-                                                AskOptionChip(
-                                                    selected = selectedSet.contains(option),
-                                                    label = option,
-                                                    onClick = {
-                                                        val current = selectedSet.toMutableSet()
-                                                        if (current.contains(option)) current.remove(option)
-                                                        else current.add(option)
-                                                        multiAnswers[q.id] = current
-                                                    },
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                                else -> {
-                                    if (q.options.isNotEmpty()) {
-                                        FlowRow(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                                        ) {
-                                            q.options.forEach { option ->
-                                                AskOptionChip(
-                                                    selected = answers[q.id] == option,
-                                                    label = option,
-                                                    onClick = { answers[q.id] = option },
-                                                )
-                                            }
-                                        }
-                                    }
-                                    OutlinedTextField(
-                                        value = answers[q.id] ?: "",
-                                        onValueChange = { answers[q.id] = it },
-                                        modifier = Modifier.fillMaxWidth(),
-                                        textStyle = MaterialTheme.typography.bodyMedium,
-                                        placeholder = {
-                                            Text(
-                                                text = "在此输入回答…",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
-                                            )
-                                        },
-                                        singleLine = false,
-                                        minLines = 2,
-                                        maxLines = 6,
-                                        shape = RoundedCornerShape(12.dp),
-                                        colors = OutlinedTextFieldDefaults.colors(
-                                            unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                                            focusedBorderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
-                                            unfocusedContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.4f),
-                                            focusedContainerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.6f),
-                                        ),
-                                    )
-                                }
-                            }
-                        } else if (isAnswered) {
-                            val answeredState = tool.approvalState as ToolApprovalState.Answered
-                            val answerJson = answeredAnswers?.get(q.id)
-                            val answerText = when {
-                                answerJson is JsonArray -> answerJson.mapNotNull { it.jsonPrimitiveOrNull?.contentOrNull }
-                                    .joinToString(" · ")
-                                answerJson != null -> answerJson.jsonPrimitiveOrNull?.contentOrNull
-                                    ?: answeredState.answer
-                                else -> answeredState.answer
-                            }
-                            Surface(
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(10.dp),
-                                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
-                                border = BorderStroke(
-                                    0.5.dp,
-                                    MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
-                                ),
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
-                                    verticalAlignment = Alignment.Top,
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                ) {
-                                    Surface(
-                                        shape = RoundedCornerShape(4.dp),
-                                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-                                    ) {
-                                        Text(
-                                            text = "A",
-                                            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
-                                            color = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                                        )
-                                    }
-                                    Text(
-                                        text = answerText,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurface,
-                                        modifier = Modifier.weight(1f),
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (isPending && onToolAnswer != null) {
-                    val anyAnswered = answers.values.any { it.isNotBlank() } ||
-                        multiAnswers.values.any { it.isNotEmpty() }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        if (anyAnswered) {
-                            Row(
-                                modifier = Modifier
-                                    .clip(RoundedCornerShape(12.dp))
-                                    .clickable {
-                                        answers.clear()
-                                        multiAnswers.clear()
-                                    }
-                                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                            ) {
-                                Icon(
-                                    imageVector = HugeIcons.Refresh01,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(12.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.65f),
-                                )
-                                Text(
-                                    text = "清空",
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                                )
-                            }
-                            Spacer(modifier = Modifier.width(8.dp))
-                        }
-                        Button(
-                            onClick = {
-                                val answerPayload = buildJsonObject {
-                                    put("answers", buildJsonObject {
-                                        questions.forEach { q ->
-                                            when (q.selectionType) {
-                                                "multi" -> put(
-                                                    q.id,
-                                                    buildJsonArray {
-                                                        multiAnswers[q.id].orEmpty().forEach { add(JsonPrimitive(it)) }
-                                                    }
-                                                )
-                                                else -> put(q.id, JsonPrimitive(answers[q.id] ?: ""))
-                                            }
-                                        }
-                                    })
-                                }
-                                onToolAnswer(tool.toolCallId, answerPayload.toString())
-                            },
-                            enabled = questions.all { q ->
-                                when (q.selectionType) {
-                                    "multi" -> !multiAnswers[q.id].isNullOrEmpty()
-                                    else -> !answers[q.id].isNullOrBlank()
-                                }
-                            },
-                            shape = RoundedCornerShape(20.dp),
-                            contentPadding = PaddingValues(horizontal = 18.dp, vertical = 8.dp),
-                        ) {
-                            Icon(
-                                imageVector = HugeIcons.Tick01,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                            )
-                            Text(
-                                text = stringResource(R.string.chat_message_tool_submit),
-                                style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
-                                modifier = Modifier.padding(start = 6.dp),
-                            )
-                        }
-                    }
-                }
-            }
-        },
-    )
-}
-
-@Composable
-private fun AskOptionChip(
-    selected: Boolean,
-    label: String,
-    onClick: () -> Unit,
-) {
-    val shape = RoundedCornerShape(20.dp)
-    Surface(
-        onClick = onClick,
-        shape = shape,
-        color = if (selected) {
-            MaterialTheme.colorScheme.primary
-        } else {
-            MaterialTheme.colorScheme.surface.copy(alpha = 0.85f)
-        },
-        contentColor = if (selected) {
-            MaterialTheme.colorScheme.onPrimary
-        } else {
-            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
-        },
-        border = if (selected) {
-            null
-        } else {
-            BorderStroke(
-                width = 0.5.dp,
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f),
-            )
-        },
-        tonalElevation = 0.dp,
-        shadowElevation = if (selected) 1.dp else 0.dp,
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 13.dp, vertical = 7.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(5.dp),
-        ) {
-            if (selected) {
-                Icon(
-                    imageVector = HugeIcons.Tick01,
-                    contentDescription = null,
-                    modifier = Modifier.size(13.dp),
-                )
-            }
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
-                ),
-            )
-        }
-    }
-}
-
-private data class AskUserQuestion(
-    val id: String,
-    val question: String,
-    val options: List<String>,
-    val selectionType: String = "text", // "text" | "single" | "multi"
-)
-
-@Composable
-private fun ToolDenyReasonDialog(
-    onDismiss: () -> Unit,
-    onConfirm: (String) -> Unit
-) {
-    var reason by remember { mutableStateOf("") }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(stringResource(R.string.chat_message_tool_deny_dialog_title))
-        },
-        text = {
-            OutlinedTextField(
-                value = reason,
-                onValueChange = { reason = it },
-                label = { Text(stringResource(R.string.chat_message_tool_deny_dialog_hint)) },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = false,
-                minLines = 2,
-                maxLines = 4
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = { onConfirm(reason) }) {
-                Text(stringResource(R.string.chat_message_tool_deny))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(android.R.string.cancel))
-            }
-        }
-    )
 }
 
 /**

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -39,15 +39,12 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -78,12 +75,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.util.fastForEach
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -103,14 +96,12 @@ import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.ui.ToolApprovalState
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.common.http.jsonObjectOrNull
-import me.rerere.highlight.HighlightText
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.BubbleChatQuestion
 import me.rerere.hugeicons.stroke.Cancel01
 import me.rerere.hugeicons.stroke.Clipboard
 import me.rerere.hugeicons.stroke.Code
 import me.rerere.hugeicons.stroke.Database02
-import me.rerere.hugeicons.stroke.Delete01
 import me.rerere.hugeicons.stroke.Eraser
 import me.rerere.hugeicons.stroke.File02
 import me.rerere.hugeicons.stroke.FullScreen
@@ -133,15 +124,11 @@ import me.rerere.rikkahub.data.agent.subagent.SubAgentDefinitions
 import me.rerere.rikkahub.data.agent.subagent.SubAgentManager
 import me.rerere.rikkahub.data.agent.subagent.SubAgentRunStatus
 import me.rerere.rikkahub.data.agent.subagent.readSubAgentDisplayTextFromTranscript
-import me.rerere.rikkahub.data.repository.MemoryRepository
-import me.rerere.rikkahub.ui.components.richtext.HighlightCodeBlock
 import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
 import me.rerere.rikkahub.ui.components.richtext.ZoomableAsyncImage
 import me.rerere.rikkahub.ui.components.ui.ChainOfThoughtScope
 import me.rerere.rikkahub.ui.components.ui.DotLoading
-import me.rerere.rikkahub.ui.components.ui.Favicon
 import me.rerere.rikkahub.ui.components.ui.FaviconRow
-import me.rerere.rikkahub.ui.components.ui.FormItem
 import me.rerere.rikkahub.ui.components.ui.WorkspaceIconButton
 import me.rerere.rikkahub.ui.components.ui.WorkspaceLeadingIcon
 import me.rerere.rikkahub.ui.components.ui.WorkspaceStatusPill
@@ -149,13 +136,11 @@ import me.rerere.rikkahub.ui.components.ui.WorkspaceTone
 import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.modifier.shimmer
 import me.rerere.rikkahub.utils.JsonInstant
-import me.rerere.rikkahub.utils.JsonInstantPretty
 import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
-import me.rerere.rikkahub.utils.openUrl
 import org.koin.compose.koinInject
 import java.io.File
 
-private object ToolNames {
+internal object ToolNames {
     const val MEMORY = "memory_tool"
     const val SEARCH_WEB = "search_web"
     const val SCRAPE_WEB = "scrape_web"
@@ -184,7 +169,7 @@ private enum class AgentToolKind {
     GENERIC,
 }
 
-private object MemoryActions {
+internal object MemoryActions {
     const val CREATE = "create"
     const val EDIT = "edit"
     const val DELETE = "delete"
@@ -312,7 +297,7 @@ private fun getToolKind(toolName: String) = when {
     else -> AgentToolKind.GENERIC
 }
 
-private fun JsonElement?.getStringContent(key: String): String? =
+internal fun JsonElement?.getStringContent(key: String): String? =
     this?.jsonObjectOrNull?.get(key)?.jsonPrimitiveOrNull?.contentOrNull
 
 private fun String.compactToolPreview(maxLength: Int = 34): String {
@@ -897,342 +882,6 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
             output = tool.output,
             onDismissRequest = { showResult = false }
         )
-    }
-}
-
-@Composable
-private fun ToolCallPreviewSheet(
-    toolName: String,
-    arguments: JsonElement,
-    content: JsonElement?,
-    output: List<UIMessagePart>,
-    onDismissRequest: () -> Unit = {}
-) {
-    val memoryRepo: MemoryRepository = koinInject()
-    val scope = rememberCoroutineScope()
-
-    val memoryAction = arguments.getStringContent("action")
-    val isMemoryOperation = toolName == ToolNames.MEMORY &&
-        memoryAction in listOf(MemoryActions.CREATE, MemoryActions.EDIT)
-    val memoryId = (content as? JsonObject)?.get("id")?.jsonPrimitiveOrNull?.intOrNull
-
-    ModalBottomSheet(
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-        onDismissRequest = onDismissRequest,
-        content = {
-            when {
-                content == null -> GenericToolPreview(
-                    toolName = toolName,
-                    arguments = arguments,
-                    output = emptyList(),
-                    isMemoryOperation = false,
-                    memoryId = null,
-                    memoryRepo = memoryRepo,
-                    scope = scope,
-                    onDismissRequest = onDismissRequest
-                )
-
-                toolName == ToolNames.SEARCH_WEB -> SearchWebPreview(
-                    arguments = arguments,
-                    content = content,
-                )
-
-                toolName == ToolNames.SCRAPE_WEB -> ScrapeWebPreview(content = content)
-                else -> GenericToolPreview(
-                    toolName = toolName,
-                    arguments = arguments,
-                    output = output,
-                    isMemoryOperation = isMemoryOperation,
-                    memoryId = memoryId,
-                    memoryRepo = memoryRepo,
-                    scope = scope,
-                    onDismissRequest = onDismissRequest
-                )
-            }
-        },
-    )
-}
-
-@Composable
-private fun SearchWebPreview(
-    arguments: JsonElement,
-    content: JsonElement,
-) {
-    val context = LocalContext.current
-    val items = content.jsonObject["items"]?.jsonArray ?: emptyList()
-    val answer = content.getStringContent("answer")
-    val query = arguments.getStringContent("query") ?: ""
-
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxHeight(0.8f)
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        item {
-            Text(stringResource(R.string.chat_message_tool_search_prefix, query))
-        }
-
-        if (answer != null) {
-            item {
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer
-                    )
-                ) {
-                    MarkdownBlock(
-                        content = answer,
-                        modifier = Modifier
-                            .padding(16.dp)
-                            .fillMaxWidth(),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-        }
-
-        // Top-level image thumbnails (from available_images)
-        val topImages = content.jsonObject["available_images"]
-            ?.jsonArray
-            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
-            ?.take(5)
-            .orEmpty()
-        if (topImages.isNotEmpty()) {
-            item {
-                Text(
-                    text = "相关图片 (${topImages.size})",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                )
-            }
-            item {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    topImages.forEach { imgUrl ->
-                        ZoomableAsyncImage(
-                            model = imgUrl,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .height(64.dp)
-                                .widthIn(max = 100.dp)
-                                .clip(RoundedCornerShape(8.dp)),
-                        )
-                    }
-                }
-            }
-        }
-
-        if (items.isNotEmpty()) {
-            items(items) { item ->
-                val url = item.getStringContent("url") ?: return@items
-                val title = item.getStringContent("title") ?: return@items
-                val text = item.getStringContent("text") ?: return@items
-                val itemImages = runCatching {
-                    item.jsonObject["images"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
-                }.getOrNull().orEmpty()
-
-                Card(
-                    onClick = { context.openUrl(url) },
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                    )
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp, horizontal = 16.dp),
-                    ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Favicon(
-                                url = url,
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(text = title, maxLines = 1)
-                                Text(
-                                    text = text,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis,
-                                    style = MaterialTheme.typography.bodySmall
-                                )
-                                Text(
-                                    text = url,
-                                    maxLines = 1,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                                )
-                            }
-                        }
-                        // Per-item images
-                        if (itemImages.isNotEmpty()) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                modifier = Modifier.padding(top = 6.dp),
-                            ) {
-                                itemImages.take(2).forEach { imgUrl ->
-                                    ZoomableAsyncImage(
-                                        model = imgUrl,
-                                        contentDescription = null,
-                                        modifier = Modifier
-                                            .height(56.dp)
-                                            .widthIn(max = 80.dp)
-                                            .clip(RoundedCornerShape(6.dp)),
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } else {
-            item {
-                HighlightText(
-                    code = JsonInstantPretty.encodeToString(content),
-                    language = "json",
-                    fontSize = 12.sp
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ScrapeWebPreview(content: JsonElement) {
-    val urls = content.jsonObject["urls"]?.jsonArray ?: emptyList()
-
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxHeight(0.8f)
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        item {
-            Text(
-                text = stringResource(
-                    R.string.chat_message_tool_scrape_prefix,
-                    urls.joinToString(", ") { it.getStringContent("url") ?: "" }
-                )
-            )
-        }
-
-        items(urls) { url ->
-            val urlObject = url.jsonObject
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = urlObject["url"]?.jsonPrimitive?.content ?: "",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Card {
-                    MarkdownBlock(
-                        content = urlObject["content"]?.jsonPrimitive?.content ?: "",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun GenericToolPreview(
-    toolName: String,
-    arguments: JsonElement,
-    output: List<UIMessagePart>,
-    isMemoryOperation: Boolean,
-    memoryId: Int?,
-    memoryRepo: MemoryRepository,
-    scope: kotlinx.coroutines.CoroutineScope,
-    onDismissRequest: () -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxHeight(0.8f)
-            .padding(16.dp)
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(R.string.chat_message_tool_call_title),
-                style = MaterialTheme.typography.headlineSmall,
-                textAlign = TextAlign.Center
-            )
-
-            if (isMemoryOperation && memoryId != null) {
-                IconButton(
-                    onClick = {
-                        scope.launch {
-                            memoryRepo.deleteMemory(memoryId)
-                            onDismissRequest()
-                        }
-                    }
-                ) {
-                    Icon(
-                        imageVector = HugeIcons.Delete01,
-                        contentDescription = "Delete memory"
-                    )
-                }
-            }
-        }
-        FormItem(
-            label = {
-                Text(stringResource(R.string.chat_message_tool_call_label, toolName))
-            }
-        ) {
-            HighlightCodeBlock(
-                code = JsonInstantPretty.encodeToString(arguments),
-                language = "json",
-                style = TextStyle(fontSize = 10.sp, lineHeight = 12.sp),
-                forceAutoWrap = true,
-            )
-        }
-        if (output.isNotEmpty()) {
-            FormItem(
-                label = {
-                    Text(stringResource(R.string.chat_message_tool_call_result))
-                }
-            ) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    output.fastForEach { part ->
-                        when (part) {
-                            is UIMessagePart.Text -> HighlightCodeBlock(
-                                code = runCatching {
-                                    JsonInstantPretty.encodeToString(
-                                        JsonInstant.parseToJsonElement(part.text)
-                                    )
-                                }.getOrElse { part.text },
-                                language = "json",
-                                style = TextStyle(fontSize = 10.sp, lineHeight = 12.sp),
-                                forceAutoWrap = true,
-                            )
-
-                            is UIMessagePart.Image -> ZoomableAsyncImage(
-                                model = part.url,
-                                contentDescription = null,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-
-                            else -> {}
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/docs/REFACTOR_P2_CHATMESSAGETOOLS_PRECUT_2026-05-19.md
+++ b/docs/REFACTOR_P2_CHATMESSAGETOOLS_PRECUT_2026-05-19.md
@@ -1,0 +1,257 @@
+# Pre-cut: ChatMessageTools.kt (P2 第四刀)
+
+> Pre-cut analysis per `docs/REFACTOR_PLAYBOOK.md` §2.1. Frozen historical record after user GO; subsequent corrections go in commit bodies, not edits to this doc.
+
+## 0. Meta
+
+- **Target**: `app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt`
+- **Parent commit (refactor baseline)**: `ae597a0d` (= current `main`)
+- **Branch**: `refactor/p2-chatmessagetools`
+- **Refactor date**: 2026-05-19
+- **Risk**: 🟡 medium (cross-block helper dependencies; no exotic Compose primitives)
+- **Unit test baseline**: 467 tests / 3 failed (`GenerativeUiPlannerTest×2`, `DefaultProvidersTest×1`)
+
+## 1. Top-level decl table
+
+`grep -nE "^(@Composable|fun|private fun|class|data class|private data class|object|const val|private const|val|private val)"` →
+
+| L | Decl | Visibility | Role |
+|---|---|---|---|
+| 198 | `getToolIcon(toolName, action)` | private | helper: pick ImageVector by tool name |
+| 263 | `getToolKind(toolName)` | private | helper: classify tool into AgentToolKind |
+| 315 | `JsonElement?.getStringContent(key)` | private | helper: parse string from json |
+| 318 | `String.compactToolPreview(maxLength)` | private | helper: truncate preview text |
+| 323 | `toolHasFailure(content, output)` | private | helper: detect tool failure |
+| 341 | `toolStatusFromMessagePart(...)` | private | helper: derive AgentToolStatus |
+| 355 | `toolStatusLabel(status)` | private | helper: localized status label |
+| 363 | `toolStatusTone(status)` | private | helper: pick WorkspaceTone |
+| 372 | `toolKindLabel(kind, toolName)` | private | helper: localized kind label |
+| 387 | `ToolStatusPill(status, modifier)` | private | UI primitive: small pill |
+| 399 | `AgentToolCallCapsule(...)` | private | UI primitive: clickable capsule |
+| 482 | `toolDisplayTitle(toolName, arguments, memoryAction)` | private | helper: human-readable title |
+| 556 | `ChainOfThoughtScope.ChatMessageToolStep(...)` | **public** | hub Composable |
+| 904 | `ToolCallPreviewSheet(...)` | private | sheet Composable |
+| 957 | `SearchWebPreview(...)` | private | sheet sub-Composable |
+| 1104 | `ScrapeWebPreview(content)` | private | sheet sub-Composable |
+| 1148 | `GenericToolPreview(...)` | private | sheet sub-Composable |
+| 1241 | `ChainOfThoughtScope.AskUserToolStep(...)` | private | Composable: AskUser step |
+| 1541 | `AskOptionChip(...)` | private | UI primitive: option chip |
+| 1593 | `AskUserQuestion(...)` | private data class | model |
+| 1601 | `ToolDenyReasonDialog(...)` | private | dialog Composable |
+| 1646 | `SubAgentTaskStepView(...)` | **public** | Composable: SubAgent step |
+| 1724 | `PHASE_LABEL_INTERVAL_MS` | private const | const: 5s |
+| 1730 | `parseLatestSubAgentStatus(tools)` | private | helper |
+| 1746 | `extractLatestSubAgentName(tools)` | private | helper |
+| 1759 | `SubAgentRunStatus.toAgentToolStatus()` | private ext | helper |
+| 1778 | `SubAgentRunSheet(...)` | private | sheet Composable |
+| 1958 | `CouncilTaskStepView(...)` | **public** | Composable: Council step |
+| 2020 | `parseLatestCouncilStatus(tools)` | private | helper |
+| 2034 | `ModelCouncilCardStatus.toAgentToolStatus()` | private ext | helper |
+| 2050 | `ModelCouncilRunSheet(...)` | private | sheet Composable |
+| 2252 | `CouncilTabEntry` | private data class | model |
+| 2254 | `CouncilRoundSection` | private data class | model |
+| 2260 | `CouncilRoundContent(...)` | private | sub-Composable |
+| 2284 | `CouncilRoundDivider(label)` | private | sub-Composable |
+| 2312 | `CouncilObjectiveCard(objective)` | private | sub-Composable |
+| 2368 | `String.shouldCollapseCouncilObjective()` | private ext | helper |
+| 2373 | `String.toCouncilRoundSections()` | private ext | helper |
+| 2403 | `COUNCIL_OBJECTIVE_COLLAPSED_LINES` | private const | const |
+| 2404 | `COUNCIL_OBJECTIVE_COLLAPSE_LINES` | private const | const |
+| 2405 | `COUNCIL_OBJECTIVE_COLLAPSE_CHARS` | private const | const |
+| 2406 | `COUNCIL_ROUND_MARKER_TEXT` | private const | const |
+| 2407 | `COUNCIL_ROUND_MARKER` | private val | const-like |
+| 2410 | `extractFinalCouncilSynthesisText(tools)` | private | helper |
+| 2427 | `extractCouncilModelLabel(tools, seatId)` | private | helper |
+| 2454 | `extractCouncilSeatEntries(tools)` | private | helper |
+| 2486 | `extractFinalCouncilSeatText(tools, seatId)` | private | helper |
+| 2521 | `JsonObject.payloadObject(name)` | private ext | json helper |
+| 2529 | `JsonObject.payloadArray(name)` | private ext | json helper |
+| 2547 | `extractFinalSubAgentText(tools)` | private | helper |
+| 2594 | `String.cleanCouncilLineBreaks()` | private ext | helper |
+
+**Public funs (cross-file callers — must stay public byte-equal)**:
+- `ChatMessageToolStep` ← `ChatMessage.kt:1313`
+- `SubAgentTaskStepView` ← `ChatMessage.kt:671, 1325, 1618`
+- `CouncilTaskStepView` ← `ChatMessage.kt:680, 1338, 1625`
+
+## 2. Section boundaries
+
+| Section | Line range | Approx |
+|---|---|---|
+| imports + package | L1-L197 | 197 |
+| **Helper cluster + UI primitives** | L198-L554 | 357 |
+| **ChatMessageToolStep** (hub) | L555-L901 | 347 |
+| **Tool preview sheets** | L903-L1238 | 336 |
+| **AskUser system** | L1240-L1644 | 405 |
+| **SubAgent system** | L1645-L1955 | 311 |
+| **Council system** | L1957-L2605 | 649 |
+| **Total** | L1-L2605 | 2605 |
+
+After all 4 stages, **coordinator = L1-L901 ≈ 899 lines** (helpers/primitives + hub).
+
+## 3. Call graph (cross-section)
+
+### 3.1 Helpers in L198-L554 used by which downstream section
+
+| Helper | L | Only used in coordinator (L555-L901)? | Used elsewhere? |
+|---|---|---|---|
+| `getToolIcon` | 198 | YES (L617) | — |
+| `getToolKind` | 263 | YES (L618) | — |
+| `getStringContent` | 315 | YES (L325, L496-L548, L576, L596-L820+) | ⚠ **ToolPreview L914,L963,L1028-1030,L1117; SubAgent L1653,L1657,L1753** |
+| `compactToolPreview` | 318 | YES (toolDisplayTitle body, L459-L549) | — |
+| `toolHasFailure` | 323 | YES (only inside `toolStatusFromMessagePart`) | — |
+| `toolStatusFromMessagePart` | 341 | YES (L590) | — |
+| `toolStatusLabel` | 355 | indirect (only inside ToolStatusPill body) | — |
+| `toolStatusTone` | 363 | indirect (only inside pill/capsule body) | — |
+| `toolKindLabel` | 372 | indirect (only inside capsule body) | — |
+| `ToolStatusPill` | 387 | YES (L470 inside capsule, L628 inside hub) | — |
+| `AgentToolCallCapsule` | 399 | YES (L614) | ⚠ **SubAgent L1701; Council L1995** |
+| `toolDisplayTitle` | 482 | YES (L589) | — |
+
+### 3.2 Helpers OUTSIDE L198-L554 that are also cross-section
+
+| Helper | Decl L | Decl block | Used at | Used by block |
+|---|---|---|---|---|
+| `PHASE_LABEL_INTERVAL_MS` | 1724 | SubAgent | L1676, L1971 | SubAgent + **Council** |
+| `payloadObject` | 2521 | Council | L1656, L2417 | **SubAgent** + Council |
+| `payloadArray` | 2529 | Council | L2438, L2461, L2493 | Council only |
+| `extractFinalSubAgentText` | 2547 | Council | L1817, L2547 | **SubAgent** + Council |
+
+⚠ **SubAgent ↔ Council circular reference** — drives stage order (Council before SubAgent, see §6).
+
+### 3.3 Section-local decls called from elsewhere
+
+| Decl | Decl block | Used at | Used by block |
+|---|---|---|---|
+| `ToolCallPreviewSheet` | ToolPreview L904 | L893 | hub (coordinator) |
+| `AskUserToolStep` | AskUser L1241 | L566 | hub (coordinator) |
+| `ToolDenyReasonDialog` | AskUser L1601 | L883 | hub (coordinator) |
+| All others (SearchWebPreview, ScrapeWebPreview, GenericToolPreview, AskOptionChip, AskUserQuestion, SubAgentRunSheet, Council {Tab,Round,Sheet,...}) | (their own block) | within-block only | — |
+
+## 4. ⚠ Same-file cross-stage caller scan (P2 stage 4 lesson)
+
+For every PRIVATE helper that **stays in coordinator** after stage N, scan future-extracted blocks for refs:
+
+| Helper kept in coordinator | Called from extracted? | Action |
+|---|---|---|
+| `getStringContent` (L315) | ToolPreview L914,963,1028-30,1117; SubAgent L1653,1657,1753 | **widen p→i at Stage 1** |
+| `AgentToolCallCapsule` (L399) | SubAgent L1701; Council L1995 | **widen p→i at Stage 3** (Council stage) |
+| `getToolIcon` / `getToolKind` / `compactToolPreview` / `toolHasFailure` / `toolStatusFromMessagePart` / `toolStatusLabel` / `toolStatusTone` / `toolKindLabel` / `ToolStatusPill` / `toolDisplayTitle` | only inside hub L555-L901 | no widening |
+
+For every PRIVATE helper that **moves to a sibling** but is called from another future-extracted block or from coordinator:
+
+| Sibling-local decl | Cross-section caller | Action |
+|---|---|---|
+| `ToolCallPreviewSheet` (Stage 1) | hub L893 | **widen p→i in sibling** |
+| `AskUserToolStep` (Stage 2) | hub L566 | **widen p→i in sibling** |
+| `ToolDenyReasonDialog` (Stage 2) | hub L883 | **widen p→i in sibling** |
+| `payloadObject` (Stage 3 Council sibling) | SubAgent block (still coord at stage 3) at L1656 | **widen p→i in sibling** |
+| `extractFinalSubAgentText` (Stage 3 Council sibling) | SubAgent block at L1817 | **widen p→i in sibling** |
+| `PHASE_LABEL_INTERVAL_MS` (Stage 4 SubAgent sibling) | Council sibling at L1971 — at extraction time Council is already a sibling → cross-sibling reference | **widen p→i at Stage 3** in coordinator (so Council sibling can see it), then preserve internal when SubAgent moves it to its sibling at Stage 4 |
+| All others (SearchWebPreview, ScrapeWebPreview, GenericToolPreview, AskOptionChip, AskUserQuestion, parse/extract SubAgent helpers, SubAgentRunSheet, Council intra-block decls, payloadArray, etc.) | within-block only | stays private |
+
+**Widening tally**:
+- Stage 1: 1 widening in coordinator (`getStringContent`), 1 widening in sibling (`ToolCallPreviewSheet`)
+- Stage 2: 2 widenings in sibling (`AskUserToolStep`, `ToolDenyReasonDialog`)
+- Stage 3 (Council): 2 widenings in coordinator (`AgentToolCallCapsule`, `PHASE_LABEL_INTERVAL_MS`), 2 widenings in sibling (`payloadObject`, `extractFinalSubAgentText`)
+- Stage 4 (SubAgent): 0 net new widenings — but `PHASE_LABEL_INTERVAL_MS` retains `internal` visibility when moved (was widened in stage 3)
+
+Total = **8 widenings** across 4 stages. All documented in their respective commit bodies.
+
+## 5. Cross-file caller scan
+
+```bash
+grep -rn --include="*.kt" "\bChatMessageToolStep\b\|\bSubAgentTaskStepView\b\|\bCouncilTaskStepView\b" app/src/main/java/
+```
+
+Result:
+- `ChatMessage.kt:1313` calls `ChatMessageToolStep`
+- `ChatMessage.kt:671, 1325, 1618` call `SubAgentTaskStepView`
+- `ChatMessage.kt:680, 1338, 1625` call `CouncilTaskStepView`
+- (no other callers anywhere in the app module)
+
+All 3 public funs **stay public byte-equal**. No tightening (no opportunity — they're consumed cross-package from `ChatMessage.kt` same package, but other potential callers cannot be excluded without a module-wide grep; staying public is the safe + byte-equal choice).
+
+## 6. Stage plan (recommended: 4 stages, Council BEFORE SubAgent)
+
+| Stage | Extract range | Sibling file | Approx lines | Widenings |
+|---|---|---|---|---|
+| 1 | L903-L1238 (ToolPreview sheets) | `ChatMessageToolPreviewSheet.kt` | 336 + imports | coord: `getStringContent` p→i; sibling: `ToolCallPreviewSheet` p→i |
+| 2 | L1240-L1644 (AskUser system) | `ChatMessageAskUserStep.kt` | 405 + imports | sibling: `AskUserToolStep` p→i, `ToolDenyReasonDialog` p→i |
+| 3 | L1957-L2605 (Council system) | `ChatMessageCouncilStep.kt` | 649 + imports | coord: `AgentToolCallCapsule` p→i, `PHASE_LABEL_INTERVAL_MS` p→i; sibling: `payloadObject` p→i, `extractFinalSubAgentText` p→i |
+| 4 | L1645-L1955 (SubAgent system) | `ChatMessageSubAgentStep.kt` | 311 + imports | none new — `PHASE_LABEL_INTERVAL_MS` stays internal when relocated |
+
+### 6.1 Why Council BEFORE SubAgent
+
+`SubAgent block (L1645-1955)` calls `payloadObject` (L1656 → L2521 in Council block) and `extractFinalSubAgentText` (L1817 → L2547 in Council block). If we extract SubAgent first, those Council-block-resident helpers would need to be widened by reaching into Council block while it's still in coordinator — feasible but awkward.
+
+Cleaner order:
+1. Extract **Council** first; Council sibling owns `payloadObject` + `extractFinalSubAgentText` (widened internal).
+2. Extract **SubAgent** next; SubAgent sibling references those helpers cross-sibling (same package, internal visibility — no import line edit needed).
+
+### 6.2 Final coordinator state
+
+After all 4 stages: `ChatMessageTools.kt` = L1-L901 of the parent commit (≈ 899 lines, minus dead-import cleanup). Contains:
+- Imports (cleaned)
+- L198-L554 helper cluster + UI primitives (2 widenings noted above)
+- L555-L901 `ChatMessageToolStep` (the hub composable, fully self-contained)
+
+### 6.3 Strip order per stage
+
+Per playbook §3 step 6: highest-line range first, OR single combined awk filter. All 4 stages here have a SINGLE contiguous range, so simple `awk 'NR<START || NR>END'` works.
+
+## 7. Risk assessment
+
+**🟡 medium-low** overall. Below baseline P1 ChatInput because:
+
+- ✅ No WebView, no graphicsLayer, no DisposableEffect, no produceState, no rememberSaveable
+- ✅ No `utils.plus` operator
+- ✅ No Sandbox-style bitmap thumbnail / state-mutation traps
+- ⚠ 10 LaunchedEffect, 15 `by` delegation — each is local to its containing composable, no cross-LE coordination. Need `getValue` + `setValue` imports per sibling that uses `by`.
+- ⚠ Cross-section helper sharing (esp. SubAgent ↔ Council circular reference) — addressed by stage ordering + 8 documented widenings.
+- ✅ 56 top-level decls (manageable) — not 70 as earlier-estimated.
+- ✅ All 3 public functions have just 7 known call sites, all in `ChatMessage.kt`. Stay public byte-equal.
+
+## 8. Decisions for user
+
+### 8.1 Stage count: 4 stages vs combined SubAgent+Council in 1 stage
+
+| Option | Stages | Pros | Cons |
+|---|---|---|---|
+| **A (recommended)** | 4 stages: ToolPreview / AskUser / Council / SubAgent | per-stage atomicity (each commit is ~300-650 lines), smaller blast radius per review | cross-sibling import dependency (SubAgent → Council) |
+| B | 3 stages: ToolPreview / AskUser / SubAgent+Council combined | no cross-sibling imports — both move together in one commit | one stage extracts ~960 lines + creates 2 new files; review surface bigger |
+
+**Recommendation**: **A (4 stages)**. Cross-sibling internal imports are clean (same package, no import line edits). Smaller per-stage commits make sub-agent + Codex review easier.
+
+### 8.2 Import sort policy
+
+**Strict byte-equal** (no alphabetical re-sort). Consistent with P1 ChatInput + P2 prior cuts. Only deletions of this-refactor orphan imports.
+
+### 8.3 PR strategy
+
+**Single PR with stage-by-stage commits**, merged with `--merge` (NEVER squash/rebase, per playbook §8.2). Audit trail per stage preserved.
+
+### 8.4 Pre-existing dead imports
+
+Will be enumerated per-stage. Verify against baseline `ae597a0d` with:
+```bash
+git show ae597a0d:app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt | grep -cE "\bSYM\b"
+```
+If = 1 (import line only) → pre-existing dead → DO NOT delete (CLAUDE.md §3).
+
+## 9. Per-stage gates (reminder)
+
+Every stage:
+1. `:app:compileDebugKotlin --offline` clean
+2. `:app:testDebugUnitTest --offline` → **467 / 3 failed** (baseline match)
+3. Sub-agent Round 1 review = APPROVE
+4. EOF clean (`tail -c 5 | xxd` shows trailing `0a`, no double newline)
+
+Final stage (Stage 4 SubAgent) additionally:
+5. `:app:assembleDebug :app:assembleNotion :app:assembleRefactortest --offline` all BUILD SUCCESSFUL
+
+Then Codex independent review (playbook §7), then PR with `--merge`.
+
+---
+
+**Status**: Pre-cut ready. Awaiting user **GO** to begin Stage 1.


### PR DESCRIPTION
## Summary

P2 fourth god-class cut: `ui/components/message/ChatMessageTools.kt` (2605 → 838, ≈ 32% of original) into thin coordinator + 4 sibling files. Coordinator keeps the shared helper cluster + `ChatMessageToolStep` hub; the four large sub-systems each become their own file. Bodies are byte-equal with baseline `ae597a0d`; the only line-level deltas are documented `private`→`internal` widenings (see commits).

Playbook: `docs/REFACTOR_PLAYBOOK.md`. Pre-cut: `docs/REFACTOR_P2_CHATMESSAGETOOLS_PRECUT_2026-05-19.md`.

## Stages (preserved as audit commits)

| Stage | Block | New sibling | Lines | Commit |
|---|---|---|---|---|
| pre-cut | docs | — | — | f525e339 |
| 1 | Tool preview sheets | `ChatMessageToolPreviewSheet.kt` (397) | 336 | b1b8ec30 |
| 2 | AskUser system | `ChatMessageAskUserStep.kt` (457) | 396 | 0cf4ae46 |
| 3 | Council UI system | `ChatMessageCouncilStep.kt` (723) | 654 | 2dd446a1 |
| 4 | SubAgent UI system | `ChatMessageSubAgentStep.kt` (376) | 315 | 8f8d118d |

Stage 3 (Council) precedes Stage 4 (SubAgent) because SubAgent block calls helpers physically declared in Council block (`payloadObject` parent L2521, `extractFinalSubAgentText` parent L2547, `extractSubAgentDisplayTextFromTranscript` parent L2569 area). Council goes first → those helpers land in the Council sibling as `internal` → SubAgent sibling references them cross-sibling (same package, no import-line edits).

## Widenings (private → internal)

**Coordinator (7)**: `getStringContent`, `ToolNames`, `MemoryActions` (stage 1); `AgentToolStatus`, `AgentToolKind`, `AgentToolCallCapsule`, `PHASE_LABEL_INTERVAL_MS` (stage 3).

**Sibling (6)**: `ToolCallPreviewSheet` (stage 1); `AskUserToolStep`, `ToolDenyReasonDialog` (stage 2); `payloadObject`, `extractFinalSubAgentText`, `extractSubAgentDisplayTextFromTranscript` (stage 3).

Note: `PHASE_LABEL_INTERVAL_MS` was widened in stage 3 (while still in coord) and carries `internal` byte-equal into the SubAgent sibling in stage 4 — Council sibling references it cross-sibling, same package.

The three cross-file public entries (`ChatMessageToolStep`, `SubAgentTaskStepView`, `CouncilTaskStepView`) stay public byte-equal; the 7 callsites in `ChatMessage.kt` (L671, 680, 1313, 1325, 1338, 1618, 1625) are same-package, no import edits needed.

## Verification

- `:app:compileDebugKotlin`: PASS (every stage)
- `:app:testDebugUnitTest`: PASS — 467 / 3 failed (baseline: `GenerativeUiPlannerTest`×2 + `DefaultProvidersTest`×1) preserved every stage
- `:app:assembleDebug`: BUILD SUCCESSFUL
- `:app:assembleNotion`: BUILD SUCCESSFUL
- `:app:assembleRefactortest`: BUILD SUCCESSFUL (locally; Codex's env had no `me.rerere.amberagent.refactortest` client in `google-services.json` — env-N/A on review side, code is fine)
- Sub-agent Round 1 per stage: 4 × APPROVE
- Codex independent review: APPROVE with 2 P3 nits (documentation 口径 + stage-order confirmation), neither blocking

## Pre-existing dead imports

Preserved per `CLAUDE.md §3`: `Box`, `BoxWithConstraints`, `CircleShape`, `FilledTonalButton`, `FilterChip`, `LocalContentColor`, `Color`, `getValue`, `setValue` (last two used implicitly via `by` delegation — 3 sites in final coord).

This-refactor orphan imports trimmed: 15 (stage 1) + 12 (stage 2) + 10 (stage 3) + 26 (stage 4) = 63 total.

## Test plan

- [x] Compile gate per stage
- [x] Test gate per stage (3/467 baseline)
- [x] 3-variant assemble after stage 4
- [x] Sub-agent Round 1 per stage
- [x] Codex independent review
- [ ] Manual UI smoke (deferred to standard QA; behavior unchanged by byte-equal extraction)

## Merge mode

Per playbook §8.2: **"Create a merge commit"** (NOT squash/rebase) — preserves the per-stage audit trail.