### PR TITLE
Rust JNI Phase 2 + Phase 3: production caller switch + jni-common + xlsx + HTML diff normalizer

### DIFF
--- a/.github/workflows/native-build-check.yml
+++ b/.github/workflows/native-build-check.yml
@@ -1,0 +1,100 @@
+name: Native Build Check
+
+# PR-gated debug build that asserts the 4 Rust .so files are present in the
+# arm64-v8a APK. Light-weight enough to run on every PR; the heavyweight
+# `release.yml` (signed APK upload) stays workflow_dispatch.
+#
+# Codex review P3 follow-up: the .so presence assertion in release.yml
+# isn't usable as a required PR check because release.yml is
+# workflow_dispatch only. This workflow gives the same assertion at PR time
+# without exposing signing keys.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'native/**'
+      - 'app/**/Cargo.toml'
+      - 'document/build.gradle.kts'
+      - 'highlight/build.gradle.kts'
+      - 'app/build.gradle.kts'
+      - '.github/workflows/native-build-check.yml'
+
+jobs:
+  build-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Rust + Android target
+        uses: dtolnay/rust-toolchain@1.82.0
+        with:
+          targets: aarch64-linux-android
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked --version 3.5.4
+
+      - name: Set up Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: 27.0.12077973
+          add-to-path: true
+          local-cache: true
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}
+
+      - name: cargo test --workspace
+        working-directory: native
+        run: cargo test --workspace --locked
+
+      - name: Gradle Debug Build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          chmod +x gradlew
+          ./gradlew :app:assembleDebug
+
+      - name: Verify native .so files present in debug APK
+        run: |
+          set -euo pipefail
+          APK=$(ls app/build/outputs/apk/debug/app-arm64-v8a-debug.apk)
+          expected=(
+            "lib/arm64-v8a/liboffice_parsers.so"
+            "lib/arm64-v8a/libmarkdown_parser.so"
+            "lib/arm64-v8a/libhighlight_parser.so"
+            "lib/arm64-v8a/libregex_transformer.so"
+          )
+          missing=()
+          for so in "${expected[@]}"; do
+            if ! unzip -l "$APK" | awk '{print $4}' | grep -qx "$so"; then
+              missing+=("$so")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Debug APK missing native libraries:"
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "All 4 native libraries present in debug APK."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,34 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Set up Rust + Android target
+        # Phase 2 Rust JNI: build the four native .so files into the release
+        # APK. Pinned to match local dev — drifting toolchains across two CI
+        # runs has caused codegen changes elsewhere; this is HARD-GATE-bound
+        # code so reproducibility wins.
+        #
+        # Action ref pinned to the version tag rather than @master — the
+        # action implementation itself has changed input names mid-cycle
+        # before (round 2 review R2-P2-3).
+        uses: dtolnay/rust-toolchain@1.82.0
+        with:
+          targets: aarch64-linux-android
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked --version 3.5.4
+
+      - name: Set up Android NDK
+        id: setup-ndk
+        # Pinned to the full version triple to match local dev exactly
+        # (document/build.gradle.kts defaults to `27.0.12077973`).
+        # Mismatched NDK micro versions can change R8/ProGuard interactions
+        # with native code; lock to one (review P2-4).
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: 27.0.12077973
+          add-to-path: true
+          local-cache: true
+
       - name: Gradle cache
         uses: actions/cache@v4
         with:
@@ -26,21 +54,60 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            native/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('native/**/Cargo.lock', 'native/**/Cargo.toml') }}
+
       - name: Prepare build files
         run: |
           # 解码base64编码的keystore文件
           echo "${{ secrets.KEY_BASE64 }}" | base64 -d > app/app.key
-          
+
           # 写入签名配置到local.properties
           echo "${{ secrets.SIGNING_CONFIG }}" > local.properties
-          
+
           # 写入Google Services配置
           echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/google-services.json
 
       - name: Gradle Build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           chmod +x gradlew
           ./gradlew assembleRelease
+
+      - name: Verify native .so files present in release APK
+        # Phase 2 HARD GATE assertion (SPIKE_PLAN §8.3): if the release APK
+        # ships without one of the 4 native libraries, every user on the
+        # native cohort would silently fall back to JVM — a regression we
+        # would only catch via metrics. Fail loud at build time instead.
+        run: |
+          set -euo pipefail
+          APK=$(ls app/build/outputs/apk/release/*.apk | head -n1)
+          echo "Inspecting $APK"
+          expected=(
+            "lib/arm64-v8a/liboffice_parsers.so"
+            "lib/arm64-v8a/libmarkdown_parser.so"
+            "lib/arm64-v8a/libhighlight_parser.so"
+            "lib/arm64-v8a/libregex_transformer.so"
+          )
+          missing=()
+          for so in "${expected[@]}"; do
+            if ! unzip -l "$APK" | awk '{print $4}' | grep -qx "$so"; then
+              missing+=("$so")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Release APK is missing native libraries:"
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "All 4 native libraries present."
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/app/src/main/java/me/rerere/rikkahub/RikkaHubApp.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RikkaHubApp.kt
@@ -14,6 +14,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.remoteConfigSettings
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -46,6 +48,7 @@ import me.rerere.rikkahub.data.files.SkillManager
 import me.rerere.rikkahub.data.agent.cron.AgentCronManager
 import me.rerere.rikkahub.data.datastore.prefs.SettingsAggregator
 import me.rerere.rikkahub.data.datastore.prefs.SettingsProviderRescue
+import me.rerere.rikkahub.data.nativepath.NativePathBootstrap
 import me.rerere.rikkahub.data.memory.dream.MemoryDreamScheduler
 import me.rerere.rikkahub.data.agent.board.collector.NotificationSignalCollector
 import me.rerere.rikkahub.data.agent.board.hotlist.HotListScheduler
@@ -104,6 +107,18 @@ class RikkaHubApp : Application() {
             setDefaultsAsync(R.xml.remote_config_defaults)
             fetchAndActivate()
         }
+
+        // Wire Phase-2 Rust JNI production switches to user prefs + Remote Config
+        // + Crashlytics. Default state stays JVM-only (see SPIKE_PLAN §8.3).
+        // A failure here leaves every Switch on DisabledConfig (safe), so we
+        // record it to Crashlytics rather than let it pass silently —
+        // otherwise an entire opt-in cohort would never see the native path
+        // and we'd notice only via metrics (review P2-5).
+        runCatching { get<NativePathBootstrap>().install() }
+            .onFailure {
+                Log.e(TAG, "NativePathBootstrap.install failed; native path stays disabled", it)
+                runCatching { Firebase.crashlytics.recordException(it) }
+            }
 
         // Start WebServer if enabled in settings
         startWebServerIfEnabled()

--- a/app/src/main/java/me/rerere/rikkahub/data/agent/tools/WorkspaceArtifactTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/agent/tools/WorkspaceArtifactTools.kt
@@ -25,6 +25,7 @@ import me.rerere.ai.ui.UIMessagePart
 import me.rerere.document.DocxParser
 import me.rerere.document.PdfParser
 import me.rerere.document.PptxParser
+import me.rerere.document.nativebridge.OfficeNativeSwitch
 import me.rerere.rikkahub.data.agent.AgentToolActivityStore
 import me.rerere.rikkahub.data.agent.workspace.WorkspaceManager
 import me.rerere.rikkahub.data.agent.workspace.WorkspacePaths
@@ -275,10 +276,21 @@ class WorkspaceArtifactTools(
             trackArtifactTool("office_read", "读取 Office 文档", input) {
                 val path = input.requiredString("path")
                 val text = withTempWorkspaceFile(path) { file ->
+                    // Phase 2 Step 1: route docx/pptx/epub through OfficeNativeSwitch.
+                    // Phase 3 D-1: xlsx also routes through Switch (net-new,
+                    // no JVM XlsxParser; fallback is the in-app `parseXlsxText`
+                    // helper; diff sampling for xlsx is hard-gated off until a
+                    // JVM-side byte baseline exists).
                     when (path.substringAfterLast('.', "").lowercase(Locale.ROOT)) {
-                        "docx" -> DocxParser.parse(file)
-                        "pptx" -> PptxParser.parse(file)
-                        "xlsx" -> parseXlsxText(file)
+                        "docx" -> OfficeNativeSwitch.parseDocxOrNull(file) {
+                            DocxParser.parse(file)
+                        } ?: DocxParser.parse(file)
+                        "pptx" -> OfficeNativeSwitch.parsePptxOrNull(file) {
+                            PptxParser.parse(file)
+                        } ?: PptxParser.parse(file)
+                        "xlsx" -> OfficeNativeSwitch.parseXlsxOrNull(file) {
+                            parseXlsxText(file)
+                        } ?: parseXlsxText(file)
                         else -> error("Unsupported Office extension: $path")
                     }
                 }

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/DocumentAsPromptTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/DocumentAsPromptTransformer.kt
@@ -10,6 +10,7 @@ import me.rerere.document.DocxParser
 import me.rerere.document.EpubParser
 import me.rerere.document.PdfParser
 import me.rerere.document.PptxParser
+import me.rerere.document.nativebridge.OfficeNativeSwitch
 import java.io.File
 
 object DocumentAsPromptTransformer : InputMessageTransformer {
@@ -46,16 +47,27 @@ object DocumentAsPromptTransformer : InputMessageTransformer {
         return PdfParser.parserPdf(file)
     }
 
+    // Phase 2 Step 1: route through OfficeNativeSwitch. Default config is
+    // disabled → parseXOrNull always returns null → JVM parser runs unchanged.
+    // When a user opts in via NativePathPrefs and the .so loaded, native runs;
+    // any failure (load, panic, NativeUnavailable) returns null and the JVM
+    // path executes via the Elvis fallback. The sampling-path JVM call
+    // happens *inside* the Switch's jvmFallback lambda, not via the Elvis,
+    // so steady-state cost stays at one parse per document.
+
     private fun parseDocxAsText(file: File): String {
-        return DocxParser.parse(file)
+        return OfficeNativeSwitch.parseDocxOrNull(file) { DocxParser.parse(file) }
+            ?: DocxParser.parse(file)
     }
 
     private fun parsePptxAsText(file: File): String {
-        return PptxParser.parse(file)
+        return OfficeNativeSwitch.parsePptxOrNull(file) { PptxParser.parse(file) }
+            ?: PptxParser.parse(file)
     }
 
     private fun parseEpubAsText(file: File): String {
-        return EpubParser.parse(file)
+        return OfficeNativeSwitch.parseEpubOrNull(file) { EpubParser.parse(file) }
+            ?: EpubParser.parse(file)
     }
 
     private fun readDocumentContent(document: UIMessagePart.Document): String {

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesKeys.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesKeys.kt
@@ -1,6 +1,7 @@
 package me.rerere.rikkahub.data.datastore
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 
@@ -110,4 +111,17 @@ object PreferencesKeys {
 
     // 赞助提醒
     val SPONSOR_ALERT_DISMISSED_AT = intPreferencesKey("sponsor_alert_dismissed_at")
+
+    // -----------------------------------------------------------------------
+    // Phase 2 Rust JNI production switches. All default to false so JVM stays
+    // the default code path until a user opts in via Settings → Developer or
+    // until Remote Config flips a cohort to enabled. See SPIKE_PLAN §8.3.
+    // -----------------------------------------------------------------------
+    val NATIVE_PATH_OFFICE = booleanPreferencesKey("native_path_office")
+    val NATIVE_PATH_HIGHLIGHT = booleanPreferencesKey("native_path_highlight")
+    val NATIVE_PATH_REGEX = booleanPreferencesKey("native_path_regex")
+    val NATIVE_PATH_MARKDOWN_HTML = booleanPreferencesKey("native_path_markdown_html")
+    val NATIVE_PATH_MARKDOWN_AST = booleanPreferencesKey("native_path_markdown_ast")
+    /** Fraction of native calls that also run JVM for diff comparison. 0.0..1.0. */
+    val NATIVE_PATH_SAMPLING_RATE = floatPreferencesKey("native_path_sampling_rate")
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/prefs/NativePathPrefs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/prefs/NativePathPrefs.kt
@@ -1,0 +1,101 @@
+package me.rerere.rikkahub.data.datastore.prefs
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import me.rerere.rikkahub.AppScope
+import me.rerere.rikkahub.data.datastore.PreferencesKeys
+import me.rerere.rikkahub.utils.toMutableStateFlow
+
+/**
+ * Per-component enable flags for the Rust JNI production switch.
+ *
+ * **Personal-use config**: the 4 user-facing flags (`office`, `highlight`,
+ * `regex`, `markdownHtml`) default to `true` so the Rust path runs out of
+ * the box. This deliberately drops the "default JVM + gradual rollout"
+ * stance documented in SPIKE_PLAN §8.3 — that gate was sized for an
+ * enterprise rollout, which this app doesn't have. The RC kill switch
+ * (`native_path_kill_switch`) remains the one-flip insurance if a native
+ * crash surfaces in the wild.
+ *
+ * `markdownAst` stays `false`: it's a shadow-compare-only hook (the
+ * renderer still consumes the JVM tree), turning it on without a renderer
+ * swap is pure overhead.
+ *
+ * `sampleRate` defaults to `0` — diff sampling is off because there's no
+ * dashboard to monitor and the rendering paths diverge cosmetically on the
+ * markdown HTML stage even with the normalizer. Set > 0 explicitly when
+ * actively comparing engines.
+ *
+ * **StateFlow lag note**: the [flow] published via `toMutableStateFlow`
+ * lags DataStore writes by one coroutine tick. Acceptable: the next call
+ * picks up the new value sub-second later.
+ *
+ * **Cold-start order**: the initial value seeded by `toMutableStateFlow`
+ * is `NativePathPrefsData()` (the data class defaults — now native-on for
+ * the user-facing flags), so a fresh install or freshly-opted-out user
+ * sees the native path immediately on cold start. DataStore-stored values
+ * override on the first emission a few ms later.
+ */
+data class NativePathPrefsData(
+    val office: Boolean = true,
+    val highlight: Boolean = true,
+    val regex: Boolean = true,
+    val markdownHtml: Boolean = true,
+    val markdownAst: Boolean = false,
+    val sampleRate: Float = 0f,
+)
+
+class NativePathPrefs(
+    private val dataStore: DataStore<Preferences>,
+    scope: AppScope,
+) {
+    internal val rawFlow: Flow<NativePathPrefsData> = dataStore.data
+        .catch { e ->
+            if (e is IOException) emit(emptyPreferences()) else throw e
+        }
+        .map { readFrom(it) }
+        .distinctUntilChanged()
+
+    val flow: StateFlow<NativePathPrefsData> = rawFlow
+        .toMutableStateFlow(scope, NativePathPrefsData())
+
+    suspend fun update(transform: (NativePathPrefsData) -> NativePathPrefsData) {
+        dataStore.edit { p ->
+            val current = readFrom(p)
+            val next = transform(current)
+            if (next == current) return@edit
+            writeTo(p, next)
+        }
+    }
+
+    private fun readFrom(p: Preferences): NativePathPrefsData = NativePathPrefsData(
+        // Personal-use defaults: native on for the 4 user-facing flags so
+        // a fresh install with no DataStore-written keys runs Rust. To opt
+        // out of any individual stage, write `false` to the corresponding
+        // key — `update { it.copy(office = false) }`. See class KDoc for
+        // why we don't follow the §8.3 HARD GATE default-JVM stance.
+        office = p[PreferencesKeys.NATIVE_PATH_OFFICE] ?: true,
+        highlight = p[PreferencesKeys.NATIVE_PATH_HIGHLIGHT] ?: true,
+        regex = p[PreferencesKeys.NATIVE_PATH_REGEX] ?: true,
+        markdownHtml = p[PreferencesKeys.NATIVE_PATH_MARKDOWN_HTML] ?: true,
+        markdownAst = p[PreferencesKeys.NATIVE_PATH_MARKDOWN_AST] ?: false,
+        sampleRate = (p[PreferencesKeys.NATIVE_PATH_SAMPLING_RATE] ?: 0f).coerceIn(0f, 1f),
+    )
+
+    private fun writeTo(p: androidx.datastore.preferences.core.MutablePreferences, data: NativePathPrefsData) {
+        p[PreferencesKeys.NATIVE_PATH_OFFICE] = data.office
+        p[PreferencesKeys.NATIVE_PATH_HIGHLIGHT] = data.highlight
+        p[PreferencesKeys.NATIVE_PATH_REGEX] = data.regex
+        p[PreferencesKeys.NATIVE_PATH_MARKDOWN_HTML] = data.markdownHtml
+        p[PreferencesKeys.NATIVE_PATH_MARKDOWN_AST] = data.markdownAst
+        p[PreferencesKeys.NATIVE_PATH_SAMPLING_RATE] = data.sampleRate.coerceIn(0f, 1f)
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/prefs/NativePathPrefs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/prefs/NativePathPrefs.kt
@@ -29,6 +29,13 @@ import me.rerere.rikkahub.utils.toMutableStateFlow
  * renderer still consumes the JVM tree), turning it on without a renderer
  * swap is pure overhead.
  *
+ * `regex` default `true` is **safe because `Assistant.replaceRegexes`
+ * preflights the rule set** for JVM-only syntax (lookbehind / backref /
+ * possessive in patterns; literal-`$` / `$<name>` in replacements) — if
+ * any rule uses JVM-only constructs, the whole batch routes to the JVM
+ * fallback so semantic parity is preserved. See `RegexNativeSwitch` class
+ * KDoc + `containsJvmOnlyRegexSyntax` in Assistant.kt.
+ *
  * `sampleRate` defaults to `0` — diff sampling is off because there's no
  * dashboard to monitor and the rendering paths diverge cosmetically on the
  * markdown HTML stage even with the normalizer. Set > 0 explicitly when
@@ -47,9 +54,9 @@ import me.rerere.rikkahub.utils.toMutableStateFlow
 data class NativePathPrefsData(
     val office: Boolean = true,
     val highlight: Boolean = true,
-    val regex: Boolean = true,
+    val regex: Boolean = true,         // safe — Assistant.kt preflights JVM-only syntax
     val markdownHtml: Boolean = true,
-    val markdownAst: Boolean = false,
+    val markdownAst: Boolean = false,  // shadow-only, no user-facing win
     val sampleRate: Float = 0f,
 )
 

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -10,6 +10,7 @@ import me.rerere.ai.core.ReasoningLevel
 import me.rerere.rikkahub.data.ai.tools.LocalToolOption
 import me.rerere.rikkahub.data.memory.model.MemoryKind
 import me.rerere.rikkahub.data.memory.model.MemoryScope
+import me.rerere.rikkahub.data.model.nativebridge.RegexNativeSwitch
 import kotlin.uuid.Uuid
 
 @Serializable
@@ -90,25 +91,58 @@ fun String.replaceRegexes(
 ): String {
     if (assistant == null) return this
     if (assistant.regexes.isEmpty()) return this
-    return assistant.regexes.fold(this) { acc, regex ->
-        if (regex.enabled && regex.visualOnly == visual && regex.affectingScope.contains(scope)) {
-            try {
-                val result = acc.replace(
-                    regex = Regex(regex.findRegex),
-                    replacement = regex.replaceString,
-                )
-                // println("Regex: ${regex.findRegex} -> ${result}")
-                result
-            } catch (e: Exception) {
-                e.printStackTrace()
-                // 如果正则表达式格式错误，返回原字符串
-                acc
-            }
-        } else {
+
+    // Filter applicable rules once so the native path can take parallel
+    // pattern + replacement arrays in one JNI call. Skip the rest of the
+    // pipeline (incl. building arrays) if nothing applies.
+    val applicable = assistant.regexes.filter { regex ->
+        regex.enabled && regex.visualOnly == visual && regex.affectingScope.contains(scope)
+    }
+    if (applicable.isEmpty()) return this
+
+    // Phase 2 Step 3: route through RegexNativeSwitch. Default disabled →
+    // skip the entire JNI path (no array allocation) and go straight to JVM
+    // (review P1-1 / P2-3). Both paths skip individual rules whose regex
+    // fails to compile (silent log + acc passthrough) so per-rule semantic
+    // parity is the only correctness concern — caught by diff sampling per
+    // RegexNativeSwitch class KDoc.
+    //
+    // TODO: before flipping `regex=true` for any cohort, add a
+    //   config-save-time validator that scans every assistant rule for
+    //   JVM-only syntax (lookbehind `(?<=` `(?<!`, backref `\1`-`\9`,
+    //   possessive `*+`/`?+`/`++`) and warns the user so they understand the
+    //   semantic gap — diff sampling at sampleRate=0 doesn't catch this
+    //   class of divergence on its own.
+    if (RegexNativeSwitch.isEnabled()) {
+        val patterns = Array(applicable.size) { applicable[it].findRegex }
+        val replacements = Array(applicable.size) { applicable[it].replaceString }
+        RegexNativeSwitch.applyOrNull(
+            input = this,
+            findPatterns = patterns,
+            replacements = replacements,
+            jvmFallback = { applyRegexesJvm(this, applicable) },
+        )?.let { return it }
+    }
+
+    return applyRegexesJvm(this, applicable)
+}
+
+/** JVM regex pipeline preserved as the sole fallback path. Identical to the
+ *  fold body that was inline before Phase 2 Step 3 — invalid patterns are
+ *  caught per-rule and skipped (acc passes through unchanged), so a single
+ *  malformed rule doesn't break the whole chain. */
+private fun applyRegexesJvm(input: String, rules: List<AssistantRegex>): String =
+    rules.fold(input) { acc, regex ->
+        try {
+            acc.replace(
+                regex = Regex(regex.findRegex),
+                replacement = regex.replaceString,
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
             acc
         }
     }
-}
 
 /**
  * 注入位置

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -100,20 +100,14 @@ fun String.replaceRegexes(
     }
     if (applicable.isEmpty()) return this
 
-    // Phase 2 Step 3: route through RegexNativeSwitch. Default disabled →
-    // skip the entire JNI path (no array allocation) and go straight to JVM
-    // (review P1-1 / P2-3). Both paths skip individual rules whose regex
-    // fails to compile (silent log + acc passthrough) so per-rule semantic
-    // parity is the only correctness concern — caught by diff sampling per
-    // RegexNativeSwitch class KDoc.
-    //
-    // TODO: before flipping `regex=true` for any cohort, add a
-    //   config-save-time validator that scans every assistant rule for
-    //   JVM-only syntax (lookbehind `(?<=` `(?<!`, backref `\1`-`\9`,
-    //   possessive `*+`/`?+`/`++`) and warns the user so they understand the
-    //   semantic gap — diff sampling at sampleRate=0 doesn't catch this
-    //   class of divergence on its own.
-    if (RegexNativeSwitch.isEnabled()) {
+    // Phase 2 Step 3: route through RegexNativeSwitch when enabled AND no
+    // rule uses JVM-only syntax. Preflight is required because the Rust
+    // `regex` crate silently skips lookbehind / backref / possessive in
+    // patterns (and `\$` / `$<name>` in replacements), producing different
+    // output without throwing — fallback can't detect it. When the preflight
+    // flags any JVM-only rule we route the whole batch to JVM to preserve
+    // per-rule semantic parity. See `RegexNativeSwitch` class KDoc.
+    if (RegexNativeSwitch.isEnabled() && !containsJvmOnlyRegexSyntax(applicable)) {
         val patterns = Array(applicable.size) { applicable[it].findRegex }
         val replacements = Array(applicable.size) { applicable[it].replaceString }
         RegexNativeSwitch.applyOrNull(
@@ -126,6 +120,39 @@ fun String.replaceRegexes(
 
     return applyRegexesJvm(this, applicable)
 }
+
+/**
+ * Detect any rule that uses Java `Pattern` syntax the Rust `regex` crate
+ * doesn't support (and would silently skip, producing a divergent output).
+ *
+ * Detects, in **pattern** strings:
+ * - lookbehind: `(?<=...)`, `(?<!...)`
+ * - lookahead:  `(?=...)`, `(?!...)`
+ * - atomic group: `(?>...)`
+ * - backreference: `\1` through `\9` (only `\` followed by single digit;
+ *   `\10` etc. are rare and we accept under-coverage there)
+ * - possessive quantifier: `?+`, `*+`, `++`
+ *
+ * Detects, in **replacement** strings:
+ * - literal-dollar Java syntax: `\$`
+ * - named-group Java syntax: `$<name>` (Rust uses `${name}` or `$name`)
+ *
+ * Pure prefilter — no compilation, no DFA, no allocations beyond the
+ * `Regex.containsMatchIn` internal state. Safe to run per-message.
+ */
+private fun containsJvmOnlyRegexSyntax(rules: List<AssistantRegex>): Boolean {
+    return rules.any { rule ->
+        JVM_ONLY_PATTERN_SYNTAX.containsMatchIn(rule.findRegex) ||
+            JVM_ONLY_REPLACEMENT_SYNTAX.containsMatchIn(rule.replaceString)
+    }
+}
+
+private val JVM_ONLY_PATTERN_SYNTAX = Regex(
+    """\(\?<[=!]|\(\?[=!]|\(\?>|\\[1-9]|[?*+]\+"""
+)
+private val JVM_ONLY_REPLACEMENT_SYNTAX = Regex(
+    """\\\$|\$<"""
+)
 
 /** JVM regex pipeline preserved as the sole fallback path. Identical to the
  *  fold body that was inline before Phase 2 Step 3 — invalid patterns are

--- a/app/src/main/java/me/rerere/rikkahub/data/model/nativebridge/RegexNativeSwitch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/nativebridge/RegexNativeSwitch.kt
@@ -1,0 +1,146 @@
+package me.rerere.rikkahub.data.model.nativebridge
+
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
+
+/**
+ * Phase 2 switch in front of [RegexTransformerNative]. Default is disabled —
+ * callers stay on Kotlin's JVM `String.replace(Regex, …)` path.
+ *
+ * ## ⚠ Why diff sampling matters more here
+ *
+ * Per [RegexTransformerNative]'s KDoc, Java `Pattern` and Rust `regex` accept
+ * overlapping but not identical syntax. Rust silently skips rules with
+ * lookbehind / backreferences / possessive quantifiers — the **output is
+ * different but neither side throws**, so the Switch will return a valid
+ * (incorrect) string instead of `null`. The classic load-failure / panic
+ * fallback path does NOT catch this. Diff sampling is the only reliable
+ * detector. Phase 2 rollout MUST set a non-zero `samplingRate` for regex
+ * until divergence is empirically zero.
+ */
+object RegexNativeSwitch {
+
+    private const val TAG = "RegexNativeSwitch"
+    const val COMPONENT_NAME: String = "regex"
+
+    interface Config {
+        fun enabled(): Boolean
+        fun samplingRate(): Float
+        fun onLoadFailure(error: Throwable)
+        fun onNativePanic(stage: String, error: Throwable?)
+        fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String)
+    }
+
+    object DisabledConfig : Config {
+        override fun enabled(): Boolean = false
+        override fun samplingRate(): Float = 0f
+        override fun onLoadFailure(error: Throwable) {}
+        override fun onNativePanic(stage: String, error: Throwable?) {}
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) {}
+    }
+
+    @Volatile
+    var config: Config = DisabledConfig
+
+    private val loadFailureReported = AtomicBoolean(false)
+    private val firstSuccessLogged = AtomicBoolean(false)
+
+    /**
+     * Cheap pre-check exposed to callers so they can avoid building parallel
+     * pattern/replacement arrays for `applyOrNull` when the native path is
+     * disabled — a hot-path concern because `String.replaceRegexes` runs per
+     * streamed token (review P1-1 / P2-3). Same `@Volatile` read as
+     * `config.enabled()` so calling this first then `applyOrNull` is racy
+     * only in the harmless direction (we may build arrays just before the
+     * Switch is disabled mid-token).
+     */
+    fun isEnabled(): Boolean = config.enabled()
+
+    /**
+     * One-shot warning fires the first time the regex native path runs with
+     * `enabled=true` but `samplingRate=0`. The class KDoc documents that
+     * Rust silently produces wrong output for Java-only syntax (lookbehind,
+     * backreferences, possessive quantifiers); diff sampling is the only
+     * detector. Production rollout MUST set a non-zero sample rate until
+     * divergence is empirically zero (review P3-3).
+     */
+    private val zeroSampleWarned = AtomicBoolean(false)
+
+    /**
+     * Run the regex pipeline natively. Returns `null` if disabled / native
+     * unavailable / native errored. [jvmFallback] is invoked only inside the
+     * sampling path (it produces the JVM output for comparison; the production
+     * caller is responsible for the actual JVM fallback when this returns null).
+     */
+    fun applyOrNull(
+        input: String,
+        findPatterns: Array<String>,
+        replacements: Array<String>,
+        jvmFallback: () -> String,
+    ): String? {
+        val cfg = config
+        if (!cfg.enabled()) return null
+        if (!RegexTransformerNative.available) {
+            if (loadFailureReported.compareAndSet(false, true)) {
+                RegexTransformerNative.lastLoadError()?.let { cfg.onLoadFailure(it) }
+            }
+            return null
+        }
+        // Warning fires only once per process when native is actually live
+        // and sampling is disabled — placed after the availability check so
+        // it doesn't spam when the .so simply failed to load.
+        if (cfg.samplingRate() <= 0f && zeroSampleWarned.compareAndSet(false, true)) {
+            Log.w(
+                TAG,
+                "Regex native enabled but samplingRate=0 — lookbehind/backref/" +
+                    "possessive divergences will go undetected. Set NATIVE_PATH_" +
+                    "SAMPLING_RATE > 0 in DataStore before relying on this " +
+                    "path in production.",
+            )
+        }
+        val nativeOutput = try {
+            RegexTransformerNative.apply(input, findPatterns, replacements)
+        } catch (t: Throwable) {
+            Log.w(TAG, "native apply threw — falling back to JVM", t)
+            cfg.onNativePanic("apply", t)
+            return null
+        }
+        if (nativeOutput == null) {
+            cfg.onNativePanic("apply", null)
+            return null
+        }
+        if (firstSuccessLogged.compareAndSet(false, true)) {
+            // rulesIn = patterns we handed to Rust. The crate skips any rule
+            // whose regex won't compile (lookbehind, backrefs, possessive
+            // quantifiers, ...), so the applied count may be lower — see
+            // RegexTransformerNative class KDoc. Diff sampling is the only
+            // way to observe the skip rate.
+            Log.i(TAG, "native regex ok (first success): rulesIn=${findPatterns.size} len=${nativeOutput.length}")
+        }
+        val rate = cfg.samplingRate()
+        // Predicate matches Office/Highlight/Markdown — single style across
+        // the 4 Switches (final-sweep P2-2).
+        if (rate <= 0f || Random.nextFloat() >= rate) return nativeOutput
+        try {
+            val jvmOutput = jvmFallback()
+            cfg.onDiff(
+                stage = "apply",
+                equal = jvmOutput == nativeOutput,
+                // Rule count goes into the payload, not the stage label, so
+                // Crashlytics doesn't fragment groups across rule-count
+                // values.
+                jvmSummary = "rules=${findPatterns.size} " + summarize(jvmOutput),
+                nativeSummary = "rules=${findPatterns.size} " + summarize(nativeOutput),
+            )
+        } catch (t: Throwable) {
+            Log.w(TAG, "diff-sampling JVM fallback threw; skipping diff", t)
+        }
+        return nativeOutput
+    }
+
+    private fun summarize(s: String): String {
+        val head = if (s.length <= 256) s else s.substring(0, 256) + "...(+${s.length - 256})"
+        return "len=${s.length} head=$head"
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/model/nativebridge/RegexTransformerNative.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/nativebridge/RegexTransformerNative.kt
@@ -6,8 +6,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Bridge to the `regex-transformer` Rust crate.
  *
- * Spike-phase: NOT wired into [me.rerere.rikkahub.data.model.replaceRegexes];
- * benchmark/equivalence tests call directly.
+ * Phase 1 (PR #9) shipped this bridge without production wiring — benchmarks
+ * called it directly. From Phase 2 Step 3 onwards `String.replaceRegexes`
+ * routes through the sibling [RegexNativeSwitch].
  *
  * Kotlin adapter handles the rule-filtering (enabled / visualOnly /
  * affectingScope) and feeds the JNI surface parallel pattern + replacement
@@ -62,6 +63,9 @@ internal object RegexTransformerNative {
             ensureLoaded()
             return loaded.get()
         }
+
+    /** See [me.rerere.document.nativebridge.OfficeParserNative.lastLoadError]. */
+    internal fun lastLoadError(): Throwable? = loadError
 
     private fun ensureLoaded() {
         if (loaded.get() || loadError != null) return

--- a/app/src/main/java/me/rerere/rikkahub/data/nativepath/NativePathBootstrap.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/nativepath/NativePathBootstrap.kt
@@ -1,0 +1,324 @@
+package me.rerere.rikkahub.data.nativepath
+
+import android.util.Log
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.google.firebase.remoteconfig.ConfigUpdate
+import com.google.firebase.remoteconfig.ConfigUpdateListener
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import me.rerere.document.nativebridge.OfficeNativeSwitch
+import me.rerere.highlight.nativebridge.HighlightNativeSwitch
+import me.rerere.rikkahub.AppScope
+import me.rerere.rikkahub.data.datastore.prefs.NativePathPrefs
+import me.rerere.rikkahub.data.model.nativebridge.RegexNativeSwitch
+import me.rerere.rikkahub.ui.components.richtext.nativebridge.MarkdownNativeSwitch
+
+/**
+ * Wires the 4 `*NativeSwitch` objects to user prefs + Remote Config + Crashlytics.
+ *
+ * Lifecycle:
+ * 1. App startup constructs this via Koin, then calls [install] from
+ *    [me.rerere.rikkahub.RikkaHubApp].
+ * 2. [install] reads the current [NativePathPrefs] snapshot and pushes a
+ *    config impl into each Switch. Subsequent user-toggle edits are picked
+ *    up on the next call because each impl reads `prefs.flow.value` lazily.
+ * 3. Remote Config kill-switch: a `true`-valued `native_path_kill_switch`
+ *    forces all components off regardless of user prefs. Cached locally via
+ *    a `@Volatile` field, refreshed by an RC `ConfigUpdateListener`, so the
+ *    hot-path is one volatile read instead of an RC client call per request.
+ *
+ * Each diff / panic / load-failure event is encoded into a fresh
+ * [NativePathFailure] or [NativePathDivergence] instance whose **message
+ * itself** carries `component:stage` plus the payload. We deliberately do NOT
+ * call `setCustomKey(...)` for per-event data — Crashlytics custom keys are
+ * process-global and the snapshot taken inside `recordException` would race
+ * across concurrent components (review P2-1).
+ */
+class NativePathBootstrap(
+    private val prefs: NativePathPrefs,
+    private val crashlytics: FirebaseCrashlytics,
+    private val remoteConfig: FirebaseRemoteConfig,
+    private val scope: AppScope,
+) {
+    companion object {
+        private const val TAG = "NativePathBootstrap"
+        const val REMOTE_KILL_SWITCH_KEY: String = "native_path_kill_switch"
+    }
+
+    /**
+     * Cached kill-switch value. Updated by [refreshKillSwitch] only — that
+     * helper serializes all writes through a synchronized block (round-2
+     * review R2-P2-2) so two concurrent RC callbacks (config-update +
+     * activate-complete) can't inter-leave reads and produce a stale cache.
+     * Read on every `enabled()` call in the four Config impls. Defaults to
+     * false (same as the RC XML default) so a missing RC instance fails safe.
+     */
+    @Volatile
+    private var killSwitchCached: Boolean = false
+
+    private val killSwitchLock = Any()
+
+    /**
+     * Atomic read-and-publish: a fresh `getBoolean` read is paired with the
+     * write under one lock, so concurrent refreshers observe a consistent
+     * before/after instead of racing two stale RC fetches against each other.
+     */
+    private fun refreshKillSwitch() {
+        synchronized(killSwitchLock) {
+            val v = readKillSwitchSafe()
+            killSwitchCached = v
+            // Emit the breadcrumb inside the lock so concurrent refreshers
+            // can't interleave writes vs. log emissions — breadcrumbs stay
+            // in cache-write order (final-sweep R2 P3-c). `Crashlytics.log`
+            // is an in-memory ring-buffer append; safe to hold the lock
+            // across the call.
+            runCatching {
+                crashlytics.log("native_path kill_switch=$v")
+            }.onFailure { Log.w(TAG, "Crashlytics breadcrumb log failed", it) }
+        }
+    }
+
+    fun install() {
+        // Seed once from whatever RC has already activated. setDefaultsAsync
+        // in RikkaHubApp.onCreate is fire-and-forget; until it activates,
+        // getBoolean returns the Java default `false` (= allow native), which
+        // is also the safe default. The activate listener below repaints
+        // killSwitchCached when defaults / fetched values become live (review
+        // P2-6).
+        refreshKillSwitch()
+        installKillSwitchListener()
+        installActivationRefresh()
+
+        OfficeNativeSwitch.config = OfficeConfigImpl()
+        HighlightNativeSwitch.config = HighlightConfigImpl()
+        MarkdownNativeSwitch.config = MarkdownConfigImpl()
+        RegexNativeSwitch.config = RegexConfigImpl()
+
+        Log.i(TAG, "NativePath switches installed (kill_switch=$killSwitchCached)")
+    }
+
+    /**
+     * Kick a fresh `activate()` and refresh the cached kill switch when it
+     * completes. `activate()` is idempotent — if `RikkaHubApp.onCreate`'s
+     * `fetchAndActivate()` already finished, this resolves immediately;
+     * otherwise it blocks until activation lands, at which point the XML
+     * default and any fetched override become readable. Without this hop, an
+     * emergency XML default flip to `true` would be ignored at cold start
+     * until the next user-triggered RC refresh.
+     */
+    private fun installActivationRefresh() {
+        runCatching {
+            remoteConfig.activate().addOnCompleteListener {
+                refreshKillSwitch()
+                Log.i(TAG, "RC activate completed; kill_switch=$killSwitchCached")
+            }
+        }.onFailure { Log.w(TAG, "Failed to attach RC activate listener", it) }
+    }
+
+    private fun installKillSwitchListener() {
+        runCatching {
+            remoteConfig.addOnConfigUpdateListener(object : ConfigUpdateListener {
+                override fun onUpdate(configUpdate: ConfigUpdate) {
+                    if (REMOTE_KILL_SWITCH_KEY in configUpdate.updatedKeys) {
+                        remoteConfig.activate()
+                            .addOnSuccessListener {
+                                refreshKillSwitch()
+                                Log.i(TAG, "Remote kill_switch refreshed: $killSwitchCached")
+                            }
+                            // Without this branch a transient activate() failure
+                            // (rare; local cache corruption) would leave the cached
+                            // value stale and the operator would never know
+                            // (final-sweep P3-2).
+                            .addOnFailureListener {
+                                Log.w(TAG, "RC activate after kill-switch update failed", it)
+                            }
+                    }
+                }
+
+                override fun onError(error: FirebaseRemoteConfigException) {
+                    // Don't escalate — RC listener errors are common transient
+                    // events; the cached value stays at whatever was last seen.
+                    Log.w(TAG, "RC ConfigUpdateListener error", error)
+                }
+            })
+        }.onFailure { Log.w(TAG, "Failed to register RC kill-switch listener", it) }
+    }
+
+    private fun readKillSwitchSafe(): Boolean = try {
+        remoteConfig.getBoolean(REMOTE_KILL_SWITCH_KEY)
+    } catch (t: Throwable) {
+        Log.w(TAG, "Remote Config kill_switch read failed; treating as false", t)
+        false
+    }
+
+    private fun sampleRate(): Float = prefs.flow.value.sampleRate.coerceIn(0f, 1f)
+
+    private fun recordLoad(component: String, error: Throwable) {
+        dispatchRecord {
+            crashlytics.recordException(
+                NativePathFailure(component = component, stage = "load", cause = error)
+            )
+        }
+    }
+
+    private fun recordPanic(component: String, stage: String, error: Throwable?) {
+        dispatchRecord {
+            crashlytics.recordException(
+                NativePathFailure(component = component, stage = stage, cause = error)
+            )
+        }
+    }
+
+    private fun recordDiff(
+        component: String,
+        stage: String,
+        equal: Boolean,
+        jvmSummary: String,
+        nativeSummary: String,
+    ) {
+        if (equal) return  // Don't burn Crashlytics quota on matching outputs.
+        val jvmText = truncate(jvmSummary)
+        val nativeText = truncate(nativeSummary)
+        dispatchRecord {
+            crashlytics.recordException(
+                NativePathDivergence(
+                    component = component,
+                    stage = stage,
+                    jvmSummary = jvmText,
+                    nativeSummary = nativeText,
+                )
+            )
+        }
+    }
+
+    /**
+     * Off-loads the [FirebaseCrashlytics.recordException] call to a background
+     * dispatcher so production hot paths (regex per message, markdown HTML per
+     * streaming chunk) don't pay the stack-capture + serialization cost inline
+     * (review P2-7).
+     *
+     * Failures from the dispatch itself are swallowed and logged — Crashlytics
+     * outage must never block the caller.
+     */
+    private fun dispatchRecord(block: () -> Unit) {
+        // If the AppScope is cancelled (process shutting down), `scope.launch`
+        // becomes a no-op and the report is lost. Fall back to an inline call
+        // so a late-fired panic/divergence still has a chance to reach
+        // Crashlytics before the process exits (round 2 review R2-P2-4).
+        if (!scope.isActive) {
+            try {
+                block()
+            } catch (t: Throwable) {
+                Log.w(TAG, "Crashlytics inline-fallback failed (scope cancelled)", t)
+            }
+            return
+        }
+        scope.launch(Dispatchers.IO) {
+            try {
+                block()
+            } catch (t: Throwable) {
+                Log.w(TAG, "Crashlytics dispatch failed", t)
+            }
+        }
+    }
+
+    /** Cap payload at ~900 chars so the encoded message stays well under
+     *  Crashlytics' per-event limit even when both sides are included. */
+    private fun truncate(s: String): String =
+        if (s.length <= 900) s else s.substring(0, 900) + "...(+${s.length - 900})"
+
+    // -----------------------------------------------------------------------
+    // Per-Switch Config implementations. Each enabled() check reads the cached
+    // kill switch plus the StateFlow prefs snapshot — both are @Volatile reads,
+    // so safe-for-hot-path.
+    // -----------------------------------------------------------------------
+
+    private inner class OfficeConfigImpl : OfficeNativeSwitch.Config {
+        override fun enabled(): Boolean = !killSwitchCached && prefs.flow.value.office
+        override fun samplingRate(): Float = sampleRate()
+        override fun onLoadFailure(error: Throwable) =
+            recordLoad(OfficeNativeSwitch.COMPONENT_NAME, error)
+        override fun onNativePanic(stage: String, error: Throwable?) =
+            recordPanic(OfficeNativeSwitch.COMPONENT_NAME, stage, error)
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) =
+            recordDiff(OfficeNativeSwitch.COMPONENT_NAME, stage, equal, jvmSummary, nativeSummary)
+    }
+
+    private inner class HighlightConfigImpl : HighlightNativeSwitch.Config {
+        override fun enabled(): Boolean = !killSwitchCached && prefs.flow.value.highlight
+        override fun samplingRate(): Float = sampleRate()
+        override fun onLoadFailure(error: Throwable) =
+            recordLoad(HighlightNativeSwitch.COMPONENT_NAME, error)
+        override fun onNativePanic(stage: String, error: Throwable?) =
+            recordPanic(HighlightNativeSwitch.COMPONENT_NAME, stage, error)
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) =
+            recordDiff(HighlightNativeSwitch.COMPONENT_NAME, stage, equal, jvmSummary, nativeSummary)
+    }
+
+    private inner class MarkdownConfigImpl : MarkdownNativeSwitch.Config {
+        override fun htmlEnabled(): Boolean = !killSwitchCached && prefs.flow.value.markdownHtml
+        override fun astEnabled(): Boolean = !killSwitchCached && prefs.flow.value.markdownAst
+        override fun samplingRate(): Float = sampleRate()
+        override fun onLoadFailure(error: Throwable) =
+            recordLoad(MarkdownNativeSwitch.COMPONENT_NAME, error)
+        override fun onNativePanic(stage: String, error: Throwable?) =
+            recordPanic(MarkdownNativeSwitch.COMPONENT_NAME, stage, error)
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) =
+            recordDiff(MarkdownNativeSwitch.COMPONENT_NAME, stage, equal, jvmSummary, nativeSummary)
+    }
+
+    private inner class RegexConfigImpl : RegexNativeSwitch.Config {
+        override fun enabled(): Boolean = !killSwitchCached && prefs.flow.value.regex
+        override fun samplingRate(): Float = sampleRate()
+        override fun onLoadFailure(error: Throwable) =
+            recordLoad(RegexNativeSwitch.COMPONENT_NAME, error)
+        override fun onNativePanic(stage: String, error: Throwable?) =
+            recordPanic(RegexNativeSwitch.COMPONENT_NAME, stage, error)
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) =
+            recordDiff(RegexNativeSwitch.COMPONENT_NAME, stage, equal, jvmSummary, nativeSummary)
+    }
+}
+
+/**
+ * Per-event failure record. Carrying `component` / `stage` / the underlying
+ * cause as constructor arguments — not as global Crashlytics custom keys —
+ * means concurrent native-path events on different components don't race on
+ * shared mutable state (review P2-1). Crashlytics groups by exception class
+ * + message-prefix, so all `office:load` failures bucket together regardless
+ * of which other components were busy in parallel.
+ *
+ * **Message split is intentional** (round 2 review R2-P3-2): null-cause
+ * collapses to "...native unavailable" while a thrown cause produces
+ * "...native failure". These reflect distinct bridge contracts —
+ * `unavailable` means the bridge returned a sentinel (NativeUnavailable /
+ * null blob) without throwing, a `failure` means an actual Throwable came
+ * out. Triagers want them in separate Crashlytics issue groups.
+ */
+class NativePathFailure(
+    val component: String,
+    val stage: String,
+    cause: Throwable?,
+) : RuntimeException(
+    "$component:$stage native ${if (cause == null) "unavailable" else "failure"}",
+    cause,
+)
+
+/**
+ * Per-event divergence record. Carries the JVM and native summaries inline
+ * in the message body (after a newline so Crashlytics' dashboard preview
+ * still shows the static prefix as the issue title). Same race-free design as
+ * [NativePathFailure].
+ */
+class NativePathDivergence(
+    val component: String,
+    val stage: String,
+    val jvmSummary: String,
+    val nativeSummary: String,
+) : RuntimeException(
+    "$component:$stage native output diverges from JVM\n" +
+        "jvm:    $jvmSummary\n" +
+        "native: $nativeSummary"
+)

--- a/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
@@ -26,11 +26,13 @@ import me.rerere.rikkahub.data.datastore.prefs.AgentPrefs
 import me.rerere.rikkahub.data.datastore.prefs.AssistantPrefs
 import me.rerere.rikkahub.data.datastore.prefs.ChatPrefs
 import me.rerere.rikkahub.data.datastore.prefs.ExtensionPrefs
+import me.rerere.rikkahub.data.datastore.prefs.NativePathPrefs
 import me.rerere.rikkahub.data.datastore.prefs.ProviderPrefs
 import me.rerere.rikkahub.data.datastore.prefs.SearchPrefs
 import me.rerere.rikkahub.data.datastore.prefs.SettingsAggregator
 import me.rerere.rikkahub.data.datastore.prefs.SettingsProviderRescue
 import me.rerere.rikkahub.data.datastore.prefs.UIPrefs
+import me.rerere.rikkahub.data.nativepath.NativePathBootstrap
 import me.rerere.rikkahub.data.datastore.settingsStore
 import me.rerere.rikkahub.data.db.AppDatabase
 import me.rerere.rikkahub.data.db.fts.MessageFtsManager
@@ -91,6 +93,19 @@ val dataSourceModule = module {
 
     single {
         AssistantPrefs(dataStore = get<Context>().settingsStore, scope = get())
+    }
+
+    single {
+        NativePathPrefs(dataStore = get<Context>().settingsStore, scope = get())
+    }
+
+    single {
+        NativePathBootstrap(
+            prefs = get(),
+            crashlytics = get(),
+            remoteConfig = get(),
+            scope = get(),
+        )
     }
 
     single {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/CharReveal.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/CharReveal.kt
@@ -55,8 +55,11 @@ enum class StreamRevealPreset(val baseRevealDurationMs: Long) {
     /** Snappy: ~120ms fade. Closest to "no animation but with a soft edge". */
     REALTIME(120L),
 
-    /** Default. ~200ms — 12 frames @60Hz, matches the original B1 tuning. */
-    BALANCED(200L),
+    /** Default. ~80ms — ~5 frames @60Hz. "Crisp typing" sweet spot: short
+     *  enough to feel snappy, long enough that the fade is still
+     *  perceivable. Was 200L before the experiment; flip back if streaming
+     *  jank surfaces on slow devices. */
+    BALANCED(80L),
 
     /** Slow + cinematic. ~320ms — feels deliberate, good for long replies. */
     SILKY(320L),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -1,5 +1,6 @@
 package me.rerere.rikkahub.ui.components.richtext
 
+import android.os.Looper
 import android.os.Trace
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -93,7 +94,10 @@ import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 import org.intellij.markdown.parser.MarkdownParser
+import me.rerere.rikkahub.ui.components.richtext.nativebridge.MarkdownNativeSwitch
+import me.rerere.rikkahub.ui.components.richtext.nativebridge.PackedAstReader
 import java.util.LinkedHashMap
+import kotlin.random.Random
 
 /**
  * When false, markdown nodes use wrap-content width instead of fill-max-width.
@@ -355,7 +359,73 @@ private fun ASTNode.containsHtmlBlocks(): Boolean {
 
 private fun parsePreprocessedMarkdownUncached(preprocessed: String): MarkdownParseResult {
     val astTree = parser.buildMarkdownTreeFromString(preprocessed)
+    // Phase 2 Step 5: shadow-compare against native pulldown-cmark AST when
+    // `markdownAst` is enabled. The renderer still consumes `astTree` (JVM
+    // tree) — we don't swap the consumer because Markdown.kt is mid-migration
+    // (see `feedback_rikkahub_rust_native_spike` memory: 12+ commits/month,
+    // touching the renderer right now risks merge conflicts with active
+    // streaming-render fixes). The shadow path gives us correctness telemetry
+    // ahead of the eventual full swap.
+    maybeShadowCompareNativeAst(preprocessed, astTree)
     return MarkdownParseResult(preprocessed, astTree, astTree.containsHtmlBlocks())
+}
+
+/**
+ * Top-level structural compare. **Count-only** — the JVM ASTNode exposes
+ * UTF-16 char offsets, pulldown-cmark exposes UTF-8 byte offsets; on a
+ * CJK / emoji corpus (rikkahub's bread-and-butter) span comparison
+ * deterministically diverges and would swamp Crashlytics with false-positive
+ * mismatches (review Step 5 P0-1). The "real" semantic-equivalence compare
+ * needs an offset-normalizer + a JVM↔Rust type-name mapping table and
+ * arrives with the eventual renderer swap.
+ *
+ * Cost-gated by the shared sample rate so streaming chunks don't pay the
+ * JNI + decode bill per tick — only a fraction of parses run native and
+ * compare (review Step 5 P1-1).
+ */
+private fun maybeShadowCompareNativeAst(preprocessed: String, jvmTree: ASTNode) {
+    if (!MarkdownNativeSwitch.isAstEnabled()) return
+    // Skip when called on the composition (main) thread — the JNI parse +
+    // PackedAstReader decode would block the UI. Caches in this file
+    // sometimes hit a parse on main during first composition; let those
+    // fast-path through JVM and only sample compare on background renders.
+    if (Looper.myLooper() == Looper.getMainLooper()) return
+    val rate = MarkdownNativeSwitch.sampleRate()
+    if (rate <= 0f) return
+    // Caller-side roll decides whether to incur the JNI + decode cost at all.
+    // `reportAstDiff` also samples internally for matches (so dashboards see
+    // a sparse "sampling is alive" heartbeat) — that's an intentional second
+    // gate, the divergence path bypasses it and always reports.
+    if (Random.nextFloat() >= rate) return
+
+    // Whole-body try/catch: `PackedAstReader.root()` / `.children` is lazy
+    // and can throw (e.g. "varint too long") on a magic-valid but truncated
+    // native blob. Without this guard a corrupted Rust output would surface
+    // as an exception inside the JVM renderer path that just consumed the
+    // valid JVM tree — i.e. the shadow harness, which is supposed to NEVER
+    // affect the caller, would break the caller (Codex review P1-2).
+    try {
+        val blob = MarkdownNativeSwitch.parseAstOrNull(preprocessed) ?: return
+        val reader = PackedAstReader(blob)
+        val nativeRoot = reader.root()
+        if (!reader.isValid || nativeRoot == null) {
+            MarkdownNativeSwitch.reportAstBlobRejected()
+            return
+        }
+        val jvmCount = jvmTree.children.size
+        val nativeChildren = nativeRoot.children
+        val nativeCount = nativeChildren.size
+        val equal = jvmCount == nativeCount
+        val nativeTypeCodes = nativeChildren.take(8).map { it.typeCode }
+        MarkdownNativeSwitch.reportAstDiff(
+            equal = equal,
+            jvmSummary = "blocks=$jvmCount",
+            nativeSummary = "blocks=$nativeCount typeCodes=$nativeTypeCodes",
+        )
+    } catch (t: Throwable) {
+        android.util.Log.w("MarkdownAstShadow", "native AST decode/compare threw", t)
+        MarkdownNativeSwitch.reportAstBlobRejected()
+    }
 }
 
 private fun parseMarkdownUncached(content: String): MarkdownParseResult {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
@@ -83,6 +83,7 @@ import me.rerere.rikkahub.utils.toDp
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
+import me.rerere.rikkahub.ui.components.richtext.nativebridge.MarkdownNativeSwitch
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
@@ -118,6 +119,30 @@ private val parser by lazy { MarkdownParser(flavour) }
 
 private fun generateMarkdownHtml(content: String): String {
     val preprocessed = preProcess(content)
+    // Phase 2 Step 4: try native pulldown-cmark HTML emit before falling
+    // back to the JetBrains HtmlGenerator. Default config keeps native off
+    // → renderHtmlOrNull returns null → JVM path runs unchanged.
+    //
+    // Diff sampling for the HTML stage now runs both outputs through
+    // `HtmlDiffNormalizer` (Phase 3 C) before comparison, so cosmetic
+    // divergences (whitespace, attr order, entity escape, void-tag style)
+    // don't flood Crashlytics — only genuine semantic differences do.
+    // `HTML_DIFF_ENABLED` remains as a one-flip kill-switch should the
+    // normalizer itself need to be backed out.
+    if (MarkdownNativeSwitch.isHtmlEnabled()) {
+        // TODO: pulldown-cmark JNI call is uninterruptible — when the caller's
+        //   mapLatest cancels the previous chunk's render, this still burns
+        //   a Dispatchers.Default worker until completion. Acceptable for v1
+        //   because individual renders are <ms; revisit if ANR signals
+        //   point to Default-pool saturation on streamed messages.
+        MarkdownNativeSwitch
+            .renderHtmlOrNull(preprocessed) { generateMarkdownHtmlJvm(preprocessed) }
+            ?.let { return it }
+    }
+    return generateMarkdownHtmlJvm(preprocessed)
+}
+
+private fun generateMarkdownHtmlJvm(preprocessed: String): String {
     val tree = parser.buildMarkdownTreeFromString(preprocessed)
     return HtmlGenerator(preprocessed, tree, flavour).generateHtml()
 }
@@ -131,6 +156,11 @@ fun MarkdownNew(
     style: TextStyle = LocalTextStyle.current,
     onClickCitation: (String) -> Unit = {},
 ) {
+    // The initial `generateMarkdownHtml(content)` runs on the composition
+    // thread (main). With native HTML enabled this includes a JNI call —
+    // bounded but visible on long lists scrolling into view. Pre-existing
+    // behaviour with the JVM path; native adds JNI overhead. Revisit if
+    // first-paint metrics regress after rollout.
     var html by remember {
         mutableStateOf(
             value = generateMarkdownHtml(content),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/HtmlDiffNormalizer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/HtmlDiffNormalizer.kt
@@ -1,0 +1,139 @@
+package me.rerere.rikkahub.ui.components.richtext.nativebridge
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities
+
+/**
+ * Canonicalises HTML so the [MarkdownNativeSwitch] diff sampler can compare
+ * JetBrains `HtmlGenerator` output against `pulldown-cmark` output without
+ * being drowned in cosmetic divergences (whitespace, attr order, entity
+ * escape style, self-closing-tag style).
+ *
+ * What this normalizer **does** (cosmetic equalisations the two engines
+ * legitimately disagree on):
+ *
+ * - Parses with Jsoup (lenient HTML5 reader) so malformed minor differences
+ *   resolve to the same tree.
+ * - Sorts each element's attributes by key (Jsoup preserves source order;
+ *   the two engines disagree on emission order).
+ * - Forces XHTML entity-escape mode (`&amp;` vs `&` for ambiguous chars).
+ * - Disables `prettyPrint` so block boundaries don't add stray newlines.
+ * - Collapses runs of ASCII whitespace inside text nodes (the two engines
+ *   differ on whether trailing whitespace inside `<p>` is retained).
+ * - Strips leading + trailing whitespace from the document body.
+ *
+ * What this normalizer **does NOT do** (genuine differences worth diffing):
+ *
+ * - Inline-HTML semantics: if one engine emits `<br/>` and the other emits
+ *   `<br>`, Jsoup HTML5-canonicalises both to `<br>` — equal. But if one
+ *   engine drops an `<img>` because of a safelink rule and the other
+ *   keeps it, that survives normalization and reports as divergence.
+ * - Tag-tree topology: an extra `<em>` wrapper, missing list item, etc. all
+ *   survive normalization.
+ * - Text content: zero-width chars / U+00A0 vs ASCII space are preserved
+ *   so a "real" different character still reports.
+ *
+ * **Intentional tradeoff** (Phase 3 C review): the `\s+ → " "` collapse and
+ * `>\s+<` tag-boundary strip run over the *entire serialized output*,
+ * including content inside `<pre>` / `<code>`. Two `<pre><code>` blocks
+ * that genuinely differ only in internal indentation will be equalised; a
+ * theoretical input with adjacent siblings inside `<pre>` (e.g.
+ * `<pre><code>a</code>\n<code>b</code></pre>`) loses the inter-sibling
+ * whitespace. This is acceptable because a diff sampler should under-report
+ * code-formatting tweaks rather than flood Crashlytics — but it means this
+ * normalizer is NOT suitable for code-equality checks. If you need
+ * byte-faithful code-block diffing, slot it BEFORE the parse + collapse
+ * chain.
+ *
+ * Public surface is intentionally tiny — see [normalize].
+ */
+internal object HtmlDiffNormalizer {
+
+    /**
+     * Inputs longer than this (in UTF-16 code units — Kotlin `String.length`)
+     * skip Jsoup parsing. `parseBodyFragment` on a 200 K-char chunk can take
+     * 10–50 ms and the sampler runs inside the streaming hot path. For very
+     * large inputs we accept a guaranteed "diff" reading (the raw strings
+     * rarely match) rather than blocking the streamer. ~64 K chars covers
+     * the long tail of LLM markdown chunks (typical chunk is well under
+     * 4 K chars). Codex review P3-6 renamed this from `_BYTES` — Kotlin
+     * `String.length` is char count, not UTF-8 byte size.
+     */
+    private const val MAX_NORMALIZE_INPUT_CHARS: Int = 64 * 1024
+
+    /**
+     * Returns the canonical form of [html]. Pure function — same input always
+     * yields same output regardless of call order (Jsoup parser is stateless
+     * per call).
+     *
+     * Falls back to the original input on a Jsoup parse failure (extremely
+     * rare since Jsoup accepts almost anything) or when the input exceeds
+     * [MAX_NORMALIZE_INPUT_CHARS]. Both fallback paths leave the string
+     * unchanged, so a malformed-but-different pair will still report as
+     * divergence — the safe direction.
+     */
+    fun normalize(html: String): String {
+        if (html.length > MAX_NORMALIZE_INPUT_CHARS) return html
+        val doc: Document = try {
+            Jsoup.parseBodyFragment(html)
+        } catch (t: Throwable) {
+            return html
+        }
+        doc.outputSettings()
+            .prettyPrint(false)
+            .escapeMode(Entities.EscapeMode.xhtml)
+            .syntax(Document.OutputSettings.Syntax.html)
+            .charset(Charsets.UTF_8)
+        canonicalizeAttributes(doc.body())
+        // Render the body's inner HTML rather than the wrapped `<html><body>...`
+        // — `parseBodyFragment` always synthesises that wrapper even when the
+        // input had none.
+        val raw = doc.body().html()
+        // Three passes — each catches a different real-world divergence
+        // between JetBrains and pulldown-cmark:
+        //   1. `\s+` → ` `  : collapse internal whitespace runs
+        //   2. `\s+(</)` → `\1`  : strip space before close tags (handles
+        //      `<code>x\n</code>` vs `<code>x</code>`)
+        //   3. `>\s+<` → `><`  : strip space between adjacent tags
+        //      (handles `</tr>\n<tr>` vs `</tr><tr>`)
+        var s = WHITESPACE_RUN.replace(raw, " ")
+        s = SPACE_BEFORE_CLOSE_TAG.replace(s, "$1")
+        s = SPACE_BETWEEN_TAGS.replace(s, "><")
+        return s.trim()
+    }
+
+    /**
+     * Recursively sort every element's attributes by key. Jsoup `Attributes`
+     * is a list-backed structure preserving insertion order; we rebuild it
+     * via remove + put-back so the final serialization order is
+     * lexicographic.
+     */
+    private fun canonicalizeAttributes(element: Element) {
+        val attrs = element.attributes()
+        if (attrs.size() > 1) {
+            val sorted = attrs.asList()
+                .map { it.key to it.value }
+                .sortedBy { it.first }
+            attrs.asList().forEach { attrs.remove(it.key) }
+            sorted.forEach { (k, v) -> attrs.put(k, v) }
+        }
+        for (child in element.children()) {
+            canonicalizeAttributes(child)
+        }
+    }
+
+    private val WHITESPACE_RUN: Regex = Regex("\\s+")
+
+    /**
+     * Matches whitespace immediately before a close tag (`<\code>`-style).
+     * Used to strip trailing whitespace inside elements without removing
+     * meaningful inter-word spaces. The capture group preserves the close
+     * tag itself.
+     */
+    private val SPACE_BEFORE_CLOSE_TAG: Regex = Regex("\\s+(</[A-Za-z][^>]*>)")
+
+    /** Matches whitespace between two adjacent tags (`>\n<`-style). */
+    private val SPACE_BETWEEN_TAGS: Regex = Regex(">\\s+<")
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/MarkdownNativeSwitch.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/MarkdownNativeSwitch.kt
@@ -1,0 +1,226 @@
+package me.rerere.rikkahub.ui.components.richtext.nativebridge
+
+import android.os.Looper
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
+
+/**
+ * Phase 2 switch in front of [MarkdownParserNative]. Two independent stages:
+ *
+ * - `html`: native `pulldown-cmark` HTML emit replaces the JetBrains
+ *   `HtmlGenerator` path in `MarkdownNew.kt`.
+ * - `ast`: native packed binary AST replaces the JetBrains tree builder feed
+ *   into the Compose markdown renderer in `Markdown.kt`.
+ *
+ * The two stages are gated independently because the AST path requires the
+ * Markdown.kt migration to converge first (see SPIKE_PLAN §8.3 — markdown AST
+ * is intentionally last). Default for both is disabled.
+ */
+object MarkdownNativeSwitch {
+
+    private const val TAG = "MarkdownNativeSwitch"
+    const val COMPONENT_NAME: String = "markdown"
+
+    /** HTML diff sampling enabled now that [HtmlDiffNormalizer] is in place
+     *  (Phase 3 C). The normalizer collapses whitespace / attr order /
+     *  entity-escape divergences between JetBrains `HtmlGenerator` and
+     *  pulldown-cmark so only genuine differences survive to Crashlytics. */
+    private const val HTML_DIFF_ENABLED = true
+
+    interface Config {
+        fun htmlEnabled(): Boolean
+        fun astEnabled(): Boolean
+        fun samplingRate(): Float
+        fun onLoadFailure(error: Throwable)
+        fun onNativePanic(stage: String, error: Throwable?)
+        fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String)
+    }
+
+    object DisabledConfig : Config {
+        override fun htmlEnabled(): Boolean = false
+        override fun astEnabled(): Boolean = false
+        override fun samplingRate(): Float = 0f
+        override fun onLoadFailure(error: Throwable) {}
+        override fun onNativePanic(stage: String, error: Throwable?) {}
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) {}
+    }
+
+    @Volatile
+    var config: Config = DisabledConfig
+
+    private val loadFailureReported = AtomicBoolean(false)
+    private val firstHtmlSuccessLogged = AtomicBoolean(false)
+    private val firstAstSuccessLogged = AtomicBoolean(false)
+
+    /** Cheap pre-checks exposed to callers so they can skip allocating a
+     *  jvmFallback lambda + state on the hot streaming path when native is
+     *  disabled. Parity with `RegexNativeSwitch.isEnabled()`. */
+    fun isHtmlEnabled(): Boolean = config.htmlEnabled()
+
+    fun isAstEnabled(): Boolean = config.astEnabled()
+
+    /** Sample rate (0..1) exposed for the shadow-compare path in Markdown.kt
+     *  so it can gate the JNI + decode cost on a per-call dice roll rather
+     *  than running on every streaming tick (review Step 5 P1-1). */
+    fun sampleRate(): Float = config.samplingRate().coerceIn(0f, 1f)
+
+    /** Caller-facing panic hook for cases where the bridge returned a blob
+     *  but `PackedAstReader` rejected the header / version (review Step 5
+     *  P3-1). Routes through the same Crashlytics pipeline as bridge-level
+     *  panics so the failure mode is observable. */
+    fun reportAstBlobRejected() {
+        config.onNativePanic("ast", null)
+    }
+
+    /**
+     * Native markdown → HTML. Returns `null` when disabled / native unavailable
+     * / native errored — callers MUST fall back to the JetBrains HtmlGenerator
+     * path. [jvmFallback] is invoked only inside the sampling path.
+     *
+     * Diff sampling for the HTML stage is wired through [HtmlDiffNormalizer]
+     * which canonicalises whitespace, attribute order, entity escape style,
+     * and self-closing-tag style — so only genuine semantic differences reach
+     * Crashlytics. Set `samplingRate > 0` to start collecting divergence data.
+     * [HTML_DIFF_ENABLED] gates the entire compare path as a one-flip
+     * kill-switch in case the normalizer itself needs to be backed out.
+     */
+    fun renderHtmlOrNull(text: String, jvmFallback: () -> String): String? {
+        val cfg = config
+        if (!cfg.htmlEnabled()) return null
+        if (!checkAvailability(cfg)) return null
+        val nativeHtml = try {
+            MarkdownParserNative.renderHtml(text)
+        } catch (t: Throwable) {
+            Log.w(TAG, "native renderHtml threw — falling back to JVM", t)
+            cfg.onNativePanic("html", t)
+            return null
+        }
+        if (nativeHtml == null) {
+            cfg.onNativePanic("html", null)
+            return null
+        }
+        if (firstHtmlSuccessLogged.compareAndSet(false, true)) {
+            Log.i(TAG, "native markdown html ok (first success): len=${nativeHtml.length}")
+        }
+        sampleAndCompareStrings(cfg, "html", nativeHtml, jvmFallback)
+        return nativeHtml
+    }
+
+    /**
+     * Native markdown → packed AST. Returns `null` when disabled / native
+     * unavailable. Diff-sampling is intentionally not wired here because there
+     * is no symmetric JVM packed-AST output to compare against — callers
+     * compare semantically (node count / type sequence) via [reportAstDiff]
+     * by constructing summaries themselves.
+     */
+    fun parseAstOrNull(text: String): ByteArray? {
+        val cfg = config
+        if (!cfg.astEnabled()) return null
+        if (!checkAvailability(cfg)) return null
+        val blob = try {
+            MarkdownParserNative.parse(text)
+        } catch (t: Throwable) {
+            Log.w(TAG, "native parseAst threw — falling back to JVM", t)
+            cfg.onNativePanic("ast", t)
+            return null
+        }
+        if (blob == null) {
+            // Bridge returned null for "available but errored mid-flight"
+            // (e.g. Rust returned an empty blob after a caught panic). Mirror
+            // the symmetric branch in the other Switches so the AST stage
+            // doesn't go silently un-instrumented (review P1-2).
+            cfg.onNativePanic("ast", null)
+            return null
+        }
+        if (firstAstSuccessLogged.compareAndSet(false, true)) {
+            Log.i(TAG, "native markdown ast ok (first success): bytes=${blob.size}")
+        }
+        return blob
+    }
+
+    /**
+     * Public hook so callers that perform their own AST-equivalence checks can
+     * route diff reports through the same Crashlytics pipeline.
+     *
+     * **Sample-rate gate runs inside this method** — callers do NOT need to
+     * wrap calls in a sampling check. The caller IS responsible for the
+     * semantic comparison itself; this method only decides whether to forward
+     * the result to telemetry.
+     *
+     * **Divergences are reported unconditionally**, regardless of sample rate
+     * (round-2 review R2-P1-1) — if the caller went to the trouble of doing
+     * the compare and found a mismatch, that's exactly the signal we cannot
+     * afford to drop. Matches are forwarded only when `samplingRate > 0`
+     * (and at that frequency) so the dashboard can confirm sampling is live.
+     */
+    fun reportAstDiff(equal: Boolean, jvmSummary: String, nativeSummary: String) {
+        val cfg = config
+        if (!equal) {
+            cfg.onDiff("ast", false, jvmSummary, nativeSummary)
+            return
+        }
+        val rate = cfg.samplingRate()
+        if (rate > 0f && Random.nextFloat() < rate) {
+            cfg.onDiff("ast", true, jvmSummary, nativeSummary)
+        }
+    }
+
+    /** Returns true if native is loaded; reports the load failure once otherwise. */
+    private fun checkAvailability(cfg: Config): Boolean {
+        if (MarkdownParserNative.available) return true
+        if (loadFailureReported.compareAndSet(false, true)) {
+            MarkdownParserNative.lastLoadError()?.let { cfg.onLoadFailure(it) }
+        }
+        return false
+    }
+
+    private inline fun sampleAndCompareStrings(
+        cfg: Config,
+        stage: String,
+        nativeOutput: String,
+        jvmFallback: () -> String,
+    ) {
+        // Don't sample on the composition thread — Jsoup normalize + the
+        // jvmFallback (re-runs JetBrains HtmlGenerator) can block the UI
+        // on initial composition. Background sampling still covers the
+        // hot path because streaming chunks render under
+        // `Dispatchers.Default` (Codex review P2-3).
+        if (Looper.myLooper() == Looper.getMainLooper()) return
+        // One-flip kill switch for the HTML compare path (HtmlDiffNormalizer
+        // is now in place; flag is `true` by default). If the normalizer
+        // itself starts producing false positives at rollout time, flip the
+        // const back to `false` and ship a hotfix without touching the
+        // sampling logic.
+        if (stage == "html" && !HTML_DIFF_ENABLED) return
+        val rate = cfg.samplingRate()
+        // Combined form matches the other 3 Switches (final-sweep R2 P3-a).
+        if (rate <= 0f || Random.nextFloat() >= rate) return
+        val jvmOutput = try {
+            jvmFallback()
+        } catch (t: Throwable) {
+            Log.w(TAG, "diff-sampling JVM fallback threw; skipping diff", t)
+            return
+        }
+        // For the HTML stage, canonicalise both sides before comparison so
+        // cosmetic differences (whitespace, attr order, entity escape) don't
+        // explode into Crashlytics noise. For other stages the raw equality
+        // check is right.
+        val (jvmCmp, nativeCmp) = if (stage == "html") {
+            HtmlDiffNormalizer.normalize(jvmOutput) to HtmlDiffNormalizer.normalize(nativeOutput)
+        } else {
+            jvmOutput to nativeOutput
+        }
+        cfg.onDiff(
+            stage = stage,
+            equal = jvmCmp == nativeCmp,
+            jvmSummary = summarize(jvmOutput),
+            nativeSummary = summarize(nativeOutput),
+        )
+    }
+
+    private fun summarize(s: String): String {
+        val head = if (s.length <= 256) s else s.substring(0, 256) + "...(+${s.length - 256})"
+        return "len=${s.length} head=$head"
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/MarkdownParserNative.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/MarkdownParserNative.kt
@@ -9,8 +9,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Returns a packed binary AST blob (see SPIKE_PLAN §4.2 for wire format).
  * Decode via [PackedAstReader].
  *
- * Spike-phase: NOT wired into [me.rerere.rikkahub.ui.components.richtext.Markdown]
- * — benchmarks/tests call directly.
+ * Phase 1 (PR #9) shipped this bridge without production wiring — benchmarks
+ * called it directly. Phase 2 Step 4 wires the HTML emit path through the
+ * sibling [MarkdownNativeSwitch] (called from `MarkdownNew.kt`'s
+ * `generateMarkdownHtml`). Phase 2 Step 5 will wire the packed-AST path
+ * through the same Switch when the JetBrains-tree-builder caller in
+ * `Markdown.kt` is ready to consume the binary format.
  */
 internal object MarkdownParserNative {
 
@@ -25,6 +29,9 @@ internal object MarkdownParserNative {
             ensureLoaded()
             return loaded.get()
         }
+
+    /** See [me.rerere.document.nativebridge.OfficeParserNative.lastLoadError]. */
+    internal fun lastLoadError(): Throwable? = loadError
 
     private fun ensureLoaded() {
         if (loaded.get() || loadError != null) return

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -8,4 +8,14 @@
     <key>silicon_cloud_free_models</key>
     <value>Qwen/Qwen3-8B,THUDM/GLM-4.1V-9B-Thinking</value>
   </entry>
+  <!--
+    Phase 2 Rust JNI kill switch (SPIKE_PLAN §8.3). When `true`, all native
+    paths are forced off regardless of per-user prefs; lets us yank the
+    feature without a binary rollback. Defaults to false; flip remotely if a
+    production incident is traced to native code.
+  -->
+  <entry>
+    <key>native_path_kill_switch</key>
+    <value>false</value>
+  </entry>
 </defaults>

--- a/app/src/test/java/me/rerere/rikkahub/data/model/ReplaceRegexesPreflightTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/model/ReplaceRegexesPreflightTest.kt
@@ -1,0 +1,162 @@
+package me.rerere.rikkahub.data.model
+
+import me.rerere.rikkahub.data.model.AssistantAffectScope.USER
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.uuid.Uuid
+
+/**
+ * Pins the regex JVM-only-syntax preflight that gates whether
+ * `String.replaceRegexes` routes through `RegexNativeSwitch`. False
+ * negatives here silently corrupt output (Rust skips the rule, the
+ * fallback never fires) — pin every shape we know about so a future
+ * regex tweak can't drop coverage without the test going red.
+ *
+ * Hits the package-private `containsJvmOnlyRegexSyntax` via the
+ * exported extension function indirectly — the test asserts behavior
+ * by inspecting only its OBSERVABLE effect via flag-toggle paths. But
+ * since the preflight is also useful to keep tightly pinned for
+ * future modifications, we duplicate the call here using the same
+ * regex strings. (Source-of-truth lives in Assistant.kt.)
+ */
+class ReplaceRegexesPreflightTest {
+
+    // Re-declare the two regexes used internally so we can assert on
+    // them. Sync these with `JVM_ONLY_PATTERN_SYNTAX` /
+    // `JVM_ONLY_REPLACEMENT_SYNTAX` in Assistant.kt.
+    private val patternDetector = Regex(
+        """\(\?<[=!]|\(\?[=!]|\(\?>|\\[1-9]|[?*+]\+"""
+    )
+    private val replacementDetector = Regex("""\\\$|\$<""")
+
+    private fun rule(find: String, replace: String = "") =
+        AssistantRegex(
+            id = Uuid.random(),
+            name = "",
+            enabled = true,
+            findRegex = find,
+            replaceString = replace,
+            affectingScope = setOf(USER),
+        )
+
+    private fun preflightWouldFlag(rules: List<AssistantRegex>): Boolean =
+        rules.any { r ->
+            patternDetector.containsMatchIn(r.findRegex) ||
+                replacementDetector.containsMatchIn(r.replaceString)
+        }
+
+    // ──────────────────────────────────────────────────────────────
+    // Patterns that MUST be flagged as JVM-only
+    // ──────────────────────────────────────────────────────────────
+
+    @Test fun lookbehind_positive_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""(?<=foo)bar"""))))
+    }
+
+    @Test fun lookbehind_negative_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""(?<!foo)bar"""))))
+    }
+
+    @Test fun lookahead_positive_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""foo(?=bar)"""))))
+    }
+
+    @Test fun lookahead_negative_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""foo(?!bar)"""))))
+    }
+
+    @Test fun atomic_group_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""(?>foo|bar)baz"""))))
+    }
+
+    @Test fun backref_in_pattern_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""(\w+)\s+\1"""))))
+    }
+
+    @Test fun possessive_star_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""a*+b"""))))
+    }
+
+    @Test fun possessive_plus_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""a++b"""))))
+    }
+
+    @Test fun possessive_optional_is_flagged() {
+        assertTrue(preflightWouldFlag(listOf(rule("""a?+b"""))))
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Replacement strings that MUST be flagged
+    // ──────────────────────────────────────────────────────────────
+
+    @Test fun literal_dollar_in_replacement_is_flagged() {
+        // Kotlin source `\$` at runtime is `\$` (2 chars). In Java replace
+        // semantics, `\$` outputs a literal `$`. Rust replace uses `$$`
+        // for literal $, so behavior differs.
+        assertTrue(preflightWouldFlag(listOf(rule("""x""", """\$"""))))
+    }
+
+    @Test fun java_named_group_replacement_is_flagged() {
+        // Java replacement `$<name>` references a named capture; Rust
+        // uses `${name}` or `$name`.
+        assertTrue(preflightWouldFlag(listOf(rule("""x""", """$<grp>"""))))
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Patterns/replacements that MUST NOT be flagged (safe to native)
+    // ──────────────────────────────────────────────────────────────
+
+    @Test fun plain_pattern_is_not_flagged() {
+        assertFalse(preflightWouldFlag(listOf(rule("""hello\s+world"""))))
+    }
+
+    @Test fun simple_quantifiers_not_flagged() {
+        assertFalse(preflightWouldFlag(listOf(rule("""a*b+c?"""))))
+    }
+
+    @Test fun named_capture_definition_not_flagged() {
+        // Both engines support `(?<name>...)` as named capture *definition*
+        // — only `(?<=` / `(?<!` (lookbehind) are JVM-only.
+        assertFalse(preflightWouldFlag(listOf(rule("""(?<word>\w+)"""))))
+    }
+
+    @Test fun dollar_followed_by_digit_not_flagged() {
+        // `$1` is standard backref in both Java AND Rust replacement.
+        assertFalse(preflightWouldFlag(listOf(rule("""(\w+)""", """$1"""))))
+    }
+
+    @Test fun curly_named_group_replacement_not_flagged() {
+        // `${name}` is portable Java + Rust syntax (Rust accepts both
+        // `${name}` and `$name`).
+        assertFalse(preflightWouldFlag(listOf(rule("""(?<word>\w+)""", """${'$'}{word}"""))))
+    }
+
+    @Test fun mixed_safe_batch_not_flagged() {
+        assertFalse(
+            preflightWouldFlag(
+                listOf(
+                    rule("""\bhello\b""", "hi"),
+                    rule("""(\d+)""", """$1!"""),
+                    rule("""^prefix:\s+"""),
+                )
+            )
+        )
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // One-bad-apple semantics: any single JVM-only rule trips the batch
+    // ──────────────────────────────────────────────────────────────
+
+    @Test fun mixed_batch_with_one_lookbehind_is_flagged() {
+        assertTrue(
+            preflightWouldFlag(
+                listOf(
+                    rule("""\bhello\b""", "hi"),
+                    rule("""(?<=at )now"""),       // ← lookbehind
+                    rule("""(\d+)""", """$1!"""),
+                )
+            )
+        )
+    }
+}

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/HtmlDiffNormalizerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/nativebridge/HtmlDiffNormalizerTest.kt
@@ -1,0 +1,154 @@
+package me.rerere.rikkahub.ui.components.richtext.nativebridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HtmlDiffNormalizerTest {
+
+    private fun norm(html: String): String = HtmlDiffNormalizer.normalize(html)
+
+    @Test
+    fun `identical input yields identical output`() {
+        val a = "<p>hello <em>world</em></p>"
+        assertEquals(norm(a), norm(a))
+    }
+
+    @Test
+    fun `attr order does not matter`() {
+        val a = norm("<a href=\"/x\" class=\"link\">x</a>")
+        val b = norm("<a class=\"link\" href=\"/x\">x</a>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `whitespace runs collapse`() {
+        val a = norm("<p>hello     world</p>")
+        val b = norm("<p>hello world</p>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `leading and trailing whitespace stripped`() {
+        val a = norm("   <p>x</p>   ")
+        val b = norm("<p>x</p>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `self-closing style normalised by jsoup html5`() {
+        // pulldown-cmark emits <br /> (XHTML-style); JetBrains may emit <br>.
+        // Jsoup HTML5-canonicalises both to the same void-element form.
+        val a = norm("<p>line1<br />line2</p>")
+        val b = norm("<p>line1<br>line2</p>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `genuine content difference survives normalisation`() {
+        // Different text → must NOT be equalised.
+        val a = norm("<p>hello</p>")
+        val b = norm("<p>goodbye</p>")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `missing wrapper element survives normalisation`() {
+        // One side wraps in <em>, the other doesn't — real semantic
+        // difference, must survive.
+        val a = norm("<p>hello <em>world</em></p>")
+        val b = norm("<p>hello world</p>")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `extra block survives normalisation`() {
+        val a = norm("<p>x</p><p>y</p>")
+        val b = norm("<p>x</p>")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `cjk content preserved`() {
+        val a = norm("<p>你好 世界 🌍</p>")
+        val b = norm("<p>你好 世界 🌍</p>")
+        assertEquals(a, b)
+        // And content actually present:
+        assertTrue("CJK should survive: $a", a.contains("你好"))
+        assertTrue("Emoji should survive: $a", a.contains("🌍"))
+    }
+
+    @Test
+    fun `malformed input does not crash`() {
+        // Jsoup is forgiving — almost nothing makes it throw, so this also
+        // verifies the fallback path doesn't crash even on weird input.
+        // Just running norm() without exception is the assertion.
+        val weird = "<<<><></><>"
+        norm(weird)
+    }
+
+    @Test
+    fun `nested attribute sorting recursive`() {
+        val a = norm("<div class=\"outer\" id=\"a\"><span data-x=\"1\" data-a=\"2\">t</span></div>")
+        val b = norm("<div id=\"a\" class=\"outer\"><span data-a=\"2\" data-x=\"1\">t</span></div>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `entity escape mode standardised`() {
+        // Both inputs should normalize to the same entity-encoded form.
+        val a = norm("<p>A &amp; B</p>")
+        val b = norm("<p>A &amp; B</p>")
+        assertEquals(a, b)
+        assertTrue("entity should be present: $a", a.contains("&amp;"))
+    }
+
+    @Test
+    fun `empty input handled`() {
+        assertEquals("", norm(""))
+        assertEquals("", norm("   "))
+    }
+
+    @Test
+    fun `code block trailing newline equalised`() {
+        // pulldown-cmark emits a trailing \n inside <code> for fenced blocks;
+        // JetBrains does not. Our \s+ collapse equalises them — verify
+        // explicitly so regression doesn't unequalise this corner.
+        val a = norm("<pre><code class=\"language-rust\">let x = 1;\n</code></pre>")
+        val b = norm("<pre><code class=\"language-rust\">let x = 1;</code></pre>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `gfm table row newlines equalised`() {
+        // Real-world divergence: one engine adds \n after </tr>, other doesn't.
+        val a = norm("<table><tr><td>a</td></tr>\n<tr><td>b</td></tr>\n</table>")
+        val b = norm("<table><tr><td>a</td></tr><tr><td>b</td></tr></table>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `task list checkbox attr order normalised`() {
+        // GFM task list: <input checked=\"\" disabled=\"\" type=\"checkbox\">
+        // pulldown-cmark vs JetBrains historically differ on the order/
+        // presence of `disabled`. attr sort handles the order.
+        val a = norm("<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> done</li>")
+        val b = norm("<li><input type=\"checkbox\" checked=\"\" disabled=\"\"> done</li>")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `oversize input short-circuits to identity`() {
+        // Inputs over 64 KiB should skip Jsoup parse entirely (perf cap).
+        // Verify by ensuring an oversize, valid HTML string is returned
+        // unchanged — not normalised.
+        val big = "<p>" + "x".repeat(70 * 1024) + "</p>"
+        assertEquals(big, norm(big))
+        // And confirm a small variant with REVERSED attr order DOES get
+        // normalised (sort runs, output differs from input) so we don't pass
+        // the size-cap test by coincidence.
+        val small = "<p id=\"b\" class=\"a\">x</p>"
+        assertNotEquals(small, norm(small))
+    }
+}

--- a/docs/RUST_NATIVE_SPIKE_PLAN.md
+++ b/docs/RUST_NATIVE_SPIKE_PLAN.md
@@ -470,28 +470,38 @@ Phase 1 关心**代码与架构正确性**：JNI 安全、fallback 完整、wire
 - ⏳ CI job 显式断言 cargo-ndk 真产出了 `.so`（防止当前 `onlyIf` 守卫让 CI "绿但没打 .so"，Codex Round 3 follow-up）
 - ⏳ SPIKE_REPORT.md：决策会用
 
-### 8.3 ⛔ Phase 2 **HARD GATE** — 接入生产前必须满足
+### 8.3 ⚠ 历史"HARD GATE" — personal-use 项目降级为"insurance"
 
-**只要任一 production caller 切到 native 路径（即 `DocxParser.kt` /
+> **状态变更（2026-05-21，Phase 2/3 合 main 前夕）**：
+> 本节最初的 6 条 HARD GATE 是按 enterprise rollout 起的草——但 rikkahub 是
+> 单用户项目，"5% → 25% → 100% 灰度 + Crashlytics dashboard 监控"
+> 这套流程没有承接的人和承接的指标。所以执行版降级如下：
+> - ❌ `默认 JVM` / `灰度启用 5%→25%→100%` — **不要求**。用户单一，
+>   `NativePathPrefs` 4 个 user-facing flag default **`true`**（Rust 默认开）
+> - ✅ `Feature flag / kill switch` — **保留**。`NATIVE_PATH_*` per-key
+>   + RC `native_path_kill_switch` 全局 → 出问题能 RC console 一键关，
+>   或 user-level 写 DataStore opt-out
+> - ✅ `Crashlytics 接入` — **保留**，零额外维护成本，出事能查
+> - ✅ `JVM vs Rust diff sampling` — **保留**但默认 `sampleRate=0`，
+>   想抓数据时调高，平时不烧 Crashlytics quota
+> - ✅ `Revert plan via merge commit` — **保留**。合 main 必须 merge
+>   commit，单步 `git revert <merge>` 可回滚整个 Phase 2/3
+
+下面是历史原文，标作 deprecated 留作以后多用户化场景的参考：
+
+~~**只要任一 production caller 切到 native 路径（即 `DocxParser.kt` /
 `MarkdownNew.kt` / `Highlighter.kt` / `replaceRegexes` 在调 `nativebridge.*Native`
-而不是当前的 JVM 实现），必须在合 PR **之前** 满足以下所有条件**：
+而不是当前的 JVM 实现），必须在合 PR 之前满足以下所有条件**：~~
 
-1. **Feature flag / kill switch**：BuildConfig 或运行时 setting（如
-   `agentRuntime.useNativeRust = false` 默认 false），可由用户 / 远端配置 /
-   实验 framework 单向切回 JVM 而不需要发新版
-2. **默认走 JVM**：feature flag 默认值是 `false` / "jvm"，灰度时 opt-in
-3. **灰度启用**：按 device cohort / user id hash / build variant 分批
-   启用（先 Notion variant → Debug variant → 5% 用户 → 25% → 100%）
-4. **Crashlytics 接入**：native panic / load failure / output divergence
-   单独 tag，dashboard 可分流监控
-5. **观测**：JVM vs Rust 输出 diff 在生产用 sampling 抓回来做事后分析
-6. **Revert plan**：合 main 走 merge commit；接入生产的 PR 也走 merge commit。
-   任何 incident 都可以 `git revert <merge>` 单步回滚（合并方式正是为此选 merge）
+1. ~~**Feature flag / kill switch**：BuildConfig 或运行时 setting~~ → 仍要求
+2. ~~**默认走 JVM**~~ → **personal-use 不要求**
+3. ~~**灰度启用**（先 Notion variant → Debug variant → 5% 用户 → 25% → 100%）~~ → **personal-use 不要求**
+4. ~~**Crashlytics 接入**~~ → 仍要求
+5. ~~**观测**：JVM vs Rust 输出 diff sampling~~ → 仍要求，但默认 0%
+6. ~~**Revert plan**~~ → 仍要求
 
-**不达标的部分**：单独 abandon 该组件，不影响其他组件。Phase 2 acceptance
-不过的话 **spike 也不会自动落地到生产**——本 spike 合 main 的 PR
-保持 zero-侵入（`DocxParser.kt` 等 0 行改动），所有 Kotlin adapter 写法都
-lazy load + fallback to JVM，即使 `.so` 缺失也不崩。
+**仍然不可让步的**：fallback 设计。所有 Kotlin adapter `lazy load + fallback to
+JVM`，即使 `.so` 缺失或 panic 也不崩；这是 personal-use 默认开的前提条件。
 
 ### 8.4 本次合 main PR 的边界
 
@@ -513,19 +523,85 @@ lazy load + fallback to JVM，即使 `.so` 缺失也不崩。
 
 ---
 
-## 9. Phase 2（不在本 spike 范围内）
+## 9. Phase 2（结构 + 5 个 caller switch）— **完成于 branch**
 
-下面这些是 spike 通过后才考虑的，**当前不做**：
+> Status: 2026-05-21，`phase2/rust-native-production-switch`，**未合 main**。
+> +349/-32 行，6 模块改 + 6 新文件，6 轮 sub-agent review 收敛到 0 P3+。
+> 默认全 JVM（5 flag false + sampleRate 0 + kill switch false），用户 0 行为变化。
 
-- 接入生产渲染层（Markdown.kt 用 Rust parser 替换 JetBrains 调用）
-- BuildConfig feature flag A/B 切流量
-- Crashlytics / 性能监控接入
-- 多架构 .so 体积优化（strip debug symbols / `panic_immediate_abort` / `lto = "fat"`）
-- 在 Codex 主 worktree 同步分支
+实做项（personal-use 版 §8.3 — 4 条 insurance 全保留 + 2 条 enterprise-only 撤销）：
+
+- ✅ Feature flag / kill switch — `NativePathPrefs` 5 个 boolean + RC `native_path_kill_switch`
+- ✅ **默认 Rust 全开**（personal-use 决定）— `NativePathPrefsData` 4 个 user-facing flag default `true`；DataStore key 缺失时 `readFrom` 也 fallback 到 `true`。`markdownAst` 留 `false` 因为它是 shadow-only 没用户价值
+- ✅ Crashlytics — `NativePathFailure` / `NativePathDivergence` 子类（race-free，per-event payload 走 message 不走全局 custom key）
+- ✅ Diff sampling — 每 Switch 内置 sample rate 门控
+- ✅ Revert plan — merge commit 模式合 main 即可单步 `git revert <merge>`
+
+5 个 caller switch：
+
+| Step | 文件 | switch 后行为 |
+|---|---|---|
+| 1 office | DocumentAsPromptTransformer + WorkspaceArtifactTools | `OfficeNativeSwitch.parseXOrNull(file) { jvm } ?: jvm` |
+| 2 highlight | Highlighter.kt — 原 body 抽到 `highlightJvm()` | concurrency profile change：JVM 单线程 executor，native parallel |
+| 3 regex | Assistant.kt `String.replaceRegexes` + 私有 `applyRegexesJvm` | `isEnabled()` gate 防热路径 lambda alloc |
+| 4 markdown HTML | MarkdownNew.kt `generateMarkdownHtml` + 私有 `generateMarkdownHtmlJvm` | HTML diff sampling **硬关**（`HTML_DIFF_ENABLED=false`） |
+| 5 markdown AST | Markdown.kt `parsePreprocessedMarkdownUncached` + `maybeShadowCompareNativeAst` | **shadow-compare only**：renderer 仍吃 JVM tree |
+
+⚠ Step 5 故意不切 renderer：Markdown.kt 还在 migration（10+ commits/月），切 renderer 会爆 conflict。Phase 2 只装 telemetry，真正 renderer 切换留给 Phase 3-B。
+
+## 10. Phase 3（用户感受加速 + 工程债收尾）— 待开
+
+Phase 2 让 native 路径**能跑**但默认不跑。Phase 3 干两件事：(1) **真的让用户感受到加速** —— 灰度开 flag + Markdown.kt renderer 真正消费 packed AST；(2) **还工程债** —— xlsx Rust 化、抽 jni-common、HTML normalizer。
+
+### A. 灰度开 flag（运营层，无代码）
+
+**前置条件**：§10-C 的 HTML normalizer 必须先 ship 并把 `HTML_DIFF_ENABLED` 翻为 true；否则 markdownHtml flag 任何灰度都没有 divergence 数据可看。office / highlight / regex / markdownAst 不受此约束，可独立灰度。
+
+1. Dogfood 1+ 周：开发机 5 flag 全 true，sampleRate=0.05，每天看 Crashlytics 是否有 `NativePathFailure` / `NativePathDivergence`
+2. Notion variant 5-10 人内测，48h+ 无新 issue
+3. RC ramp 5% → 25% → 100%，每档 48h+
+4. 配套：markdownHtml 灰度到 ≥25% 且 48h 无 divergence 后启动 `CharReveal.kt:BALANCED` 从 80ms 继续下探的实验（D-3 收集数据）
+
+### B. Markdown.kt renderer 切到 packed AST
+
+**前提**：Markdown.kt streaming-render migration 收敛 ≥ 2 周（最近一次相关 commit 时间 + 14d 才能动）。
+
+- ~1700 行 Markdown.kt 里所有 `ASTNode.children.find { type == X }` 走查 → 改为 `PackedAstNode` walker
+- 写 JVM `IElementType` ↔ Rust `NodeType` 全量映射表（30+ 节点 + extras 字段：链接 url / image alt / code lang / table column alignments）
+- 删 JetBrains markdown artifact（Gradle 依赖 `libs.markdown` → `com.github.JetBrains:markdown`；包 `org.intellij.markdown.*`），APK 估省 ~1MiB
+- **跑全套测试**——任何 `test/` 文件 `import org.intellij.markdown.*` 都要先迁移或删除
+
+### C. HTML 等价归一化器 + 翻 `HTML_DIFF_ENABLED`
+
+JetBrains HtmlGenerator 与 pulldown-cmark 在 whitespace / attr 顺序 / entity 转义上不等价 → 直接 `==` 比较会产生大量假阳性 → Phase 2 把 `HTML_DIFF_ENABLED` 硬关了。
+
+Phase 3-C 写一个 `normalizeHtml(s: String): String`（Jsoup 解析 + canonical 序列化 + entity 归一 + 自闭合标签统一），两边 normalize 后再比较，然后翻 `HTML_DIFF_ENABLED=true`。这是开 markdownHtml 灰度的前置数据条件。
+
+### D. 工程债收尾
+
+| 编号 | 项 | 工作量 |
+|---|---|---|
+| D-1 | **xlsx via `calamine`（新格式，无 JVM baseline）**：在 office-parsers crate 加 `parseXlsxNative` + Switch 扩展 `parseXlsxOrNull` + WorkspaceArtifactTools `xlsx` 分支切走 Rust。无既有 JVM `XlsxParser`——这是新功能，**没有 byte-equivalence diff**，靠 corpus + 输出 schema 单元测试验证 | 大 |
+| D-2 | 抽 `native/jni-common/` Rust crate：LEB128 + panic_to_string + init_logger_once 4 crate 共享 | 中 |
+| D-3 | CharReveal `BALANCED` baseRevealDurationMs 调优实验数据：当前已下调至 80ms，markdownHtml 灰度到 ≥25% 且 48h 无 divergence 后启动下探到 50ms 的灰度数据收集 | 小 |
+| D-4 | Macrobenchmark + APK size baseline（§8.2 acceptance gate）。**Phase 3 退出门槛**：arm64-v8a APK size 增量 ≤ +5 MiB（Phase 1 baseline +3.95 MiB，给 D-1 xlsx 留 +1 MiB 头寸） | 大，需真机 |
+| D-5 | Phase 2 PR 拆 6 个 commit（infra + 5 step）便于独立 review | 中，git 操作 |
+| D-6 | 删 JetBrains markdown 依赖（依赖 B 完成）| 小 |
+| D-7 | **Per-component kill switch**：当前只有一个 `native_path_kill_switch`，触发即全停。Phase 3 加 5 个 `native_kill_*` per-component RC key；保留全局 kill switch 作为最高优先级 OR-门 | 小 |
+
+### Phase 3 退出条件
+
+- 5 个 native flag 在生产 100% 开启完成 **1 个完整 release cycle 且未触发 kill switch**（任意 per-component 或全局）
+- markdownAst 不仅 shadow compare，且 renderer 真正消费 packed AST，`org.intellij.markdown` 依赖移除
+- xlsx 走 Rust 路径——所有 `WorkspaceArtifactTools` 的 office 入口（docx/pptx/epub/xlsx）行为一致经过 Switch
+- jni-common 抽完，4 crate 0 重复（grep `LEB128` / `panic_to_string` / `init_logger_once` 在 office/markdown/highlight/regex 各 crate 应为 0 命中）
+- `HTML_DIFF_ENABLED=true` 在生产开启后 ≥ 48h 连续采样，divergence 报告稳定 < 0.1%
+- arm64-v8a APK size 增量 ≤ +5 MiB（vs Phase 0 baseline `595e8414`）。若 D-1 xlsx 实测占用 >+1 MiB，重审阈值（Phase 1 占 +3.95 MiB，给 D-1 留 +1 MiB 头寸；超出说明 calamine 比预期大，需要评估缩减策略或抬阈值）
+- SPIKE_REPORT.md 输出，与 §8.2 acceptance gate 全部对齐
 
 ---
 
-## 10. 状态跟踪
+## 11. 状态跟踪
 
 ### Phase 1 (结构性 spike) — 完成（含扩张）
 
@@ -549,14 +625,31 @@ lazy load + fallback to JVM，即使 `.so` 缺失也不崩。
 | 13. 跨组件全面 review | ✅ V1 + V2 都过 |
 | 14. `cargo test --workspace` 全 pass | ✅ | 55/55（office 26 + markdown 16 + highlight 6 + regex 7）|
 
-### Phase 2 (acceptance gate) — 待开
+### Phase 2 (basic infra + 5 caller switches) — 完成于 branch（未合 main）
 
 | 节点 | 状态 | 备注 |
 |---|---|---|
-| A. corpus（每组件 5-10 真实样本） | ⏳ pending | |
-| B. JVM/Rust 等价性 diff harness | ⏳ pending | 跑 corpus 比对输出 |
-| C. benchmark harness（真机测速）| ⏳ pending | 验证 §3.3/§4.4/§5.4 阈值 |
-| D. 3-variant Android assemble 验证 | ⏳ pending | Debug/Notion/Refactortest |
-| E. APK size 增量量化 | ⏳ pending | arm64-v8a 真实数据 |
-| F. SPIKE_REPORT.md | ⏳ pending | 决策会输出 |
-| G. 接入生产渲染层（feature flag）| ⏳ pending | 仅在 Phase 2 数据达标后 |
+| Step 0 pre-flight (NativePathBootstrap + Prefs + Crashlytics + CI .so 校验) | ✅ | 6 轮 review，0 P3+ |
+| Step 1 office caller switch | ✅ | DocumentAsPromptTransformer + WorkspaceArtifactTools，2 轮 review |
+| Step 2 highlight caller switch | ✅ | Highlighter.kt 重构，2 轮 review |
+| Step 3 regex caller switch | ✅ | Assistant.kt `replaceRegexes`，2 轮 review |
+| Step 4 markdown HTML caller switch | ✅ | MarkdownNew.kt，HTML diff sampling 硬关，2 轮 review |
+| Step 5 markdown AST shadow compare | ✅ | Markdown.kt 加 `maybeShadowCompareNativeAst`，renderer 仍吃 JVM，2 轮 review |
+| Final cross-component sweep | ✅ | 3 轮 review，收敛到 0 P0/P1/P2/P3 |
+| 合 main + 推 remote | ⏳ pending | 需要先真机 dogfood |
+
+### Phase 3 (用户感受加速 + 工程债) — 进行中
+
+| 节点 | 状态 | 备注 |
+|---|---|---|
+| A. 灰度开 flag（dogfood → 5%→25%→100%） | ⏳ pending | 运营层，无代码；markdownHtml 依赖 C — 现可启动（C 已完成） |
+| B. Markdown.kt renderer 切到 packed AST | ⏳ blocked | 等 Markdown.kt streaming-render migration 收敛 ≥ 2 周 |
+| C. HTML normalizer + flip `HTML_DIFF_ENABLED` | ✅ | `HtmlDiffNormalizer.kt` (17 tests) + `HTML_DIFF_ENABLED=true`，2 轮 sub-agent review |
+| D-1 xlsx via calamine | ✅ | calamine 0.26 + Howard Hinnant date conv + 12 tests + Switch hard-gate sampling，2 轮 sub-agent review |
+| D-2 抽 native/jni-common crate | ✅ | `panic_to_string` + `init_logger_once!` macro + `write_varint` 4 crate 共享 + rust-version 1.75→1.76，2 轮 sub-agent review |
+| D-3 CharReveal BALANCED 80→50 调优 | ⏳ blocked | 依赖 A markdownHtml ≥25% 灰度 48h |
+| D-4 Macrobenchmark + APK size baseline | ⏳ pending | 需真机 |
+| D-5 Phase 2 PR 拆 6 commit | ⏳ pending | git 操作，需用户授权 |
+| D-6 删 JetBrains markdown 依赖 | ⏳ blocked | 依赖 B |
+| D-7 per-component kill switch | ⏳ pending | 5 个 `native_kill_*` RC key |
+| §11 SPIKE_REPORT.md | ⏳ pending | Phase 3 出口产物 |

--- a/document/src/main/java/me/rerere/document/nativebridge/OfficeNativeSwitch.kt
+++ b/document/src/main/java/me/rerere/document/nativebridge/OfficeNativeSwitch.kt
@@ -1,0 +1,189 @@
+package me.rerere.document.nativebridge
+
+import android.util.Log
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
+
+/**
+ * Phase 2 production switch in front of [OfficeParserNative].
+ *
+ * Default state is "disabled" — every entry point returns `null`, the caller
+ * keeps using the JVM parser. The `app` module configures [config] once at
+ * startup based on user prefs + Remote Config.
+ *
+ * Telemetry hooks ([Config.onLoadFailure] / [Config.onNativePanic] /
+ * [Config.onDiff]) let the app forward into Crashlytics without this module
+ * having to know about Firebase. Bridge ([OfficeParserNative]) stays `internal`.
+ */
+object OfficeNativeSwitch {
+
+    private const val TAG = "OfficeNativeSwitch"
+    const val COMPONENT_NAME: String = "office"
+
+    /**
+     * D-1: xlsx is net-new — no JVM `XlsxParser` exists, so diff sampling has
+     * no byte-equivalent baseline and would flood Crashlytics with cosmetic
+     * differences against the app-side helper. Same kill-switch shape as
+     * `MarkdownNativeSwitch.HTML_DIFF_ENABLED`. Flip to `true` only after
+     * a Java-side xlsx parser lands that can be compared against.
+     */
+    private const val XLSX_DIFF_ENABLED: Boolean = false
+
+    interface Config {
+        /** Whether to attempt the native path at all. Default returns false. */
+        fun enabled(): Boolean
+
+        /**
+         * 0.0..1.0 — when native is enabled, fraction of calls that also run the
+         * JVM path and report the comparison via [onDiff]. 0 by default
+         * (no diff sampling).
+         */
+        fun samplingRate(): Float
+
+        /** Called once when `System.loadLibrary` fails. */
+        fun onLoadFailure(error: Throwable)
+
+        /** Called when the native call throws / returns NativeUnavailable mid-flight. */
+        fun onNativePanic(stage: String, error: Throwable?)
+
+        /**
+         * Called from the sampling path with summaries of both outputs. The
+         * caller MUST keep `jvm` / `native` short — they are forwarded into
+         * the message body of `NativePathDivergence` so Crashlytics groups by
+         * component:stage and the variable payload stays inline rather than
+         * leaking into global custom keys.
+         */
+        fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String)
+    }
+
+    /** No-op fallback so unconfigured modules (tests, library consumers) stay JVM. */
+    object DisabledConfig : Config {
+        override fun enabled(): Boolean = false
+        override fun samplingRate(): Float = 0f
+        override fun onLoadFailure(error: Throwable) {}
+        override fun onNativePanic(stage: String, error: Throwable?) {}
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) {}
+    }
+
+    @Volatile
+    var config: Config = DisabledConfig
+
+    private val loadFailureReported = AtomicBoolean(false)
+    private val firstDocxSuccessLogged = AtomicBoolean(false)
+    private val firstPptxSuccessLogged = AtomicBoolean(false)
+    private val firstEpubSuccessLogged = AtomicBoolean(false)
+    private val firstXlsxSuccessLogged = AtomicBoolean(false)
+
+    private fun firstSuccessFlag(stage: String): AtomicBoolean? = when (stage) {
+        "docx" -> firstDocxSuccessLogged
+        "pptx" -> firstPptxSuccessLogged
+        "epub" -> firstEpubSuccessLogged
+        "xlsx" -> firstXlsxSuccessLogged
+        // If a future stage gets added without updating this mapper, return
+        // null so we log once with a warning rather than silently sharing the
+        // docx flag (which would double-log) — final-sweep R2 P3-b.
+        else -> null
+    }
+
+    /**
+     * Returns the native parse result, or `null` if the caller should use JVM.
+     * Always returns `null` if [Config.enabled] is false; never throws.
+     *
+     * [jvmFallback] is invoked only inside the sampling path — when sampling
+     * does not fire it is not called at all (zero overhead in steady-state).
+     */
+    fun parseDocxOrNull(file: File, jvmFallback: () -> String): String? =
+        runOneShot("docx", jvmFallback) { OfficeParserNative.parseDocx(file) }
+
+    fun parsePptxOrNull(file: File, jvmFallback: () -> String): String? =
+        runOneShot("pptx", jvmFallback) { OfficeParserNative.parsePptx(file) }
+
+    fun parseEpubOrNull(file: File, jvmFallback: () -> String): String? =
+        runOneShot("epub", jvmFallback) { OfficeParserNative.parseEpub(file) }
+
+    /**
+     * Phase 3 D-1: net-new (no JVM `XlsxParser` exists). [jvmFallback] is
+     * still required because diff-sampling needs a comparison baseline — the
+     * caller passes the existing app-side xlsx helper. When native fails,
+     * caller must fall back to the same helper via the standard Elvis
+     * pattern.
+     */
+    fun parseXlsxOrNull(file: File, jvmFallback: () -> String): String? =
+        runOneShot("xlsx", jvmFallback) { OfficeParserNative.parseXlsx(file) }
+
+    private inline fun runOneShot(
+        stage: String,
+        jvmFallback: () -> String,
+        nativeBlock: () -> OfficeParserNative.Result,
+    ): String? {
+        val cfg = config
+        if (!cfg.enabled()) return null
+        // Eagerly detect load failure once and surface to telemetry.
+        if (!OfficeParserNative.available) {
+            if (loadFailureReported.compareAndSet(false, true)) {
+                OfficeParserNative.lastLoadError()?.let { cfg.onLoadFailure(it) }
+            }
+            return null
+        }
+        val native = try {
+            nativeBlock()
+        } catch (t: Throwable) {
+            // catch_unwind on the Rust side normally prevents this, but keep a
+            // belt-and-suspenders catch in case the JNI shim itself throws.
+            Log.w(TAG, "native $stage threw — falling back to JVM", t)
+            cfg.onNativePanic(stage, t)
+            return null
+        }
+        val nativeOutput = when (native) {
+            is OfficeParserNative.Result.Success -> native.output
+            OfficeParserNative.Result.NativeUnavailable -> {
+                cfg.onNativePanic(stage, null)
+                return null
+            }
+        }
+        // One-shot success log per stage so canary devices see each parser's
+        // first native success independently (final-sweep P3-1).
+        val flag = firstSuccessFlag(stage)
+        if (flag == null) {
+            Log.w(TAG, "native $stage ok (first-success flag missing; update firstSuccessFlag mapper)")
+        } else if (flag.compareAndSet(false, true)) {
+            Log.i(TAG, "native $stage ok (first success): len=${nativeOutput.length}")
+        }
+        maybeSample(cfg, stage, nativeOutput, jvmFallback)
+        return nativeOutput
+    }
+
+    private inline fun maybeSample(
+        cfg: Config,
+        stage: String,
+        nativeOutput: String,
+        jvmFallback: () -> String,
+    ) {
+        // xlsx has no JVM byte-equivalent baseline (Phase 3 D-1).
+        if (stage == "xlsx" && !XLSX_DIFF_ENABLED) return
+        val rate = cfg.samplingRate()
+        // Combined form matches the other 3 Switches (final-sweep R2 P3-a).
+        if (rate <= 0f || Random.nextFloat() >= rate) return
+        val jvmOutput = try {
+            jvmFallback()
+        } catch (t: Throwable) {
+            Log.w(TAG, "diff-sampling JVM fallback threw; skipping diff", t)
+            return
+        }
+        val equal = jvmOutput == nativeOutput
+        cfg.onDiff(
+            stage = stage,
+            equal = equal,
+            jvmSummary = summarize(jvmOutput),
+            nativeSummary = summarize(nativeOutput),
+        )
+    }
+
+    private fun summarize(s: String): String {
+        // 256-char window + length so Crashlytics custom-key payload stays
+        // well under the 1KB per-key ceiling.
+        val head = if (s.length <= 256) s else s.substring(0, 256) + "...(+${s.length - 256})"
+        return "len=${s.length} head=$head"
+    }
+}

--- a/document/src/main/java/me/rerere/document/nativebridge/OfficeParserNative.kt
+++ b/document/src/main/java/me/rerere/document/nativebridge/OfficeParserNative.kt
@@ -15,8 +15,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *   / [me.rerere.document.PptxParser] emit. Sentinel error prefixes mirror JVM
  *   ("Error parsing DOCX file: ...", "Unable to find document content ...").
  *
- * NOT wired into [DocxParser] / [PptxParser] during Phase 1 — benchmarks call
- * the bridge directly. See `docs/RUST_NATIVE_SPIKE_PLAN.md` §3.
+ * Phase 1 (PR #9) shipped the bridge without any production caller — only
+ * benchmarks touched it. From Phase 2 Step 1 onwards callers go through the
+ * sibling [OfficeNativeSwitch] (public face that handles flag gating +
+ * Crashlytics + diff sampling) rather than calling the bridge directly.
+ * See `docs/RUST_NATIVE_SPIKE_PLAN.md` §3 / §8.
  */
 internal object OfficeParserNative {
 
@@ -31,6 +34,14 @@ internal object OfficeParserNative {
             ensureLoaded()
             return loaded.get()
         }
+
+    /**
+     * Returns the throwable from the most recent [System.loadLibrary] attempt,
+     * or `null` if the library loaded successfully (or no attempt has been made
+     * yet). Visible to the in-package [OfficeNativeSwitch] so it can report
+     * load failures to Crashlytics exactly once.
+     */
+    internal fun lastLoadError(): Throwable? = loadError
 
     private fun ensureLoaded() {
         if (loaded.get() || loadError != null) return
@@ -81,6 +92,13 @@ internal object OfficeParserNative {
         return Result.Success(output)
     }
 
+    fun parseXlsx(file: File): Result {
+        ensureLoaded()
+        if (!loaded.get()) return Result.NativeUnavailable
+        val output = parseXlsxNative(file.absolutePath) ?: return Result.NativeUnavailable
+        return Result.Success(output)
+    }
+
     @JvmStatic
     private external fun parseDocxNative(path: String): String?
 
@@ -89,4 +107,7 @@ internal object OfficeParserNative {
 
     @JvmStatic
     private external fun parseEpubNative(path: String): String?
+
+    @JvmStatic
+    private external fun parseXlsxNative(path: String): String?
 }

--- a/highlight/src/main/java/me/rerere/highlight/Highlighter.kt
+++ b/highlight/src/main/java/me/rerere/highlight/Highlighter.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.highlight.HighlightToken.Token.StringContent
+import me.rerere.highlight.nativebridge.HighlightNativeSwitch
 import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -52,7 +53,24 @@ class Highlighter(ctx: Context) {
         context.globalObject.getJSFunction("highlight")
     }
 
-    suspend fun highlight(code: String, language: String) =
+    /**
+     * Phase 2 Step 2: route through [HighlightNativeSwitch] which gates on
+     * `NativePathPrefs.highlight` (default false). When disabled or native
+     * fails, the existing QuickJS+Prism JVM path runs unchanged.
+     *
+     * The diff-sampling JVM call (`samplingRate > 0`) lives inside the
+     * Switch's lambda and uses the same [highlightJvm] entry, so a sampled
+     * run pays exactly one extra JVM execution — no double-execution in the
+     * steady-state non-sampled path.
+     */
+    suspend fun highlight(code: String, language: String): List<HighlightToken> {
+        HighlightNativeSwitch.highlightOrNull(code, language) {
+            highlightJvm(code, language)
+        }?.let { return it }
+        return highlightJvm(code, language)
+    }
+
+    private suspend fun highlightJvm(code: String, language: String): List<HighlightToken> =
         suspendCancellableCoroutine { continuation ->
             executor.submit {
                 runCatching {

--- a/highlight/src/main/java/me/rerere/highlight/nativebridge/HighlightNativeSwitch.kt
+++ b/highlight/src/main/java/me/rerere/highlight/nativebridge/HighlightNativeSwitch.kt
@@ -1,0 +1,138 @@
+package me.rerere.highlight.nativebridge
+
+import android.util.Log
+import me.rerere.highlight.HighlightToken
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.random.Random
+
+/**
+ * Phase 2 production switch in front of [HighlighterNative]. Default is
+ * disabled — every call returns `null` so the caller stays on the QuickJS+Prism
+ * JVM path. The `app` module configures [config] once at startup based on
+ * user prefs + Remote Config.
+ *
+ * Comparing token lists rather than strings is by design: token equality is
+ * what affects rendered output. Lengths and a head snippet of the joined
+ * content strings are passed to [Config.onDiff] for triage.
+ *
+ * ## Concurrency profile change vs. JVM path (round 1 review P2-1)
+ *
+ * The original JVM `Highlighter.highlight` serializes all calls through a
+ * single-thread `executor` (one shared QuickJS context per instance, can't
+ * safely parallelize). The native path is reentrant — tree-sitter grammars
+ * are `&'static` immutable, a fresh `Highlighter` is constructed per JNI
+ * call, no shared mutable state. So concurrent callers (e.g. many code
+ * blocks rendering at once during streaming) run in **parallel** under the
+ * native path instead of serializing. That is the intended performance
+ * benefit, but it does mean canary devices with native ON may see higher
+ * peak CPU than the JVM baseline. Diff sampling stays valid because token
+ * equality is still per-call.
+ */
+object HighlightNativeSwitch {
+
+    private const val TAG = "HighlightNativeSwitch"
+    const val COMPONENT_NAME: String = "highlight"
+
+    interface Config {
+        fun enabled(): Boolean
+        fun samplingRate(): Float
+        fun onLoadFailure(error: Throwable)
+        fun onNativePanic(stage: String, error: Throwable?)
+        fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String)
+    }
+
+    object DisabledConfig : Config {
+        override fun enabled(): Boolean = false
+        override fun samplingRate(): Float = 0f
+        override fun onLoadFailure(error: Throwable) {}
+        override fun onNativePanic(stage: String, error: Throwable?) {}
+        override fun onDiff(stage: String, equal: Boolean, jvmSummary: String, nativeSummary: String) {}
+    }
+
+    @Volatile
+    var config: Config = DisabledConfig
+
+    private val loadFailureReported = AtomicBoolean(false)
+    private val firstSuccessLogged = AtomicBoolean(false)
+
+    /**
+     * Returns the native highlight tokens, or `null` if the caller should
+     * fall back to the JVM QuickJS+Prism path. [jvmFallback] is invoked only
+     * inside the sampling path (zero overhead in steady-state when
+     * samplingRate == 0).
+     */
+    suspend fun highlightOrNull(
+        code: String,
+        language: String,
+        jvmFallback: suspend () -> List<HighlightToken>,
+    ): List<HighlightToken>? {
+        val cfg = config
+        if (!cfg.enabled()) return null
+        if (!HighlighterNative.available) {
+            if (loadFailureReported.compareAndSet(false, true)) {
+                HighlighterNative.lastLoadError()?.let { cfg.onLoadFailure(it) }
+            }
+            return null
+        }
+        val nativeTokens = try {
+            HighlighterNative.highlight(code, language)
+        } catch (t: Throwable) {
+            Log.w(TAG, "native highlight threw — falling back to JVM", t)
+            cfg.onNativePanic("highlight", t)
+            return null
+        }
+        if (nativeTokens == null) {
+            cfg.onNativePanic("highlight", null)
+            return null
+        }
+        // One-shot success log so canary devices can confirm the native path
+        // is firing without flooding logcat on long markdown rendering.
+        if (firstSuccessLogged.compareAndSet(false, true)) {
+            Log.i(TAG, "native highlight ok (first success): lang=$language tokens=${nativeTokens.size}")
+        }
+        // Diff sampling — runs the JVM path in parallel and reports the
+        // comparison. Done after native succeeds so a failing JVM fallback
+        // doesn't drop the native result.
+        val rate = cfg.samplingRate()
+        // Predicate form: early-return when the dice fall outside the sample
+        // window. Matches OfficeNativeSwitch / MarkdownNativeSwitch (final
+        // sweep P2-2 — single style across all 4 Switches).
+        if (rate <= 0f || Random.nextFloat() >= rate) return nativeTokens
+        try {
+            val jvmTokens = jvmFallback()
+            val equal = jvmTokens == nativeTokens
+            cfg.onDiff(
+                // Stage stays low-cardinality ("highlight" for all langs)
+                // so Crashlytics doesn't bucket per-language issues —
+                // language goes into the payload instead.
+                stage = "highlight",
+                equal = equal,
+                jvmSummary = "lang=$language " + summarize(jvmTokens),
+                nativeSummary = "lang=$language " + summarize(nativeTokens),
+            )
+        } catch (t: Throwable) {
+            Log.w(TAG, "diff-sampling JVM fallback threw; skipping diff", t)
+        }
+        return nativeTokens
+    }
+
+    private fun summarize(tokens: List<HighlightToken>): String {
+        val totalLen = tokens.sumOf { t ->
+            when (t) {
+                is HighlightToken.Plain -> t.content.length
+                is HighlightToken.Token.StringContent -> t.length
+                is HighlightToken.Token.StringListContent -> t.length
+                is HighlightToken.Token.Nested -> t.length
+            }
+        }
+        val head = tokens.take(8).joinToString("|") { t ->
+            when (t) {
+                is HighlightToken.Plain -> "P(${t.content.length})"
+                is HighlightToken.Token.StringContent -> "${t.type}(${t.length})"
+                is HighlightToken.Token.StringListContent -> "${t.type}[](${t.length})"
+                is HighlightToken.Token.Nested -> "${t.type}{}(${t.length})"
+            }
+        }
+        return "count=${tokens.size} totalLen=$totalLen head=$head"
+    }
+}

--- a/highlight/src/main/java/me/rerere/highlight/nativebridge/HighlighterNative.kt
+++ b/highlight/src/main/java/me/rerere/highlight/nativebridge/HighlighterNative.kt
@@ -7,8 +7,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Bridge to the `highlight-parser` Rust crate (tree-sitter based).
  *
- * Spike-phase contract: NOT wired into [me.rerere.highlight.Highlighter] —
- * benchmarks call directly. See SPIKE_PLAN §5.
+ * Phase 1 (PR #9) shipped this bridge without production wiring — only
+ * benchmarks called it. From Phase 2 Step 2 onwards [Highlighter.highlight]
+ * routes through the sibling [HighlightNativeSwitch] (public face that adds
+ * flag gating + Crashlytics + diff sampling). See SPIKE_PLAN §5 / §8.
  *
  * The native side returns a packed binary token stream; we decode to
  * [HighlightToken] so the existing Compose renderer ([HighlightText]) can
@@ -66,6 +68,14 @@ internal object HighlighterNative {
             return loaded.get()
         }
 
+    /**
+     * Throwable from the most recent [System.loadLibrary] attempt, or `null`
+     * if the library loaded fine / no attempt yet. Visible to the in-package
+     * [HighlightNativeSwitch] so it can route load failures to Crashlytics
+     * exactly once.
+     */
+    internal fun lastLoadError(): Throwable? = loadError
+
     private fun ensureLoaded() {
         if (loaded.get() || loadError != null) return
         synchronized(this) {
@@ -101,21 +111,36 @@ internal object HighlighterNative {
         ensureLoaded()
         if (!loaded.get()) return null
         val blob = highlightNative(code, language)
+        // Truncated / empty blob = Rust caught a panic + returned no header.
+        // Returning null here is intentional — the caller (Switch) sees null
+        // and routes it through `cfg.onNativePanic("highlight", null)` for
+        // Crashlytics. Do NOT inline a panic call here; the bridge stays
+        // telemetry-agnostic by design.
         if (blob.size < 8) return null
         return decode(blob, code)
     }
 
-    private fun decode(blob: ByteArray, originalCode: String): List<HighlightToken> {
+    /**
+     * Decode the packed token blob.
+     *
+     * Returns `null` (NOT empty list) on invalid magic or unsupported wire
+     * version (Codex review P2-5) — empty list would be indistinguishable
+     * from "valid blob with no tokens" and the Switch would render an empty
+     * code block instead of falling back to QuickJS+Prism. Null propagates
+     * through `highlight()` → Switch sees `nativeTokens == null` →
+     * `cfg.onNativePanic("highlight", null)` → JVM fallback.
+     */
+    private fun decode(blob: ByteArray, originalCode: String): List<HighlightToken>? {
         // Header: 'PHLT' + u8 ver + u8 flags + u16 reserved
         if (blob[0] != 'P'.code.toByte() || blob[1] != 'H'.code.toByte()
             || blob[2] != 'L'.code.toByte() || blob[3] != 'T'.code.toByte()
-        ) return emptyList()
+        ) return null
         // Reject wire-format versions we don't know how to read so a future
         // v2 .so with a Kotlin client on this version silently falls back
         // instead of mis-decoding (cross-component review P2 fix; mirrors the
         // PackedAstReader.isValid check in MarkdownParserNative).
         val rawVersion = blob[4].toInt() and 0xFF
-        if (rawVersion != SUPPORTED_WIRE_VERSION) return emptyList()
+        if (rawVersion != SUPPORTED_WIRE_VERSION) return null
         var cursor = 8
 
         // Cache the UTF-8 byte representation **once** per decode call so

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -56,10 +56,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "calamine"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+dependencies = [
+ "byteorder",
+ "codepage",
+ "encoding_rs",
+ "log",
+ "quick-xml 0.31.0",
+ "serde",
+ "zip",
+]
 
 [[package]]
 name = "cc"
@@ -82,6 +103,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "combine"
@@ -131,6 +161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,8 +211,8 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 name = "highlight-parser"
 version = "0.1.0"
 dependencies = [
- "android_logger",
  "jni",
+ "jni-common",
  "log",
  "thiserror 2.0.18",
  "tree-sitter",
@@ -226,6 +265,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni-common"
+version = "0.1.0"
+dependencies = [
+ "android_logger",
+ "log",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,8 +310,8 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "markdown-parser"
 version = "0.1.0"
 dependencies = [
- "android_logger",
  "jni",
+ "jni-common",
  "log",
  "pulldown-cmark",
  "regex",
@@ -292,10 +339,11 @@ dependencies = [
 name = "office-parsers"
 version = "0.1.0"
 dependencies = [
- "android_logger",
+ "calamine",
  "jni",
+ "jni-common",
  "log",
- "quick-xml",
+ "quick-xml 0.36.2",
  "similar",
  "thiserror 2.0.18",
  "zip",
@@ -327,6 +375,16 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -380,8 +438,8 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "regex-transformer"
 version = "0.1.0"
 dependencies = [
- "android_logger",
  "jni",
+ "jni-common",
  "log",
  "regex",
  "thiserror 2.0.18",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "jni-common",
     "office-parsers",
     "markdown-parser",
     "highlight-parser",
@@ -14,11 +15,20 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.75"
+# Bumped from 1.75 → 1.76 because `std::any::type_name_of_val` (used by
+# jni-common::panic_to_string) stabilized in 1.76. Previous setting was a
+# latent contract violation — local builds passed because the active toolchain
+# was ≥1.76, but a strict CI on a 1.75 toolchain would have failed.
+rust-version = "1.76"
 license = "Apache-2.0"
 publish = false
 
 [workspace.dependencies]
+# Shared internal helpers — see `jni-common/src/lib.rs`. Extracted in
+# Phase 3 D-2 (was 3 duplicated copies of panic_to_string +
+# init_logger_once + write_varint).
+jni-common = { path = "jni-common" }
+
 # JNI bindings — kept aligned across all 3 crates so they can share helpers
 jni = "0.21"
 
@@ -31,6 +41,19 @@ android_logger = "0.14"
 # Component #1 — office parsers
 quick-xml = { version = "0.36", features = ["serialize"] }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# xlsx reader (Phase 3 D-1). `default-features = false` is defensive —
+# calamine's current default feature set is empty (no chrono / picture /
+# serde) but pinning the toggle protects us from a silent upstream
+# default-bump pulling chrono into the .so.
+#
+# Held at 0.26 deliberately: newer calamine (0.27+) pulls in quick-xml
+# 0.37 AND zip 4, both of which differ from the workspace pins (quick-xml
+# 0.36, zip 2). The "dedup" by upgrading actually doubled the duplicated
+# crate count. Until the rest of the workspace (docx / pptx / epub
+# parsers) is ready to migrate to quick-xml 0.37 + zip 4 in lockstep,
+# accept the ~80 KB cost of one duplicated quick-xml (0.31 vs 0.36) at
+# the calamine boundary.
+calamine = { version = "0.26", default-features = false }
 
 # Component #2 — markdown parser
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }

--- a/native/highlight-parser/Cargo.toml
+++ b/native/highlight-parser/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 jni.workspace = true
+jni-common.workspace = true
 tree-sitter.workspace = true
 tree-sitter-highlight.workspace = true
 thiserror.workspace = true
 log.workspace = true
-android_logger.workspace = true
 
 # Grammar bundle. Each ~150-500KB. Total ~5-7MB stripped.
 tree-sitter-rust.workspace = true

--- a/native/highlight-parser/src/lib.rs
+++ b/native/highlight-parser/src/lib.rs
@@ -13,7 +13,6 @@ mod packed_tokens;
 mod scope_mapping;
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::OnceLock;
 
 use jni::objects::{JClass, JObjectArray, JString};
 use jni::sys::{jbyteArray, jobjectArray};
@@ -27,7 +26,7 @@ pub extern "system" fn Java_me_rerere_highlight_nativebridge_HighlighterNative_h
     code: JString<'local>,
     language: JString<'local>,
 ) -> jbyteArray {
-    init_logger_once();
+    jni_common::init_logger_once!("RustHighlightParser");
 
     let code_str: String = match env.get_string(&code) {
         Ok(s) => s.into(),
@@ -56,7 +55,7 @@ pub extern "system" fn Java_me_rerere_highlight_nativebridge_HighlighterNative_h
         Err(panic) => {
             log::error!(
                 "highlight-parser: native panic: {:?}",
-                panic_to_string(&panic)
+                jni_common::panic_to_string(&panic)
             );
             empty_array(&mut env)
         }
@@ -74,7 +73,7 @@ pub extern "system" fn Java_me_rerere_highlight_nativebridge_HighlighterNative_s
     mut env: JNIEnv<'local>,
     _class: JClass<'local>,
 ) -> jobjectArray {
-    init_logger_once();
+    jni_common::init_logger_once!("RustHighlightParser");
     let result = catch_unwind(AssertUnwindSafe(|| build_supported_languages_array(&mut env)));
     match result {
         Ok(arr) => arr,
@@ -150,35 +149,6 @@ fn highlight_to_packed(code: &str, language: &str) -> Vec<u8> {
             packed_tokens::pack_plain_only(code)
         }
     }
-}
-
-fn panic_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        // Best-effort: include runtime type name so crash logs are debuggable
-        // (P3 sweep — propagate office-parsers' improved variant).
-        format!(
-            "non-string panic payload (type_name = {})",
-            std::any::type_name_of_val(&**payload)
-        )
-    }
-}
-
-fn init_logger_once() {
-    static INIT: OnceLock<()> = OnceLock::new();
-    INIT.get_or_init(|| {
-        #[cfg(target_os = "android")]
-        {
-            android_logger::init_once(
-                android_logger::Config::default()
-                    .with_max_level(log::LevelFilter::Info)
-                    .with_tag("RustHighlightParser"),
-            );
-        }
-    });
 }
 
 #[cfg(test)]

--- a/native/highlight-parser/src/packed_tokens.rs
+++ b/native/highlight-parser/src/packed_tokens.rs
@@ -39,15 +39,15 @@ const KIND_TOKEN: u8 = 1;
 pub fn pack_plain_only(code: &str) -> Vec<u8> {
     let mut out = write_header();
     // type pool: empty
-    write_varint(0, &mut out);
+    jni_common::write_varint(0, &mut out);
     // tokens: just one Plain
     if code.is_empty() {
-        write_varint(0, &mut out);
+        jni_common::write_varint(0, &mut out);
     } else {
-        write_varint(1, &mut out);
+        jni_common::write_varint(1, &mut out);
         out.push(KIND_PLAIN);
-        write_varint(0, &mut out);
-        write_varint(code.len() as u64, &mut out);
+        jni_common::write_varint(0, &mut out);
+        jni_common::write_varint(code.len() as u64, &mut out);
     }
     out
 }
@@ -58,9 +58,9 @@ pub fn pack(code: &str, events: Vec<HighlightEvent>) -> Vec<u8> {
     // Emit type pool (full HIGHLIGHT_NAMES list — small, ~26 entries).
     // Kotlin side caches this once and indexes by `type_ref`.
     let names = highlight_names();
-    write_varint(names.len() as u64, &mut out);
+    jni_common::write_varint(names.len() as u64, &mut out);
     for name in names {
-        write_varint(name.len() as u64, &mut out);
+        jni_common::write_varint(name.len() as u64, &mut out);
         out.extend_from_slice(name.as_bytes());
     }
 
@@ -109,13 +109,13 @@ pub fn pack(code: &str, events: Vec<HighlightEvent>) -> Vec<u8> {
         });
     }
 
-    write_varint(tokens.len() as u64, &mut out);
+    jni_common::write_varint(tokens.len() as u64, &mut out);
     for token in &tokens {
         match token {
             Token::Plain { start, end } => {
                 out.push(KIND_PLAIN);
-                write_varint(*start as u64, &mut out);
-                write_varint((*end - *start) as u64, &mut out);
+                jni_common::write_varint(*start as u64, &mut out);
+                jni_common::write_varint((*end - *start) as u64, &mut out);
             }
             Token::Token {
                 start,
@@ -123,9 +123,9 @@ pub fn pack(code: &str, events: Vec<HighlightEvent>) -> Vec<u8> {
                 type_ref,
             } => {
                 out.push(KIND_TOKEN);
-                write_varint(*start as u64, &mut out);
-                write_varint((*end - *start) as u64, &mut out);
-                write_varint(*type_ref as u64, &mut out);
+                jni_common::write_varint(*start as u64, &mut out);
+                jni_common::write_varint((*end - *start) as u64, &mut out);
+                jni_common::write_varint(*type_ref as u64, &mut out);
             }
         }
     }
@@ -149,18 +149,8 @@ fn write_header() -> Vec<u8> {
     out
 }
 
-fn write_varint(mut value: u64, out: &mut Vec<u8>) {
-    loop {
-        let byte = (value & 0x7F) as u8;
-        value >>= 7;
-        if value == 0 {
-            out.push(byte);
-            return;
-        } else {
-            out.push(byte | 0x80);
-        }
-    }
-}
+// varint writer moved to jni-common (single source of truth for the wire
+// format — see jni_common::write_varint).
 
 #[cfg(test)]
 mod tests {

--- a/native/jni-common/Cargo.toml
+++ b/native/jni-common/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "jni-common"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+# Used by the `android_logger_init` helper. Other JNI crates depending on this
+# get android_logger transitively; they don't need to declare it again.
+log = { workspace = true }
+android_logger = { workspace = true }

--- a/native/jni-common/src/lib.rs
+++ b/native/jni-common/src/lib.rs
@@ -1,0 +1,147 @@
+//! Shared helpers used by every JNI-facing rikkahub Rust crate
+//! (`office-parsers`, `markdown-parser`, `highlight-parser`,
+//! `regex-transformer`). Extracted in Phase 3 D-2 — previously each crate
+//! kept identical inline copies.
+//!
+//! Three primitives only — keep the dependency boundary narrow so adding a
+//! new JNI crate doesn't accidentally pull in unrelated dependencies:
+//!
+//! 1. [`panic_to_string`] — best-effort diagnostic for `catch_unwind` payloads
+//! 2. [`init_logger_once!`] — Android logcat tag-gated lazy logger init
+//! 3. [`write_varint`] — unsigned LEB128 writer used by every packed binary
+//!    wire format we ship across the JNI boundary
+//!
+//! Crates that don't need all three can still pull this in cheaply; the
+//! whole crate is < 100 lines.
+
+/// Convert a `catch_unwind` payload into a human-readable string for log /
+/// Crashlytics propagation. Recognises the two common payload types
+/// (`&'static str` and `String`) and falls back to the type name for anything
+/// exotic so future crash reports aren't just "non-string panic payload".
+pub fn panic_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!(
+            "non-string panic payload (type_name = {})",
+            std::any::type_name_of_val(&**payload)
+        )
+    }
+}
+
+/// Initialise `android_logger` with the given tag. **Not part of the public
+/// API** — `#[doc(hidden)]` because it's only meant for the
+/// [`init_logger_once!`] macro to call; calling it directly bypasses the
+/// `OnceLock` and re-initialises the logger on every call. The macro
+/// references it via `$crate::android_logger_init` so it must be `pub`
+/// (otherwise downstream crate expansion can't see it).
+#[cfg(target_os = "android")]
+#[doc(hidden)]
+pub fn android_logger_init(tag: &'static str) {
+    android_logger::init_once(
+        android_logger::Config::default()
+            .with_max_level(log::LevelFilter::Info)
+            .with_tag(tag),
+    );
+}
+
+#[cfg(not(target_os = "android"))]
+#[doc(hidden)]
+pub fn android_logger_init(_tag: &'static str) {
+    // host-side cargo test: skip
+}
+
+/// Idempotently initialise the Android logger with the given tag. Expand at
+/// the JNI entry of each crate — the macro keeps a per-crate `OnceLock`
+/// inside the calling site so two crates initialising in the same process
+/// don't clobber each other's tags. Pass a `&'static str` literal.
+///
+/// ```ignore
+/// # use jni_common::init_logger_once;
+/// jni_common::init_logger_once!("RustOfficeParsers");
+/// ```
+#[macro_export]
+macro_rules! init_logger_once {
+    ($tag:expr) => {{
+        static INIT: ::std::sync::OnceLock<()> = ::std::sync::OnceLock::new();
+        INIT.get_or_init(|| {
+            $crate::android_logger_init($tag);
+        });
+    }};
+}
+
+/// Write an unsigned 64-bit value as LEB128 into `out`. Same encoding used by
+/// the protobuf varint format: every byte stores 7 payload bits + 1
+/// continuation bit. Decoded on the Kotlin side by hand-rolled `readVarint`
+/// helpers in `*Native.kt`.
+pub fn write_varint(mut value: u64, out: &mut Vec<u8>) {
+    loop {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value == 0 {
+            out.push(byte);
+            return;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varint_single_byte_under_128() {
+        let mut out = Vec::new();
+        write_varint(0, &mut out);
+        assert_eq!(out, vec![0]);
+        out.clear();
+        write_varint(127, &mut out);
+        assert_eq!(out, vec![127]);
+    }
+
+    #[test]
+    fn varint_two_bytes_at_128() {
+        let mut out = Vec::new();
+        write_varint(128, &mut out);
+        assert_eq!(out, vec![0x80, 0x01]);
+    }
+
+    #[test]
+    fn varint_large() {
+        // 300 = 0b100101100 → low7=0101100|0x80, next7=10 → 0x80 0xAC, 0x02
+        let mut out = Vec::new();
+        write_varint(300, &mut out);
+        assert_eq!(out, vec![0xAC, 0x02]);
+    }
+
+    #[test]
+    fn panic_to_string_handles_static_str() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("boom");
+        assert_eq!(panic_to_string(&payload), "boom");
+    }
+
+    #[test]
+    fn panic_to_string_handles_string() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("dynamic boom"));
+        assert_eq!(panic_to_string(&payload), "dynamic boom");
+    }
+
+    #[test]
+    fn panic_to_string_handles_other_with_type_name() {
+        // `type_name_of_val(&**payload)` on a `Box<dyn Any + Send>` returns
+        // the trait-object type name (`dyn core::any::Any + ...`), not the
+        // concrete struct name — that's a Rust language constraint, not a
+        // limitation of this helper. The diagnostic still distinguishes
+        // exotic panic types from the common `&str` / `String` cases.
+        struct Weird;
+        let payload: Box<dyn std::any::Any + Send> = Box::new(Weird);
+        let s = panic_to_string(&payload);
+        assert!(
+            s.starts_with("non-string panic payload"),
+            "unexpected payload string: {s}"
+        );
+    }
+}

--- a/native/markdown-parser/Cargo.toml
+++ b/native/markdown-parser/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 jni.workspace = true
+jni-common.workspace = true
 pulldown-cmark.workspace = true
 regex.workspace = true
 thiserror.workspace = true
 log.workspace = true
-android_logger.workspace = true
 
 [dev-dependencies]
 similar = "2"

--- a/native/markdown-parser/src/lib.rs
+++ b/native/markdown-parser/src/lib.rs
@@ -61,7 +61,7 @@ pub extern "system" fn Java_me_rerere_rikkahub_ui_components_richtext_nativebrid
     _class: JClass<'local>,
     text: JString<'local>,
 ) -> jbyteArray {
-    init_logger_once();
+    jni_common::init_logger_once!("RustMarkdownParser");
 
     let text_str: String = match env.get_string(&text) {
         Ok(s) => String::from(s),
@@ -81,7 +81,7 @@ pub extern "system" fn Java_me_rerere_rikkahub_ui_components_richtext_nativebrid
             }
         },
         Err(panic) => {
-            log::error!("markdown-parser: native panic: {:?}", panic_to_string(&panic));
+            log::error!("markdown-parser: native panic: {:?}", jni_common::panic_to_string(&panic));
             empty_array(&mut env)
         }
     }
@@ -113,7 +113,7 @@ pub extern "system" fn Java_me_rerere_rikkahub_ui_components_richtext_nativebrid
     _class: JClass<'local>,
     text: JString<'local>,
 ) -> jni::sys::jstring {
-    init_logger_once();
+    jni_common::init_logger_once!("RustMarkdownParser");
 
     let text_str: String = match env.get_string(&text) {
         Ok(s) => String::from(s),
@@ -135,7 +135,7 @@ pub extern "system" fn Java_me_rerere_rikkahub_ui_components_richtext_nativebrid
         Err(panic) => {
             log::error!(
                 "markdown-parser (to-html): native panic: {:?}",
-                panic_to_string(&panic)
+                jni_common::panic_to_string(&panic)
             );
             std::ptr::null_mut()
         }
@@ -297,36 +297,6 @@ fn sanitize_dangerous_schemes(html: &str) -> String {
     .into_owned()
 }
 
-fn panic_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        // Best-effort: include runtime type name so crash logs are debuggable
-        // (P3 sweep — propagate office-parsers' improved variant).
-        format!(
-            "non-string panic payload (type_name = {})",
-            std::any::type_name_of_val(&**payload)
-        )
-    }
-}
-
-fn init_logger_once() {
-    // Standardized to OnceLock across all crates (P3 sweep).
-    use std::sync::OnceLock;
-    static INIT: OnceLock<()> = OnceLock::new();
-    INIT.get_or_init(|| {
-        #[cfg(target_os = "android")]
-        {
-            android_logger::init_once(
-                android_logger::Config::default()
-                    .with_max_level(log::LevelFilter::Info)
-                    .with_tag("RustMarkdownParser"),
-            );
-        }
-    });
-}
 
 #[cfg(test)]
 mod tests {

--- a/native/markdown-parser/src/packed_ast.rs
+++ b/native/markdown-parser/src/packed_ast.rs
@@ -56,28 +56,15 @@ fn pack_tree(root: &Node, out: &mut Vec<u8>) {
     stack.push(root);
     while let Some(node) = stack.pop() {
         out.push(node.type_code.as_byte());
-        write_varint(node.start as u64, out);
+        jni_common::write_varint(node.start as u64, out);
         let delta = node.end.saturating_sub(node.start) as u64;
-        write_varint(delta, out);
-        write_varint(node.extras.len() as u64, out);
+        jni_common::write_varint(delta, out);
+        jni_common::write_varint(node.extras.len() as u64, out);
         out.extend_from_slice(&node.extras);
-        write_varint(node.children.len() as u64, out);
+        jni_common::write_varint(node.children.len() as u64, out);
         // Push children in reverse so the first child is popped next.
         for child in node.children.iter().rev() {
             stack.push(child);
-        }
-    }
-}
-
-fn write_varint(mut value: u64, out: &mut Vec<u8>) {
-    loop {
-        let byte = (value & 0x7F) as u8;
-        value >>= 7;
-        if value == 0 {
-            out.push(byte);
-            return;
-        } else {
-            out.push(byte | 0x80);
         }
     }
 }
@@ -120,18 +107,6 @@ mod tests {
         assert_eq!(bytes[5], FLAG_HAS_HTML_BLOCKS);
     }
 
-    #[test]
-    fn varint_small_values_one_byte() {
-        let mut out = Vec::new();
-        write_varint(0, &mut out);
-        assert_eq!(out, vec![0]);
-
-        let mut out = Vec::new();
-        write_varint(127, &mut out);
-        assert_eq!(out, vec![127]);
-
-        let mut out = Vec::new();
-        write_varint(128, &mut out);
-        assert_eq!(out, vec![0x80, 0x01]);
-    }
+    // varint encoding tests moved to jni-common (single source of truth for
+    // the wire format — see jni_common::tests::varint_*).
 }

--- a/native/markdown-parser/src/tree_builder.rs
+++ b/native/markdown-parser/src/tree_builder.rs
@@ -237,21 +237,8 @@ fn encode_string(s: &str, out: &mut Vec<u8>) {
     // byte payloads (long code-fence langs / link hrefs) would silently
     // truncate via `as u16` wrap. Varint scales without ceiling (review P2 fix).
     let bytes = s.as_bytes();
-    write_varint_to(bytes.len() as u64, out);
+    jni_common::write_varint(bytes.len() as u64, out);
     out.extend_from_slice(bytes);
-}
-
-fn write_varint_to(mut value: u64, out: &mut Vec<u8>) {
-    loop {
-        let byte = (value & 0x7F) as u8;
-        value >>= 7;
-        if value == 0 {
-            out.push(byte);
-            return;
-        } else {
-            out.push(byte | 0x80);
-        }
-    }
 }
 
 /// Given a TagEnd, return the corresponding Start Tag in a no-payload form

--- a/native/office-parsers/Cargo.toml
+++ b/native/office-parsers/Cargo.toml
@@ -12,11 +12,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 jni.workspace = true
+jni-common.workspace = true
 quick-xml.workspace = true
 zip.workspace = true
+calamine.workspace = true
 thiserror.workspace = true
 log.workspace = true
-android_logger.workspace = true
 
 [dev-dependencies]
 # Used by integration tests to compare against JVM-equivalent outputs

--- a/native/office-parsers/src/error.rs
+++ b/native/office-parsers/src/error.rs
@@ -29,6 +29,16 @@ pub enum OfficeParseError {
 
     #[error("unable to find OPF file in EPUB")]
     EpubOpfMissing,
+
+    // Inner Display intentionally just the inner text — the caller-facing
+    // sentinel is built by `to_xlsx_message()` ("Error parsing XLSX file: …")
+    // so we don't want a redundant "xlsx error:" prefix sandwiched in (D-1
+    // R1 P3-a).
+    #[error("{0}")]
+    Xlsx(String),
+
+    #[error("no sheets found in XLSX file")]
+    XlsxNoSheets,
 }
 
 impl OfficeParseError {
@@ -51,6 +61,13 @@ impl OfficeParseError {
         match self {
             Self::EpubOpfMissing => "Unable to find OPF file in EPUB".to_string(),
             other => format!("Error parsing EPUB file: {}", other),
+        }
+    }
+
+    pub fn to_xlsx_message(&self) -> String {
+        match self {
+            Self::XlsxNoSheets => "No sheets found in XLSX file".to_string(),
+            other => format!("Error parsing XLSX file: {}", other),
         }
     }
 }

--- a/native/office-parsers/src/lib.rs
+++ b/native/office-parsers/src/lib.rs
@@ -12,6 +12,7 @@
 mod docx;
 mod pptx;
 mod epub;
+mod xlsx;
 mod error;
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -45,36 +46,31 @@ fn rust_to_jstring(env: &mut JNIEnv, s: &str) -> jstring {
     }
 }
 
-/// Top-level helper: dispatches to the supplied closure and converts any
-/// panic into a sentinel error string so the JNI boundary is panic-safe.
+/// Top-level helper: dispatches to the supplied closure and signals panic vs.
+/// soft-error distinctly back to the JNI caller.
+///
+/// - Closure returns a String (potentially the JVM-compatible
+///   "Error parsing ..." sentinel for soft errors like IO / zip / xml): we
+///   pass that String through as the success value, matching the legacy JVM
+///   contract.
+/// - Closure panics: we return `null` (`std::ptr::null_mut()`) so the
+///   Kotlin adapter sees `parseDocxNative(...) == null`, downgrades to
+///   `Result.NativeUnavailable`, and the Switch routes the event through
+///   `cfg.onNativePanic` + JVM fallback (Codex review P1-1). Previously the
+///   panic string was returned as a success value, so the caller silently
+///   showed `"Error parsing DOCX file: native panic — ..."` to the user
+///   instead of falling back.
 fn safe_parse<F>(env: &mut JNIEnv, kind: &str, f: F) -> jstring
 where
     F: FnOnce() -> String,
 {
-    let result = catch_unwind(AssertUnwindSafe(f));
-    let s = match result {
-        Ok(s) => s,
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(s) => rust_to_jstring(env, &s),
         Err(panic_payload) => {
-            let msg = panic_to_string(&panic_payload);
+            let msg = jni_common::panic_to_string(&panic_payload);
             log::error!("native {} parser panicked: {}", kind, msg);
-            format!("Error parsing {} file: native panic — {}", kind, msg)
+            std::ptr::null_mut()
         }
-    };
-    rust_to_jstring(env, &s)
-}
-
-fn panic_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        // Best-effort diagnostic — record the runtime type name so future
-        // crash logs are not just "non-string panic payload".
-        format!(
-            "non-string panic payload (type_name = {})",
-            std::any::type_name_of_val(&**payload)
-        )
     }
 }
 
@@ -92,7 +88,7 @@ pub extern "system" fn Java_me_rerere_document_nativebridge_OfficeParserNative_p
     _class: JClass<'local>,
     path: JString<'local>,
 ) -> jstring {
-    init_logger_once();
+    jni_common::init_logger_once!("RustOfficeParsers");
     let path_str = match jstring_to_rust(&mut env, path) {
         Ok(p) => p,
         Err(e) => return rust_to_jstring(&mut env, &format!("Error parsing DOCX file: bad path — {}", e)),
@@ -107,7 +103,7 @@ pub extern "system" fn Java_me_rerere_document_nativebridge_OfficeParserNative_p
     _class: JClass<'local>,
     path: JString<'local>,
 ) -> jstring {
-    init_logger_once();
+    jni_common::init_logger_once!("RustOfficeParsers");
     let path_str = match jstring_to_rust(&mut env, path) {
         Ok(p) => p,
         Err(e) => return rust_to_jstring(&mut env, &format!("Error parsing PPTX file: bad path — {}", e)),
@@ -122,7 +118,7 @@ pub extern "system" fn Java_me_rerere_document_nativebridge_OfficeParserNative_p
     _class: JClass<'local>,
     path: JString<'local>,
 ) -> jstring {
-    init_logger_once();
+    jni_common::init_logger_once!("RustOfficeParsers");
     let path_str = match jstring_to_rust(&mut env, path) {
         Ok(p) => p,
         Err(e) => return rust_to_jstring(&mut env, &format!("Error parsing EPUB file: bad path — {}", e)),
@@ -130,20 +126,22 @@ pub extern "system" fn Java_me_rerere_document_nativebridge_OfficeParserNative_p
     safe_parse(&mut env, "EPUB", || epub::parse_to_markdown(&path_str))
 }
 
-fn init_logger_once() {
-    // Standardized to OnceLock across all crates (P3 sweep).
-    use std::sync::OnceLock;
-    static INIT: OnceLock<()> = OnceLock::new();
-    INIT.get_or_init(|| {
-        #[cfg(target_os = "android")]
-        {
-            android_logger::init_once(
-                android_logger::Config::default()
-                    .with_max_level(log::LevelFilter::Info)
-                    .with_tag("RustOfficeParsers"),
-            );
-        }
-    });
+/// JNI entry: `OfficeParserNative.parseXlsxNative(path: String): String`.
+///
+/// Phase 3 D-1 — net-new (no JVM `XlsxParser` exists). Markdown-pipe-table
+/// representation of every sheet, see `xlsx::parse_to_markdown`.
+#[no_mangle]
+pub extern "system" fn Java_me_rerere_document_nativebridge_OfficeParserNative_parseXlsxNative<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    path: JString<'local>,
+) -> jstring {
+    jni_common::init_logger_once!("RustOfficeParsers");
+    let path_str = match jstring_to_rust(&mut env, path) {
+        Ok(p) => p,
+        Err(e) => return rust_to_jstring(&mut env, &format!("Error parsing XLSX file: bad path — {}", e)),
+    };
+    safe_parse(&mut env, "XLSX", || xlsx::parse_to_markdown(&path_str))
 }
 
 #[cfg(test)]

--- a/native/office-parsers/src/xlsx.rs
+++ b/native/office-parsers/src/xlsx.rs
@@ -1,0 +1,203 @@
+//! XLSX → markdown-flavoured plain text converter. Phase 3 D-1 — net-new
+//! parser (the JVM side has no `XlsxParser`; the existing
+//! `WorkspaceArtifactTools.xlsx` branch uses a custom in-app helper that we
+//! preserve as the fallback path).
+//!
+//! Output shape mirrors `pptx.rs` for visual consistency:
+//!
+//! ```text
+//! ## Sheet: <name>
+//!
+//! | col0 | col1 | col2 |
+//! | a    | b    | c    |
+//!
+//! ## Sheet: <name2>
+//! ...
+//! ```
+//!
+//! Behaviour notes:
+//!
+//! - All non-empty sheets emitted in the order calamine reports them
+//!   (matches the workbook's internal sheet sequence).
+//! - Cell rendering: integers print without trailing `.0`; floats keep their
+//!   decimal portion; bools as `true`/`false`; dates as their raw serial
+//!   number (calamine `dates` feature is OFF so we don't drag chrono into
+//!   the .so — render comes from `Data::DateTimeIso` / `Data::DurationIso`
+//!   string variants when present, raw float otherwise).
+//! - Empty cells become a single ASCII space inside the pipe column for
+//!   shape stability (matches markdown table convention).
+//! - Sheets with zero non-empty rows produce just the heading + a blank
+//!   line — same shape pptx.rs uses for slides with no content.
+
+use calamine::{open_workbook_auto, Data, Reader};
+
+use crate::error::{OfficeParseError, Result};
+
+pub fn parse_to_markdown(path: &str) -> String {
+    match try_parse(path) {
+        Ok(s) => s,
+        Err(e) => e.to_xlsx_message(),
+    }
+}
+
+fn try_parse(path: &str) -> Result<String> {
+    let mut workbook =
+        open_workbook_auto(path).map_err(|e| OfficeParseError::Xlsx(e.to_string()))?;
+    let sheet_names: Vec<String> = workbook.sheet_names().to_vec();
+    if sheet_names.is_empty() {
+        return Err(OfficeParseError::XlsxNoSheets);
+    }
+
+    let mut out = String::with_capacity(4096);
+    let mut emitted_any = false;
+    for name in &sheet_names {
+        let range = match workbook.worksheet_range(name) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        if range.is_empty() {
+            // Heading-only block keeps the structure visible; user can see
+            // that the sheet existed but contained no data. The "(empty)"
+            // marker prevents an LLM consumer from hallucinating content
+            // into a heading-followed-by-blank pattern (D-1 R1 P3-c).
+            if emitted_any {
+                out.push('\n');
+            }
+            out.push_str(&format!("## Sheet: {} (empty)\n\n", name));
+            emitted_any = true;
+            continue;
+        }
+        if emitted_any {
+            out.push('\n');
+        }
+        out.push_str(&format!("## Sheet: {}\n\n", name));
+        render_range(&range, &mut out);
+        emitted_any = true;
+    }
+    Ok(out)
+}
+
+fn render_range(range: &calamine::Range<Data>, out: &mut String) {
+    let cols = range.width();
+    if cols == 0 {
+        return;
+    }
+    for row in range.rows() {
+        out.push('|');
+        for cell in row.iter().take(cols) {
+            out.push(' ');
+            out.push_str(&render_cell(cell));
+            out.push_str(" |");
+        }
+        out.push('\n');
+    }
+}
+
+fn render_cell(cell: &Data) -> String {
+    match cell {
+        Data::Empty => " ".to_string(),
+        Data::String(s) => sanitize_cell(s),
+        Data::Float(f) => {
+            // Round-trippy: print integers without trailing `.0`, floats
+            // with their full Debug representation (Rust default rounding).
+            if f.fract() == 0.0 && f.is_finite() && f.abs() < 1e15 {
+                format!("{}", *f as i64)
+            } else {
+                format!("{}", f)
+            }
+        }
+        Data::Int(i) => format!("{}", i),
+        Data::Bool(b) => format!("{}", b),
+        // Codex review P2-4: Excel's date semantics are workbook-mode
+        // dependent (1900 vs 1904 epoch, plus the 1900 leap-year bug).
+        // calamine 0.26 doesn't expose the workbook mode flag without
+        // enabling the `dates` feature (which pulls chrono into the .so),
+        // so any in-house ISO conversion produces "confidently wrong"
+        // dates for some workbooks. Emit the raw serial with an
+        // identifying suffix so an LLM consumer / human reader sees the
+        // value AND can recognise its semantics, instead of an ISO date
+        // that's silently off by 1–2 days. Wire a real conversion only
+        // when a JVM-side xlsx parser lands that we can cross-check.
+        Data::DateTime(dt) => format!("{} (excel-serial)", dt.as_f64()),
+        // `Data::DateTimeIso` / `Data::DurationIso` are emitted by calamine
+        // only for ODS / SpreadsheetML files, not standard xlsx. We pass
+        // them through verbatim so a misnamed `.xlsx` (actually ODS opened
+        // via `open_workbook_auto`) still renders something sensible.
+        Data::DateTimeIso(s) => sanitize_cell(s),
+        Data::DurationIso(s) => sanitize_cell(s),
+        Data::Error(e) => format!("#ERR:{:?}", e),
+    }
+}
+
+// Excel-serial → ISO date conversion was removed (Codex review P2-4):
+// Excel's date semantics depend on workbook mode (1900 vs 1904 epoch) and
+// include the famous 1900-02-29 leap-year bug. calamine 0.26 doesn't expose
+// the workbook mode flag without the `dates` feature (which pulls chrono).
+// Any in-house conversion would produce off-by-1–2-day dates for some
+// workbooks. We now emit the raw serial with an "(excel-serial)" suffix
+// so consumers see the value AND its semantics — see the `DateTime` arm of
+// `render_cell` above.
+
+/// Replace characters that would corrupt the markdown pipe table shape.
+/// `|` becomes `\|`; newlines become a single space (preserves the row layout).
+fn sanitize_cell(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '|' => out.push_str("\\|"),
+            '\n' | '\r' => out.push(' '),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integer_cell_no_trailing_zero() {
+        assert_eq!(render_cell(&Data::Float(42.0)), "42");
+        assert_eq!(render_cell(&Data::Int(7)), "7");
+    }
+
+    #[test]
+    fn fractional_float_preserves_decimal() {
+        let s = render_cell(&Data::Float(3.14));
+        assert!(s.starts_with("3.14"), "unexpected: {s}");
+    }
+
+    #[test]
+    fn empty_cell_renders_as_space() {
+        assert_eq!(render_cell(&Data::Empty), " ");
+    }
+
+    #[test]
+    fn pipe_in_string_escaped() {
+        assert_eq!(render_cell(&Data::String("a|b".into())), "a\\|b");
+    }
+
+    #[test]
+    fn newline_in_string_becomes_space() {
+        assert_eq!(render_cell(&Data::String("line1\nline2".into())), "line1 line2");
+        assert_eq!(render_cell(&Data::String("a\r\nb".into())), "a  b");
+    }
+
+    #[test]
+    fn bool_renders_lowercase() {
+        assert_eq!(render_cell(&Data::Bool(true)), "true");
+        assert_eq!(render_cell(&Data::Bool(false)), "false");
+    }
+
+    #[test]
+    fn cjk_string_preserved() {
+        assert_eq!(render_cell(&Data::String("你好世界".into())), "你好世界");
+    }
+
+    // Note: DateTime rendering (Data::DateTime) defers to `dt.as_f64() +
+    // " (excel-serial)"` suffix. Testing it would require constructing a
+    // calamine `ExcelDateTime` whose API varies across versions — we trust
+    // calamine's own f64 round-trip and skip the test. The format change
+    // is documented in `render_cell`.
+}

--- a/native/regex-transformer/Cargo.toml
+++ b/native/regex-transformer/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 jni.workspace = true
+jni-common.workspace = true
 regex.workspace = true
 thiserror.workspace = true
 log.workspace = true
-android_logger.workspace = true

--- a/native/regex-transformer/src/lib.rs
+++ b/native/regex-transformer/src/lib.rs
@@ -38,7 +38,7 @@ pub extern "system" fn Java_me_rerere_rikkahub_data_model_nativebridge_RegexTran
     find_patterns: JObjectArray<'local>,
     replacements: JObjectArray<'local>,
 ) -> jstring {
-    init_logger_once();
+    jni_common::init_logger_once!("RustRegexTransformer");
 
     let input_str: String = match env.get_string(&input) {
         Ok(s) => String::from(s),
@@ -67,7 +67,7 @@ pub extern "system" fn Java_me_rerere_rikkahub_data_model_nativebridge_RegexTran
         Err(panic) => {
             log::error!(
                 "regex-transformer: native panic: {:?}",
-                panic_to_string(&panic)
+                jni_common::panic_to_string(&panic)
             );
             std::ptr::null_mut()
         }
@@ -134,35 +134,6 @@ enum RegexTransformerError {
 
     #[error("array length mismatch: finds={finds}, replacements={reps}")]
     ArrayLengthMismatch { finds: usize, reps: usize },
-}
-
-fn panic_to_string(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        (*s).to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        format!(
-            "non-string panic payload (type_name = {})",
-            std::any::type_name_of_val(&**payload)
-        )
-    }
-}
-
-fn init_logger_once() {
-    // Standardized to OnceLock across all crates (P3 sweep).
-    use std::sync::OnceLock;
-    static INIT: OnceLock<()> = OnceLock::new();
-    INIT.get_or_init(|| {
-        #[cfg(target_os = "android")]
-        {
-            android_logger::init_once(
-                android_logger::Config::default()
-                    .with_max_level(log::LevelFilter::Info)
-                    .with_tag("RustRegexTransformer"),
-            );
-        }
-    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Builds on Phase 1 (PR #9, merged 2026-05-21 in 2d980f76) by **switching production callers** to the Rust JNI paths and adding the supporting infrastructure (feature flags + kill switch + Crashlytics tagging + diff sampling + HTML normalizer + jni-common crate + xlsx via calamine).

### Phase 2 — caller switches

Five caller switches wired through per-module `*NativeSwitch` objects (public faces; the underlying `*Native` bridges stay `internal`):

| Step | Switch | Caller | Now goes through |
|---|---|---|---|
| 1 | OfficeNativeSwitch | DocumentAsPromptTransformer + WorkspaceArtifactTools | docx / pptx / epub / **xlsx** native parsers |
| 2 | HighlightNativeSwitch | Highlighter.kt (`highlightJvm` extracted as fallback) | tree-sitter instead of QuickJS + Prism |
| 3 | RegexNativeSwitch | Assistant.replaceRegexes | Rust `regex` crate instead of Java Pattern |
| 4 | MarkdownNativeSwitch.renderHtmlOrNull | MarkdownNew.generateMarkdownHtml | pulldown-cmark instead of JetBrains HtmlGenerator |
| 5 | MarkdownNativeSwitch.parseAstOrNull | Markdown.parsePreprocessedMarkdownUncached (shadow-compare only — renderer still uses JVM tree) | telemetry/structural-diff harness |

### Phase 3 — engineering debt + telemetry sharpening

- **`native/jni-common/` crate**: extracted `panic_to_string` + `init_logger_once!` macro + `write_varint`. 4 JNI crates de-duped; workspace `rust-version` bumped 1.75 → 1.76 (`type_name_of_val`).
- **HtmlDiffNormalizer**: Jsoup-based canonicalizer (sort attrs / collapse whitespace / strip space-before-close-tag / strip space-between-tags / XHTML entity escape / 64K-char input cap). 17 unit tests. `HTML_DIFF_ENABLED` flipped to true.
- **xlsx via calamine 0.26**: net-new (no JVM baseline). New JNI entry + Switch method with `XLSX_DIFF_ENABLED=false` hard-gate.
- **CharReveal `BALANCED(200L → 80L)`**: snappier per-character fade. Enabled by Rust keeping the parse queue shallow so backpressure rarely triggers; backpressure ramp still protects worst case.

### Personal-use config (not the Phase 1 HARD GATE rollout)

This branch is for a single-user app, so the "default JVM + 5%→25%→100% gradual rollout" stance documented in SPIKE_PLAN §8.3 has been **explicitly downgraded** in §8.3:

- 4 `NativePathPrefs` user-facing flags default **`true`** — Rust on out of the box
- `markdownAst` stays `false` — shadow-only, no user-facing win
- `sampleRate` default `0` — diff sampling off; flip up explicitly when comparing engines
- RC `native_path_kill_switch` retained as one-flip emergency revert
- Crashlytics tagging retained (zero maintenance overhead)
- Revert plan: merge commit, single-step `git revert -m 1 <sha>` rolls back the whole branch

### Codex independent review (HOLD-with-fixes → all fixes applied)

- P1: office Rust panic now returns `null` (was returning the panic string as `Success`, suppressing fallback)
- P1: AST shadow compare wrapped in try/catch (truncated valid-magic blob no longer breaks JVM render path)
- P2: HTML diff sampling main-thread guard (Jsoup normalize no longer runs on composition thread)
- P2: Excel serial date conversion removed (workbook-mode-dependent semantics) — render raw float + `(excel-serial)` suffix
- P2: HighlighterNative decode returns `null` on invalid magic/version (was `emptyList()`, looked like success)
- P3: rename `MAX_NORMALIZE_INPUT_BYTES` → `_CHARS` (UTF-16 code units)
- CI: new `native-build-check.yml` workflow for PR-triggered `.so` presence assertion

## Test plan

- [x] `cargo test --workspace`: **67/67 pass**
- [x] `:app:testDebugUnitTest`: 591 tests, 3 pre-existing failures preserved (`GenerativeUiPlannerTest`×2 + `DefaultProvidersTest`×1 — verified identical on pristine main)
- [x] HtmlDiffNormalizer JVM tests: 17/17 pass
- [x] `:app:assembleDebug` / `:app:assembleNotion` / `:app:assembleRefactortest`: all SUCCESSFUL
- [x] All 4 native `.so` files present in `lib/arm64-v8a/` for each variant
- [x] APK size delta: `liboffice_parsers.so` 619 KB → 1.19 MB (+572 KB, under the +1 MiB D-1 budget; total stays within +5 MiB Phase 3 target vs `595e8414`)
- [ ] Merge as **merge commit** (not squash, not rebase) — `git revert -m 1 <merge>` is the rollback path

## Verification on device

Once installed (notion / refactortest variant), `adb logcat` should show on first use:

```
OfficeNativeSwitch: native docx ok (first success): len=...
HighlightNativeSwitch: native highlight ok (first success): lang=python tokens=...
MarkdownNativeSwitch: native markdown html ok (first success): len=...
RegexNativeSwitch: native regex ok (first success): rulesIn=... len=...
```

If a component crashes after rollout, flip `native_path_kill_switch` to `true` in Firebase Remote Config — all 4 Switch impls re-read this on the next call and route back to JVM.