### PR TITLE
Split Paragraph composable into static + per-frame reveal overlay

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -254,6 +254,13 @@ private const val MARKDOWN_PARSE_CACHE_MAX_CHARS = 1_200_000
 private const val MARKDOWN_PERF_TAG = "AmberChatPerf"
 private const val MARKDOWN_PARSE_HIT_LOG_MIN_CHARS = 600
 
+// Tag used to mark leaf-text ranges in the static AnnotatedString that
+// are eligible for per-frame reveal alpha. The annotation's value carries
+// the leaf's absolute startOffset in the source content string so the
+// overlay can map static positions back to CharRevealController offsets.
+// See applyRevealOverlay below. internal so the parity test can pin it.
+internal const val REVEAL_LEAF_TAG = "rikkahub.reveal.leaf"
+
 private data class MarkdownParseCacheKey(
     val content: String,
     val contentHash: Int,
@@ -1300,9 +1307,17 @@ private fun Paragraph(
         { url -> context.openUrl(url) }
     }
 
-    // Active streaming paragraphs deliberately rebuild only their AnnotatedString
-    // while reveal entries are alive. Finalized paragraphs have a null controller
-    // and stay keyed by content like the stable path.
+    // Streaming-aware text build, split into two layers so per-frame work
+    // is bounded by the active reveal window instead of the whole paragraph:
+    //   - staticAnnotated: built once per (content, theme, AST) tuple. Marks
+    //     fade-eligible leaves with REVEAL_LEAF_TAG annotations carrying the
+    //     leaf's source startOffset.
+    //   - annotatedString:  if the controller has active reveal entries,
+    //     layer per-codepoint alpha on top of staticAnnotated via
+    //     applyRevealOverlay; otherwise pass staticAnnotated through.
+    // Previously a single remember(...) keyed on revealClock rebuilt the
+    // whole AST every frame at 60 Hz — that contended with LazyColumn
+    // scroll measure/layout under concurrent tool calls.
     val revealController = LocalCharRevealController.current
     val baseColor = LocalContentColor.current
     val revealClock = revealController?.nowNanos ?: 0L
@@ -1315,13 +1330,16 @@ private fun Paragraph(
                 else Modifier
             )
     ) {
-        val annotatedString = remember(
+        val staticAnnotated = remember(
             content,
             enableLatexRendering,
             onClickUrl,
-            revealController,
-            revealClock,
             baseColor,
+            node,
+            trim,
+            colorScheme,
+            density,
+            textStyle,
         ) {
             buildAnnotatedString {
                 node.children.fastForEach { child ->
@@ -1337,9 +1355,21 @@ private fun Paragraph(
                         enableLatexRendering = enableLatexRendering,
                         onClickUrl = onClickUrl,
                         baseColor = baseColor,
-                        revealController = revealController,
                     )
                 }
+            }
+        }
+
+        val annotatedString = remember(
+            staticAnnotated,
+            revealController,
+            revealClock,
+            baseColor,
+        ) {
+            if (revealController != null && revealController.hasActiveReveals()) {
+                applyRevealOverlay(staticAnnotated, revealController, baseColor)
+            } else {
+                staticAnnotated
             }
         }
 
@@ -1448,7 +1478,6 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
     onClickCitation: (String) -> Unit = {},
     onClickUrl: (String) -> Unit = {},
     baseColor: Color = Color.Unspecified,
-    revealController: CharRevealController? = null,
 ) {
     when {
         node.type == MarkdownTokenTypes.BLOCK_QUOTE -> {}
@@ -1466,42 +1495,20 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
             val rawText = node.getTextInNode(content)
             val text = (if (trim) rawText.trim() else rawText)
                 .replace(BREAK_LINE_REGEX, "\n")
-            // B1 char-reveal: when an active controller is provided AND we
-            // have a usable baseColor, split the text by codepoint and
-            // wrap each in a SpanStyle whose alpha tracks the reveal
-            // window. baseColor=Unspecified (no LocalContentColor handed
-            // down) falls through to the fast path — visually a no-op
-            // because the reveal effect requires color modulation.
-            //
-            // Offset accuracy: the stable-prefix shortcut is only safe
-            // when this leaf text is byte-for-byte aligned with the AST
-            // source. Trimmed or <br>-collapsed leaves keep the old path.
-            if (revealController != null && baseColor != Color.Unspecified) {
-                val baseOffset = node.startOffset
-                val canAppendStablePrefix = !trim && text == rawText
-                var i = if (canAppendStablePrefix) {
-                    (revealController.stableOffsetExclusive() - baseOffset)
-                        .coerceIn(0, text.length)
-                } else {
-                    0
-                }
-                if (i > 0) {
-                    append(text, 0, i)
-                }
-                while (i < text.length) {
-                    val cp = text.codePointAt(i)
-                    val cpLen = Character.charCount(cp)
-                    val alpha = revealController.alphaAt(baseOffset + i)
-                        .coerceIn(0f, 1f)
-                    if (alpha >= 1f) {
-                        append(text, i, i + cpLen)
-                    } else {
-                        withStyle(SpanStyle(color = baseColor.copy(alpha = alpha))) {
-                            append(text, i, i + cpLen)
-                        }
-                    }
-                    i += cpLen
-                }
+            // B1 char-reveal: mark the leaf as fade-eligible iff its text is
+            // byte-for-byte aligned with the AST source (no trim, no
+            // <br>-collapse) AND we have a usable baseColor to modulate.
+            // The annotation carries the leaf's absolute startOffset so
+            // applyRevealOverlay can map static positions back to the
+            // controller's content-offset space. baseColor=Unspecified or
+            // trimmed/collapsed text falls through to a bulk append — the
+            // reveal effect requires color modulation and a 1:1 offset
+            // map, both of which fail in those cases.
+            val canFade = baseColor != Color.Unspecified && !trim && text == rawText
+            if (canFade) {
+                pushStringAnnotation(REVEAL_LEAF_TAG, node.startOffset.toString())
+                append(text)
+                pop()
             } else {
                 append(text)
             }
@@ -1521,7 +1528,6 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                         onClickCitation = onClickCitation,
                         onClickUrl = onClickUrl,
                         baseColor = baseColor,
-                        revealController = revealController,
                     )
                 }
             }
@@ -1541,7 +1547,6 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                         onClickCitation = onClickCitation,
                         onClickUrl = onClickUrl,
                         baseColor = baseColor,
-                        revealController = revealController,
                     )
                 }
             }
@@ -1561,7 +1566,6 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                         onClickCitation = onClickCitation,
                         onClickUrl = onClickUrl,
                         baseColor = baseColor,
-                        revealController = revealController,
                     )
                 }
             }
@@ -1695,8 +1699,59 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                     onClickCitation = onClickCitation,
                     onClickUrl = onClickUrl,
                     baseColor = baseColor,
-                    revealController = revealController,
                 )
+            }
+        }
+    }
+}
+
+/**
+ * Frame-local alpha overlay for the static [AnnotatedString] produced by
+ * [appendMarkdownNodeContent]. Reads the [REVEAL_LEAF_TAG] string
+ * annotations marked during static build; for each marked range, computes
+ * per-codepoint alpha from [revealController] and layers a translucent
+ * color [SpanStyle] on top of the existing styling.
+ *
+ * Cost is O(unrevealed codepoints across all leaves), bounded by
+ * [CharRevealController]'s BACKLOG_DEGRADE (≈ 80). Skip-stable-prefix is
+ * applied per leaf using [CharRevealController.stableOffsetExclusive].
+ *
+ * Returns [static] unchanged when there's no usable [baseColor] or no
+ * fade-eligible leaves were marked — preserves Color.Unspecified parity
+ * with the pre-refactor leaf-text fast path.
+ */
+internal fun applyRevealOverlay(
+    static: AnnotatedString,
+    revealController: CharRevealController,
+    baseColor: Color,
+): AnnotatedString {
+    if (baseColor == Color.Unspecified) return static
+    val ranges = static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
+    if (ranges.isEmpty()) return static
+    return buildAnnotatedString {
+        append(static)
+        ranges.fastForEach { range ->
+            val baseOffset = range.item.toIntOrNull() ?: return@fastForEach
+            val rangeLen = range.end - range.start
+            val stableRel = (revealController.stableOffsetExclusive() - baseOffset)
+                .coerceAtLeast(0)
+            if (stableRel >= rangeLen) return@fastForEach
+            var i = range.start + stableRel
+            val rangeEnd = range.end
+            while (i < rangeEnd) {
+                val cp = static.text.codePointAt(i)
+                val cpLen = Character.charCount(cp)
+                val alpha = revealController
+                    .alphaAt(baseOffset + (i - range.start))
+                    .coerceIn(0f, 1f)
+                if (alpha < 1f) {
+                    addStyle(
+                        style = SpanStyle(color = baseColor.copy(alpha = alpha)),
+                        start = i,
+                        end = i + cpLen,
+                    )
+                }
+                i += cpLen
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -1280,7 +1280,15 @@ private fun Paragraph(
     modifier: Modifier,
 ) {
     // dumpAst(node, content)
-    if (node.findChildOfTypeRecursive(MarkdownElementTypes.IMAGE, GFMElementTypes.BLOCK_MATH) != null) {
+    // Cache the AST-walk result so a per-frame recomposition (triggered by
+    // revealClock subscription below) doesn't re-traverse the whole subtree
+    // just to decide between FlowRow-of-MarkdownNode (images/block-math
+    // present) and the inline AnnotatedString path. Pre-cache mirrors
+    // hasInlineMath's pattern further down.
+    val hasImageOrBlockMath = remember(node) {
+        node.findChildOfTypeRecursive(MarkdownElementTypes.IMAGE, GFMElementTypes.BLOCK_MATH) != null
+    }
+    if (hasImageOrBlockMath) {
         FlowRow(modifier = modifier.fillWidthIf(LocalMarkdownFillWidth.current)) {
             node.children.fastForEach { child ->
                 MarkdownNode(
@@ -1292,12 +1300,14 @@ private fun Paragraph(
     }
 
     val colorScheme = MaterialTheme.colorScheme
-    // Lifecycle pinned to this Paragraph composable; populated lazily
-    // by appendMarkdownNodeContent during the staticAnnotated build
-    // (INLINE_LINK citation + INLINE_MATH formula keys). Keep the same
-    // remember()-no-key form so the map persists across recompositions
-    // alongside staticAnnotated's lambda re-runs — they're created and
-    // disposed together as part of the same composable scope.
+    // Populated lazily by appendMarkdownNodeContent during static rebuilds
+    // via putIfAbsent for INLINE_LINK citation + INLINE_MATH formula
+    // keys. Lives as long as this Paragraph composable (remember without
+    // keys), so entries from previously rendered inline nodes can persist
+    // across content changes — pre-existing behavior, not introduced by
+    // the reveal-overlay refactor. Acceptable because content changes
+    // during streaming only append new inline nodes; the user doesn't
+    // edit/remove inline content mid-stream in this app.
     val inlineContents = remember {
         mutableStateMapOf<String, InlineTextContent>()
     }
@@ -1381,10 +1391,15 @@ private fun Paragraph(
             staticAnnotated.getStringAnnotations(REVEAL_LEAF_TAG, 0, staticAnnotated.length)
         }
 
+        // revealClock = controller?.nowNanos ?: 0L already covers the
+        // null↔non-null transition (the clock jumps between 0 and a real
+        // nanoTime when the controller is installed/removed), so the
+        // controller reference itself isn't a needed key — keeping it
+        // would just add identity churn during the brief streaming-end
+        // window without functional benefit.
         val annotatedString = remember(
             staticAnnotated,
             revealRanges,
-            revealController,
             revealClock,
             baseColor,
         ) {
@@ -1492,6 +1507,29 @@ internal fun extractMarkdownTableData(node: ASTNode, content: String): MarkdownT
     )
 }
 
+/**
+ * Walks a markdown [ASTNode] and appends its rendered content into the
+ * receiver [AnnotatedString.Builder] — including spans for EMPH /
+ * STRONG / STRIKETHROUGH / links / code / inline math.
+ *
+ * **Reveal convention**: when adding a new arm to this function that
+ * calls `append(text)` directly (rather than recursing into children),
+ * decide whether the new arm's text should fade in during streaming.
+ *  - If YES: wrap the append in
+ *    `pushStringAnnotation(REVEAL_LEAF_TAG, node.startOffset.toString())`
+ *    / `pop()` so [applyRevealOverlay] knows to layer per-frame alpha
+ *    on it. The [shouldMarkLeafAsFadeEligible] helper encodes the
+ *    canonical gate (text-aligned-with-source + valid baseColor + not
+ *    trim'd). See the [LeafASTNode] arm for the reference pattern.
+ *  - If NO (typical for code spans, inline links, autolinks, inline
+ *    math — they have their own non-fade visual treatment and would
+ *    look weird with an alpha modulation on top): just `append(text)`
+ *    or use [withStyle], don't push the annotation.
+ *
+ * Recursing arms (EMPH / STRONG / STRIKETHROUGH / default) automatically
+ * inherit the convention because their leaf descendants land in the
+ * [LeafASTNode] arm.
+ */
 internal fun AnnotatedString.Builder.appendMarkdownNodeContent(
     node: ASTNode,
     content: String,
@@ -1805,6 +1843,16 @@ internal fun applyRevealOverlay(
             if (stableRel >= rangeLen) return@fastForEach
             var i = range.start + stableRel
             val rangeEnd = range.end
+            // Batch adjacent codepoints that share the same alpha into one
+            // SpanStyle. CharRevealController slices the queue by reveal
+            // entry (whitespace / CJK / word) and every codepoint inside
+            // one entry returns the same alpha from alphaAt(), so this
+            // collapses ~5-10 per-codepoint addStyle calls per word into
+            // one — under BACKLOG_DEGRADE=80 entries this is the
+            // difference between sub-millisecond and ~3-5ms per frame
+            // worst case.
+            var runStart = -1
+            var runAlpha = 0f
             while (i < rangeEnd) {
                 val cp = static.text.codePointAt(i)
                 val cpLen = Character.charCount(cp)
@@ -1812,13 +1860,37 @@ internal fun applyRevealOverlay(
                     .alphaAt(baseOffset + (i - range.start))
                     .coerceIn(0f, 1f)
                 if (alpha < 1f) {
+                    if (runStart < 0) {
+                        runStart = i
+                        runAlpha = alpha
+                    } else if (alpha != runAlpha) {
+                        addStyle(
+                            style = SpanStyle(color = baseColor.copy(alpha = runAlpha)),
+                            start = runStart,
+                            end = i,
+                        )
+                        runStart = i
+                        runAlpha = alpha
+                    }
+                } else if (runStart >= 0) {
+                    // alpha == 1f: revealed codepoint terminates any
+                    // accumulated run. The revealed codepoint itself
+                    // needs no style.
                     addStyle(
-                        style = SpanStyle(color = baseColor.copy(alpha = alpha)),
-                        start = i,
-                        end = i + cpLen,
+                        style = SpanStyle(color = baseColor.copy(alpha = runAlpha)),
+                        start = runStart,
+                        end = i,
                     )
+                    runStart = -1
                 }
                 i += cpLen
+            }
+            if (runStart >= 0) {
+                addStyle(
+                    style = SpanStyle(color = baseColor.copy(alpha = runAlpha)),
+                    start = runStart,
+                    end = rangeEnd,
+                )
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -1292,6 +1292,12 @@ private fun Paragraph(
     }
 
     val colorScheme = MaterialTheme.colorScheme
+    // Lifecycle pinned to this Paragraph composable; populated lazily
+    // by appendMarkdownNodeContent during the staticAnnotated build
+    // (INLINE_LINK citation + INLINE_MATH formula keys). Keep the same
+    // remember()-no-key form so the map persists across recompositions
+    // alongside staticAnnotated's lambda re-runs — they're created and
+    // disposed together as part of the same composable scope.
     val inlineContents = remember {
         mutableStateMapOf<String, InlineTextContent>()
     }
@@ -1330,6 +1336,11 @@ private fun Paragraph(
                 else Modifier
             )
     ) {
+        // `node` is included as a defensive key — in practice it's stable
+        // across content-equal recompositions because MarkdownParseCache
+        // returns the same root reference, so this rarely contributes to
+        // invalidations. Kept so a future cache refactor that breaks the
+        // identity invariant doesn't silently stale the static AnnotatedString.
         val staticAnnotated = remember(
             content,
             enableLatexRendering,
@@ -1360,14 +1371,29 @@ private fun Paragraph(
             }
         }
 
+        // Cache the REVEAL_LEAF_TAG range list once per static AnnotatedString.
+        // getStringAnnotations(tag, ...) walks every annotation in the doc to
+        // tag-filter, including any UrlAnnotation / InlineContent annotations
+        // pushed by INLINE_LINK / INLINE_MATH. For a paragraph with dozens of
+        // citations + formulas that's O(N) per frame — exactly the kind of
+        // per-frame regression this refactor exists to prevent.
+        val revealRanges = remember(staticAnnotated) {
+            staticAnnotated.getStringAnnotations(REVEAL_LEAF_TAG, 0, staticAnnotated.length)
+        }
+
         val annotatedString = remember(
             staticAnnotated,
+            revealRanges,
             revealController,
             revealClock,
             baseColor,
         ) {
-            if (revealController != null && revealController.hasActiveReveals()) {
-                applyRevealOverlay(staticAnnotated, revealController, baseColor)
+            if (
+                revealController != null &&
+                revealController.hasActiveReveals() &&
+                revealRanges.isNotEmpty()
+            ) {
+                applyRevealOverlay(staticAnnotated, revealRanges, revealController, baseColor)
             } else {
                 staticAnnotated
             }
@@ -1466,7 +1492,7 @@ internal fun extractMarkdownTableData(node: ASTNode, content: String): MarkdownT
     )
 }
 
-private fun AnnotatedString.Builder.appendMarkdownNodeContent(
+internal fun AnnotatedString.Builder.appendMarkdownNodeContent(
     node: ASTNode,
     content: String,
     trim: Boolean = false,
@@ -1707,26 +1733,28 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
 
 /**
  * Frame-local alpha overlay for the static [AnnotatedString] produced by
- * [appendMarkdownNodeContent]. Reads the [REVEAL_LEAF_TAG] string
- * annotations marked during static build; for each marked range, computes
- * per-codepoint alpha from [revealController] and layers a translucent
- * color [SpanStyle] on top of the existing styling.
+ * [appendMarkdownNodeContent]. Caller passes the pre-cached
+ * [REVEAL_LEAF_TAG] range list (caching avoids per-frame
+ * getStringAnnotations tag-filter cost — see the [remember] in
+ * [Paragraph]); for each range, computes per-codepoint alpha from
+ * [revealController] and layers a translucent color [SpanStyle] on top
+ * of the existing styling.
  *
  * Cost is O(unrevealed codepoints across all leaves), bounded by
  * [CharRevealController]'s BACKLOG_DEGRADE (≈ 80). Skip-stable-prefix is
  * applied per leaf using [CharRevealController.stableOffsetExclusive].
  *
- * Returns [static] unchanged when there's no usable [baseColor] or no
- * fade-eligible leaves were marked — preserves Color.Unspecified parity
- * with the pre-refactor leaf-text fast path.
+ * Returns [static] unchanged when there's no usable [baseColor] or
+ * [ranges] is empty — preserves Color.Unspecified parity with the
+ * pre-refactor leaf-text fast path.
  */
 internal fun applyRevealOverlay(
     static: AnnotatedString,
+    ranges: List<AnnotatedString.Range<String>>,
     revealController: CharRevealController,
     baseColor: Color,
 ): AnnotatedString {
     if (baseColor == Color.Unspecified) return static
-    val ranges = static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
     if (ranges.isEmpty()) return static
     return buildAnnotatedString {
         append(static)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -1530,7 +1530,12 @@ internal fun AnnotatedString.Builder.appendMarkdownNodeContent(
             // trimmed/collapsed text falls through to a bulk append — the
             // reveal effect requires color modulation and a 1:1 offset
             // map, both of which fail in those cases.
-            val canFade = baseColor != Color.Unspecified && !trim && text == rawText
+            val canFade = shouldMarkLeafAsFadeEligible(
+                rawText = rawText,
+                text = text,
+                baseColor = baseColor,
+                trim = trim,
+            )
             if (canFade) {
                 pushStringAnnotation(REVEAL_LEAF_TAG, node.startOffset.toString())
                 append(text)
@@ -1732,6 +1737,36 @@ internal fun AnnotatedString.Builder.appendMarkdownNodeContent(
 }
 
 /**
+ * Decides whether the [LeafASTNode] arm of [appendMarkdownNodeContent]
+ * should mark this leaf with [REVEAL_LEAF_TAG]. Extracted so the rule
+ * can be pinned by [RevealOverlayParityTest] without going through the
+ * MarkdownParser, which doesn't reliably keep `<br>` inside a single
+ * TEXT leaf and therefore can't exercise the `text == rawText` clause
+ * via end-to-end parsing.
+ *
+ * Three gates, all must pass:
+ *  - [baseColor] is not [Color.Unspecified]: the reveal effect modulates
+ *    foreground color; without a baseColor there's nothing to modulate.
+ *  - [trim] is false: ATX heading children call with trim=true, which
+ *    runs `rawText.trim()` and breaks the static↔content offset map
+ *    the overlay relies on (the controller is in content-offset space).
+ *  - [text] equals [rawText]: when BREAK_LINE_REGEX rewrites `<br>` to
+ *    `\n` the lengths differ and offset alignment is similarly broken.
+ *
+ * Failing any gate falls through to a bulk append — no fade, no
+ * annotation. This is a small behavioral change from the pre-refactor
+ * code, which attempted fade with mis-aligned alphas in the trim /
+ * `<br>` cases; the misalignment was a latent bug that always produced
+ * the wrong char-to-alpha mapping. No-fade is the safer fallback.
+ */
+internal fun shouldMarkLeafAsFadeEligible(
+    rawText: String,
+    text: String,
+    baseColor: Color,
+    trim: Boolean,
+): Boolean = baseColor != Color.Unspecified && !trim && text == rawText
+
+/**
  * Frame-local alpha overlay for the static [AnnotatedString] produced by
  * [appendMarkdownNodeContent]. Caller passes the pre-cached
  * [REVEAL_LEAF_TAG] range list (caching avoids per-frame
@@ -1740,9 +1775,13 @@ internal fun AnnotatedString.Builder.appendMarkdownNodeContent(
  * [revealController] and layers a translucent color [SpanStyle] on top
  * of the existing styling.
  *
- * Cost is O(unrevealed codepoints across all leaves), bounded by
- * [CharRevealController]'s BACKLOG_DEGRADE (≈ 80). Skip-stable-prefix is
- * applied per leaf using [CharRevealController.stableOffsetExclusive].
+ * Cost: O(unrevealed codepoints across all marked leaves). In practice
+ * this stays small because (a) the per-leaf stable-prefix shortcut
+ * skips chars whose absolute offset is below
+ * [CharRevealController.stableOffsetExclusive], so only chars inside
+ * the active fade window contribute, and (b) the reveal queue itself
+ * is degraded to instant-promote once it crosses [CharRevealController]'s
+ * BACKLOG_DEGRADE entry count, draining unrevealed codepoints quickly.
  *
  * Returns [static] unchanged when there's no usable [baseColor] or
  * [ranges] is empty — preserves Color.Unspecified parity with the

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
@@ -14,6 +14,7 @@ import org.intellij.markdown.ast.LeafASTNode
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.parser.MarkdownParser
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -111,11 +112,13 @@ class RevealOverlayParityTest {
 
     @Test
     fun overlay_skips_at_stable_offset_equal_to_leaf_length() {
-        // Boundary: stableRel == rangeLen → early-out path. Distinct from
-        // "fully drained" because here the queue might still have entries
-        // for OTHER leaves, but THIS leaf's stableHead just reached its
-        // end. Lock the early-return so a future off-by-one (`>` vs `>=`)
-        // can't sneak back in.
+        // Boundary: stableRel == rangeLen → early-out. Locks the
+        // `stableRel >= rangeLen` clause against a future off-by-one
+        // (`>` instead of `>=`). With a single-leaf static the
+        // "queue drained" and "this leaf's stableHead reached its
+        // end" cases collapse to the same code path; the test
+        // exercises the early-return but doesn't isolate it from
+        // drain. Sufficient for the off-by-one regression risk.
         val content = "hi"
         val static = buildAnnotatedString {
             pushStringAnnotation(REVEAL_LEAF_TAG, "0")
@@ -383,6 +386,39 @@ class RevealOverlayParityTest {
                 "align with the static positions after .trim() modifies the string",
             0,
             annotations.size,
+        )
+    }
+
+    @Test
+    fun shouldMarkLeaf_false_when_text_differs_from_rawText() {
+        // BREAK_LINE_REGEX rewrites `<br>` → `\n` inside the LeafASTNode
+        // arm. When that fires, `text != rawText` and the offset map
+        // breaks. The end-to-end MarkdownParser path can't reach this
+        // case reliably (GFM may not preserve `<br>` inside a single
+        // TEXT leaf), so pin it via the extracted helper.
+        assertFalse(
+            "Leaf with text != rawText (BREAK_LINE_REGEX collision) must not be " +
+                "marked — alpha offsets would misalign with content positions",
+            shouldMarkLeafAsFadeEligible(
+                rawText = "a<br>b",
+                text = "a\nb",
+                baseColor = baseColor,
+                trim = false,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldMarkLeaf_true_when_all_gates_pass() {
+        // Symmetric positive case for the helper: identical rawText/text,
+        // trim=false, valid baseColor → marking allowed.
+        assertTrue(
+            shouldMarkLeafAsFadeEligible(
+                rawText = "hello",
+                text = "hello",
+                baseColor = baseColor,
+                trim = false,
+            ),
         )
     }
 

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
@@ -1,11 +1,18 @@
 package me.rerere.rikkahub.ui.components.richtext
 
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.Density
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.LeafASTNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -31,11 +38,14 @@ import org.junit.Test
  *     (bold / italic / etc.) survive intact via [buildAnnotatedString]'s
  *     append-AnnotatedString copy.
  *
- * These tests don't go through MarkdownParser — they hand-craft the
- * static AnnotatedString with [REVEAL_LEAF_TAG] annotations so the
- * unit under test is the overlay layer in isolation. The end-to-end
- * "static build emits the right annotations" path is verified by
- * device dogfood, not here.
+ * The first group of tests hand-crafts the static AnnotatedString
+ * with [REVEAL_LEAF_TAG] annotations so the overlay's logic is the
+ * unit under test in isolation. The "static marking" tests at the
+ * bottom go end-to-end through [appendMarkdownNodeContent] with a
+ * MarkdownParser-built [LeafASTNode] to lock the static side's
+ * decision (trim'd headings, BREAK_LINE_REGEX-collapsed text, and
+ * Color.Unspecified baseColor must NOT emit the annotation; ordinary
+ * paragraph leaves MUST).
  */
 class RevealOverlayParityTest {
 
@@ -47,6 +57,9 @@ class RevealOverlayParityTest {
         c.onContentChanged(content)
         return c
     }
+
+    private fun rangesOf(static: AnnotatedString): List<AnnotatedString.Range<String>> =
+        static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
 
     // ──────────────────────────────────────────────────────────────
     // Fast-path: no alpha layering should happen
@@ -63,7 +76,7 @@ class RevealOverlayParityTest {
         // baseColor Unspecified means there's no color to modulate — the
         // pre-refactor leaf-text branch also fell straight through to
         // `append(text)` in that case (Markdown.kt LeafASTNode arm).
-        assertSame(static, applyRevealOverlay(static, c, Color.Unspecified))
+        assertSame(static, applyRevealOverlay(static, rangesOf(static), c, Color.Unspecified))
     }
 
     @Test
@@ -71,7 +84,7 @@ class RevealOverlayParityTest {
         val static = buildAnnotatedString { append("hello world") }
         val c = controllerFor("hello world")
         // No fade-eligible leaves marked — overlay has nothing to do.
-        assertSame(static, applyRevealOverlay(static, c, baseColor))
+        assertSame(static, applyRevealOverlay(static, rangesOf(static), c, baseColor))
     }
 
     @Test
@@ -87,13 +100,35 @@ class RevealOverlayParityTest {
         // queue (stableOffsetExclusive == contentLength). The overlay
         // should detect this and skip per-codepoint work.
         c.onFrame(System.nanoTime() + 10 * revealDurationNanos)
-        val result = applyRevealOverlay(static, c, baseColor)
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         // After drain, no alpha SpanStyles are added — observable proof
         // is the result has the same text and no extra spans beyond
         // whatever the static already had.
         assertEquals(static.text, result.text)
         // static had zero SpanStyles; result should too.
         assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun overlay_skips_at_stable_offset_equal_to_leaf_length() {
+        // Boundary: stableRel == rangeLen → early-out path. Distinct from
+        // "fully drained" because here the queue might still have entries
+        // for OTHER leaves, but THIS leaf's stableHead just reached its
+        // end. Lock the early-return so a future off-by-one (`>` vs `>=`)
+        // can't sneak back in.
+        val content = "hi"
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append(content)
+            pop()
+        }
+        val c = controllerFor(content)
+        c.onFrame(System.nanoTime() + 10 * revealDurationNanos)
+        // stableOffsetExclusive should equal content length (= range end).
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
+        // Skip path: zero alpha spans added.
+        assertEquals(0, result.spanStyles.size)
+        assertEquals(static.text, result.text)
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -113,7 +148,7 @@ class RevealOverlayParityTest {
         // every entry's age is well below revealDurationNanos. Result:
         // queue full, stableOffsetExclusive == 0, every char unrevealed.
         c.onFrame(System.nanoTime())
-        val result = applyRevealOverlay(static, c, baseColor)
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         // At least one codepoint must have alpha < 1 styled on top.
         assertTrue(
             "Expected alpha SpanStyles for unrevealed chars; found none",
@@ -139,7 +174,7 @@ class RevealOverlayParityTest {
         // Drain so no alpha overlay is added — we only want to verify
         // that the append-AnnotatedString copy preserves the bold span.
         c.onFrame(System.nanoTime() + 10 * revealDurationNanos)
-        val result = applyRevealOverlay(static, c, baseColor)
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         assertEquals(static.text, result.text)
         // Bold span should still be present after the no-op overlay.
         assertTrue(
@@ -163,7 +198,7 @@ class RevealOverlayParityTest {
         }
         val c = controllerFor("hello world")
         c.onFrame(System.nanoTime())  // all unrevealed
-        val result = applyRevealOverlay(static, c, baseColor)
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         assertEquals(static.text, result.text)
         // Both leaves should have contributed alpha spans (proves overlay
         // processed each range, not just the first).
@@ -186,6 +221,36 @@ class RevealOverlayParityTest {
     }
 
     @Test
+    fun overlay_aligns_with_non_zero_range_start() {
+        // The annotated range doesn't begin at static position 0 — there's
+        // prefix text first. Lock that the codepoint walk starts at
+        // `range.start + stableRel`, not from 0.
+        val content = "prefix body"
+        val static = buildAnnotatedString {
+            append("prefix ")  // unmarked filler
+            pushStringAnnotation(REVEAL_LEAF_TAG, "7")  // body starts at source 7
+            append("body")
+            pop()
+        }
+        val c = controllerFor(content)
+        c.onFrame(System.nanoTime())  // unrevealed
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
+        val alphaSpans = result.spanStyles.filter { span ->
+            span.item.color != Color.Unspecified && span.item.color.alpha < 1f
+        }
+        // All alpha spans must land in [7..11) — the annotated range —
+        // not anywhere in the unmarked prefix [0..7).
+        assertTrue(
+            "Expected alpha spans only inside annotated range [7..11); " +
+                "found at offsets ${alphaSpans.map { it.start }}",
+            alphaSpans.all { it.start in 7..10 }
+        )
+        // And there should be at least one (proves the body was actually
+        // processed, didn't just early-out).
+        assertTrue(alphaSpans.isNotEmpty())
+    }
+
+    @Test
     fun overlay_skips_leaf_with_unparseable_baseOffset() {
         val static = buildAnnotatedString {
             // Intentionally garbage value — overlay must defend.
@@ -195,7 +260,7 @@ class RevealOverlayParityTest {
         }
         val c = controllerFor("hello")
         c.onFrame(System.nanoTime())
-        val result = applyRevealOverlay(static, c, baseColor)
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         // Defensive skip: no alpha overlay added for the bad-value range.
         assertEquals(static.text, result.text)
         assertEquals(0, result.spanStyles.size)
@@ -213,19 +278,19 @@ class RevealOverlayParityTest {
         }
         val c = controllerFor(content)
         c.onFrame(System.nanoTime())
-        val result = applyRevealOverlay(static, c, baseColor)
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         assertEquals(static.text, result.text)
-        // The emoji's alpha span must cover [0..2) — the whole surrogate
-        // pair. If overlay walked by char (not codepoint), the second
+        // The emoji's alpha span must cover the WHOLE surrogate pair
+        // [0..2). If overlay walked by char (not codepoint), the second
         // surrogate at position 1 would get its own span starting at 1,
-        // and the first span would be [0..1). We assert no span starts
-        // at position 1 — the codepoint walk skipped to 2.
+        // and the first span would only span [0..1).
         val alphaSpans = result.spanStyles.filter { span ->
             span.item.color != Color.Unspecified && span.item.color.alpha < 1f
         }
         assertTrue(
-            "No alpha span starts at the emoji position 0",
-            alphaSpans.any { it.start == 0 }
+            "Emoji span at position 0 must span the full surrogate pair " +
+                "(start=0, end=2); found spans: ${alphaSpans.map { it.start to it.end }}",
+            alphaSpans.any { it.start == 0 && it.end == 2 }
         )
         assertTrue(
             "Unexpected alpha span starts at position 1 — overlay walked by " +
@@ -248,6 +313,90 @@ class RevealOverlayParityTest {
         }
         val c = controllerFor("hello")
         c.onFrame(System.nanoTime())
-        assertSame(static, applyRevealOverlay(static, c, baseColor))
+        assertSame(static, applyRevealOverlay(static, rangesOf(static), c, baseColor))
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Static-side: appendMarkdownNodeContent must NOT mark trim'd
+    // leaves or Color.Unspecified leaves. Locks the silent behavioral
+    // change documented in the commit (trim/BREAK_LINE_REGEX leaves
+    // now show no fade, vs. the old code's misaligned-alpha fade).
+    // ──────────────────────────────────────────────────────────────
+
+    private fun firstLeaf(content: String): LeafASTNode {
+        val root: ASTNode =
+            MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(content)
+        fun walk(node: ASTNode): LeafASTNode? {
+            if (node is LeafASTNode) return node
+            return node.children.firstNotNullOfOrNull { walk(it) }
+        }
+        return walk(root) ?: error("no LeafASTNode found in parse of: $content")
+    }
+
+    private fun buildStaticFor(
+        leaf: LeafASTNode,
+        content: String,
+        trim: Boolean,
+        baseColor: Color,
+    ): AnnotatedString = buildAnnotatedString {
+        appendMarkdownNodeContent(
+            node = leaf,
+            content = content,
+            trim = trim,
+            inlineContents = mutableMapOf(),
+            colorScheme = lightColorScheme(),
+            density = Density(1f, 1f),
+            style = TextStyle(),
+            baseColor = baseColor,
+        )
+    }
+
+    @Test
+    fun static_marks_ordinary_leaf_with_REVEAL_LEAF_TAG() {
+        val content = "hello"
+        val leaf = firstLeaf(content)
+        val static = buildStaticFor(leaf, content, trim = false, baseColor = baseColor)
+        val annotations = static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
+        assertEquals(
+            "Ordinary leaf with usable baseColor must be marked as fade-eligible",
+            1,
+            annotations.size,
+        )
+        assertEquals(
+            "Annotation value must be the leaf's source startOffset",
+            leaf.startOffset.toString(),
+            annotations[0].item,
+        )
+    }
+
+    @Test
+    fun static_does_not_mark_trim_leaf() {
+        // trim=true is set only by the ATX_HEADER branch in Markdown.kt.
+        // We invoke the function directly with trim=true to pin its
+        // contribution to canFade in the LeafASTNode arm.
+        val content = "hello"
+        val leaf = firstLeaf(content)
+        val static = buildStaticFor(leaf, content, trim = true, baseColor = baseColor)
+        val annotations = static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
+        assertEquals(
+            "trim=true leaves must not be marked — their source offset cannot " +
+                "align with the static positions after .trim() modifies the string",
+            0,
+            annotations.size,
+        )
+    }
+
+    @Test
+    fun static_does_not_mark_leaf_when_baseColor_unspecified() {
+        val content = "hello"
+        val leaf = firstLeaf(content)
+        val static = buildStaticFor(leaf, content, trim = false, baseColor = Color.Unspecified)
+        val annotations = static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
+        assertEquals(
+            "Color.Unspecified means there's no color to alpha-modulate; " +
+                "marking would just waste an annotation slot",
+            0,
+            annotations.size,
+        )
     }
 }

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.util.fastForEach
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.LeafASTNode
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
@@ -272,8 +273,24 @@ class RevealOverlayParityTest {
     @Test
     fun overlay_handles_surrogate_pair_emoji() {
         // U+1F600 (😀) is a surrogate pair: 2 Java chars, 1 codepoint.
-        // The codepoint walk must advance by 2 chars per emoji, not 1.
-        val content = "😀 hi"  // "😀 hi" — 5 Java chars, 4 codepoints
+        // The codepoint walk must advance by 2 chars per emoji, not 1 —
+        // otherwise it would land on the dangling low-surrogate at
+        // position 1 and emit a span starting there.
+        //
+        // Note: post-batching, adjacent codepoints in the same reveal
+        // entry / chunk share alpha and collapse to a single span, so
+        // we can't isolate the emoji's exact end boundary from spans
+        // alone — that would require interleaving different alphas
+        // across the surrogate boundary, which requires multi-chunk
+        // setup that doesn't compose well with the controller's
+        // System.nanoTime-based stamping. The observable invariant we
+        // CAN check is "no span starts at position 1" — a buggy
+        // char-walk would produce one there (high-surrogate alpha at
+        // 0, low-surrogate alpha at 1) regardless of batching, because
+        // surrogate-half codepoints are distinct (Character.codePointAt
+        // at offset 1 returns U+DE00 — the low surrogate as a standalone
+        // codepoint).
+        val content = "😀 hi"  // 5 Java chars, 4 codepoints
         val static = buildAnnotatedString {
             pushStringAnnotation(REVEAL_LEAF_TAG, "0")
             append(content)
@@ -283,18 +300,19 @@ class RevealOverlayParityTest {
         c.onFrame(System.nanoTime())
         val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
         assertEquals(static.text, result.text)
-        // The emoji's alpha span must cover the WHOLE surrogate pair
-        // [0..2). If overlay walked by char (not codepoint), the second
-        // surrogate at position 1 would get its own span starting at 1,
-        // and the first span would only span [0..1).
         val alphaSpans = result.spanStyles.filter { span ->
             span.item.color != Color.Unspecified && span.item.color.alpha < 1f
         }
+        // Some span must cover the emoji at position 0 (proves the walk
+        // didn't bail out before reaching it).
         assertTrue(
-            "Emoji span at position 0 must span the full surrogate pair " +
-                "(start=0, end=2); found spans: ${alphaSpans.map { it.start to it.end }}",
-            alphaSpans.any { it.start == 0 && it.end == 2 }
+            "Expected at least one alpha span starting at position 0 covering " +
+                "the emoji; found spans: ${alphaSpans.map { it.start to it.end }}",
+            alphaSpans.any { it.start == 0 && it.end >= 2 }
         )
+        // Critical: no span starts at position 1. A buggy char-walk
+        // (i++) would process the low surrogate at position 1 as its
+        // own codepoint and emit a span there.
         assertTrue(
             "Unexpected alpha span starts at position 1 — overlay walked by " +
                 "Java char instead of codepoint, splitting the surrogate pair",
@@ -434,5 +452,87 @@ class RevealOverlayParityTest {
             0,
             annotations.size,
         )
+    }
+
+    @Test
+    fun static_marks_both_leaves_inside_strong_wrapping() {
+        // Locks the STRONG-recurse-threads-baseColor-correctly invariant:
+        // if a future refactor drops baseColor from the recursive call
+        // (compiles clean, parses fine, just silently disables fade for
+        // bold/italic text mid-stream), this test goes red. End-to-end
+        // through MarkdownParser to exercise the actual recursive arm.
+        val content = "**bold** plain"
+        val root: ASTNode =
+            MarkdownParser(GFMFlavourDescriptor()).buildMarkdownTreeFromString(content)
+        // Find the PARAGRAPH and build the static from its children
+        // (mirrors what Paragraph composable does).
+        fun findParagraph(n: ASTNode): ASTNode? {
+            if (n.type.name == "PARAGRAPH") return n
+            return n.children.firstNotNullOfOrNull { findParagraph(it) }
+        }
+        val paragraph = findParagraph(root) ?: error("paragraph not found")
+        val static = buildAnnotatedString {
+            paragraph.children.fastForEach { child ->
+                appendMarkdownNodeContent(
+                    node = child,
+                    content = content,
+                    trim = false,
+                    inlineContents = mutableMapOf(),
+                    colorScheme = lightColorScheme(),
+                    density = Density(1f, 1f),
+                    style = TextStyle(),
+                    baseColor = baseColor,
+                )
+            }
+        }
+        val annotations = static.getStringAnnotations(REVEAL_LEAF_TAG, 0, static.length)
+        // Both the leaf inside the STRONG wrap AND the plain leaf after
+        // it must be marked. If the STRONG recursion drops baseColor or
+        // somehow skips the leaf arm, the bold leaf's annotation goes
+        // missing.
+        assertTrue(
+            "Expected at least 2 REVEAL_LEAF_TAG annotations (one for the " +
+                "leaf inside STRONG, one for the plain text after); got " +
+                "${annotations.size} at offsets ${annotations.map { it.item }}",
+            annotations.size >= 2,
+        )
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Batching: same-alpha codepoints collapse to one SpanStyle
+    // ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun overlay_batches_adjacent_same_alpha_codepoints() {
+        // CharRevealController slices its queue by word/CJK/whitespace
+        // entry. Inside one word entry, every codepoint returns the SAME
+        // alpha from alphaAt() (per CharReveal.kt's alphaAt formula —
+        // age and duration are entry-level fields). applyRevealOverlay
+        // batches by alpha-equal run to avoid N×addStyle when one would do.
+        // Lock the savings: a single contiguous word's worth of unrevealed
+        // codepoints should produce ONE alpha SpanStyle, not N.
+        val content = "hello"  // one word, slices into one entry of length 5
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append(content)
+            pop()
+        }
+        val c = controllerFor(content)
+        c.onFrame(System.nanoTime())  // entry queued, age ~0 → alpha 0+
+        val result = applyRevealOverlay(static, rangesOf(static), c, baseColor)
+        val alphaSpans = result.spanStyles.filter { span ->
+            span.item.color != Color.Unspecified && span.item.color.alpha < 1f
+        }
+        assertEquals(
+            "Five codepoints in one reveal entry must collapse to a single " +
+                "alpha SpanStyle; found ${alphaSpans.size} spans at " +
+                "${alphaSpans.map { it.start to it.end }}",
+            1,
+            alphaSpans.size,
+        )
+        // And the single span must cover the whole word [0..5).
+        val span = alphaSpans.single()
+        assertEquals(0, span.start)
+        assertEquals(5, span.end)
     }
 }

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/RevealOverlayParityTest.kt
@@ -1,0 +1,253 @@
+package me.rerere.rikkahub.ui.components.richtext
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [applyRevealOverlay]'s observable contract — what the
+ * per-frame reveal layer adds on top of the static AnnotatedString
+ * built by [appendMarkdownNodeContent]. Two correctness goals:
+ *
+ *  1. **Fast-path parity**: when there's nothing to fade (no
+ *     annotations, no usable baseColor, or every leaf is already
+ *     past the controller's stable head), the overlay returns the
+ *     input AnnotatedString unchanged. Critical for finalized
+ *     messages and the post-reveal idle window — see
+ *     [CharRevealController.onFrame]'s idle short-circuit at the
+ *     top of CharReveal.kt.
+ *
+ *  2. **Overlay correctness**: when a leaf is mid-fade, the
+ *     overlay adds per-codepoint SpanStyles with the alpha-modulated
+ *     baseColor on the *unrevealed* tail of that leaf, leaving the
+ *     stable prefix untouched. The static's pre-existing SpanStyles
+ *     (bold / italic / etc.) survive intact via [buildAnnotatedString]'s
+ *     append-AnnotatedString copy.
+ *
+ * These tests don't go through MarkdownParser — they hand-craft the
+ * static AnnotatedString with [REVEAL_LEAF_TAG] annotations so the
+ * unit under test is the overlay layer in isolation. The end-to-end
+ * "static build emits the right annotations" path is verified by
+ * device dogfood, not here.
+ */
+class RevealOverlayParityTest {
+
+    private val baseColor = Color(0xFF000000)
+    private val revealDurationNanos = 100_000_000L  // 100ms
+
+    private fun controllerFor(content: String): CharRevealController {
+        val c = CharRevealController(revealDurationNanos = revealDurationNanos)
+        c.onContentChanged(content)
+        return c
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Fast-path: no alpha layering should happen
+    // ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun overlay_returns_same_when_baseColor_unspecified() {
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append("hello world")
+            pop()
+        }
+        val c = controllerFor("hello world")
+        // baseColor Unspecified means there's no color to modulate — the
+        // pre-refactor leaf-text branch also fell straight through to
+        // `append(text)` in that case (Markdown.kt LeafASTNode arm).
+        assertSame(static, applyRevealOverlay(static, c, Color.Unspecified))
+    }
+
+    @Test
+    fun overlay_returns_same_when_no_annotations() {
+        val static = buildAnnotatedString { append("hello world") }
+        val c = controllerFor("hello world")
+        // No fade-eligible leaves marked — overlay has nothing to do.
+        assertSame(static, applyRevealOverlay(static, c, baseColor))
+    }
+
+    @Test
+    fun overlay_returns_same_when_all_leaves_revealed() {
+        val content = "hello world"
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append(content)
+            pop()
+        }
+        val c = controllerFor(content)
+        // Advance well past revealDurationNanos so onFrame drains the
+        // queue (stableOffsetExclusive == contentLength). The overlay
+        // should detect this and skip per-codepoint work.
+        c.onFrame(System.nanoTime() + 10 * revealDurationNanos)
+        val result = applyRevealOverlay(static, c, baseColor)
+        // After drain, no alpha SpanStyles are added — observable proof
+        // is the result has the same text and no extra spans beyond
+        // whatever the static already had.
+        assertEquals(static.text, result.text)
+        // static had zero SpanStyles; result should too.
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Overlay correctness: chars in the fade window get alpha spans
+    // ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun overlay_adds_alpha_spans_for_unrevealed_chars() {
+        val content = "hello world"
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append(content)
+            pop()
+        }
+        val c = controllerFor(content)
+        // Call onFrame with a timestamp barely after contentChanged so
+        // every entry's age is well below revealDurationNanos. Result:
+        // queue full, stableOffsetExclusive == 0, every char unrevealed.
+        c.onFrame(System.nanoTime())
+        val result = applyRevealOverlay(static, c, baseColor)
+        // At least one codepoint must have alpha < 1 styled on top.
+        assertTrue(
+            "Expected alpha SpanStyles for unrevealed chars; found none",
+            result.spanStyles.any { span ->
+                span.item.color != Color.Unspecified && span.item.color.alpha < 1f
+            }
+        )
+        // Text content is preserved by buildAnnotatedString { append(static); ... }
+        assertEquals(static.text, result.text)
+    }
+
+    @Test
+    fun overlay_preserves_existing_static_spans() {
+        val content = "bold text"
+        val static = buildAnnotatedString {
+            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+                append(content)
+                pop()
+            }
+        }
+        val c = controllerFor(content)
+        // Drain so no alpha overlay is added — we only want to verify
+        // that the append-AnnotatedString copy preserves the bold span.
+        c.onFrame(System.nanoTime() + 10 * revealDurationNanos)
+        val result = applyRevealOverlay(static, c, baseColor)
+        assertEquals(static.text, result.text)
+        // Bold span should still be present after the no-op overlay.
+        assertTrue(
+            "Bold SpanStyle was lost across overlay copy",
+            result.spanStyles.any { it.item.fontWeight == FontWeight.Bold }
+        )
+    }
+
+    @Test
+    fun overlay_processes_multiple_leaves_independently() {
+        // Two separate fade-eligible leaves at different baseOffsets.
+        // First leaf: source offset 0, static positions [0..5)
+        // Second leaf: source offset 6, static positions [5..11)
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append("hello")
+            pop()
+            pushStringAnnotation(REVEAL_LEAF_TAG, "6")
+            append(" world")
+            pop()
+        }
+        val c = controllerFor("hello world")
+        c.onFrame(System.nanoTime())  // all unrevealed
+        val result = applyRevealOverlay(static, c, baseColor)
+        assertEquals(static.text, result.text)
+        // Both leaves should have contributed alpha spans (proves overlay
+        // processed each range, not just the first).
+        val alphaSpans = result.spanStyles.filter { span ->
+            span.item.color != Color.Unspecified && span.item.color.alpha < 1f
+        }
+        assertTrue(
+            "Expected alpha spans from both leaves; found ${alphaSpans.size} total",
+            alphaSpans.size >= 2
+        )
+        // At least one span should be in each leaf's static range.
+        assertTrue(
+            "No alpha span in first leaf range [0..5)",
+            alphaSpans.any { it.start in 0..4 }
+        )
+        assertTrue(
+            "No alpha span in second leaf range [5..11)",
+            alphaSpans.any { it.start in 5..10 }
+        )
+    }
+
+    @Test
+    fun overlay_skips_leaf_with_unparseable_baseOffset() {
+        val static = buildAnnotatedString {
+            // Intentionally garbage value — overlay must defend.
+            pushStringAnnotation(REVEAL_LEAF_TAG, "not-an-int")
+            append("hello")
+            pop()
+        }
+        val c = controllerFor("hello")
+        c.onFrame(System.nanoTime())
+        val result = applyRevealOverlay(static, c, baseColor)
+        // Defensive skip: no alpha overlay added for the bad-value range.
+        assertEquals(static.text, result.text)
+        assertEquals(0, result.spanStyles.size)
+    }
+
+    @Test
+    fun overlay_handles_surrogate_pair_emoji() {
+        // U+1F600 (😀) is a surrogate pair: 2 Java chars, 1 codepoint.
+        // The codepoint walk must advance by 2 chars per emoji, not 1.
+        val content = "😀 hi"  // "😀 hi" — 5 Java chars, 4 codepoints
+        val static = buildAnnotatedString {
+            pushStringAnnotation(REVEAL_LEAF_TAG, "0")
+            append(content)
+            pop()
+        }
+        val c = controllerFor(content)
+        c.onFrame(System.nanoTime())
+        val result = applyRevealOverlay(static, c, baseColor)
+        assertEquals(static.text, result.text)
+        // The emoji's alpha span must cover [0..2) — the whole surrogate
+        // pair. If overlay walked by char (not codepoint), the second
+        // surrogate at position 1 would get its own span starting at 1,
+        // and the first span would be [0..1). We assert no span starts
+        // at position 1 — the codepoint walk skipped to 2.
+        val alphaSpans = result.spanStyles.filter { span ->
+            span.item.color != Color.Unspecified && span.item.color.alpha < 1f
+        }
+        assertTrue(
+            "No alpha span starts at the emoji position 0",
+            alphaSpans.any { it.start == 0 }
+        )
+        assertTrue(
+            "Unexpected alpha span starts at position 1 — overlay walked by " +
+                "Java char instead of codepoint, splitting the surrogate pair",
+            alphaSpans.none { it.start == 1 }
+        )
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Annotation marking shape — pins how the static side maps to overlay
+    // ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun overlay_reads_annotations_via_REVEAL_LEAF_TAG() {
+        // Wrong tag — overlay must ignore it.
+        val static = buildAnnotatedString {
+            pushStringAnnotation("some.other.tag", "0")
+            append("hello")
+            pop()
+        }
+        val c = controllerFor("hello")
+        c.onFrame(System.nanoTime())
+        assertSame(static, applyRevealOverlay(static, c, baseColor))
+    }
+}


### PR DESCRIPTION
## Summary

Fix scroll jank during active streaming + concurrent tool calls. Previously the `Paragraph` composable in `Markdown.kt` rebuilt the whole markdown AST tree's AnnotatedString every frame (60 Hz) while a `CharRevealController` had active reveal entries — the `remember(...)` key included `revealClock = controller.nowNanos` which updates every frame. Walking the AST + per-leaf `withStyle`/`append` cost 3-10 ms/frame on long paragraphs, contending with LazyColumn measure/layout when the user scrolled history during streaming.

Splits the work into two layers:

- **`staticAnnotated`** — built only when (content, AST, theme) changes. The LeafASTNode arm in `appendMarkdownNodeContent` now marks fade-eligible leaves with a `REVEAL_LEAF_TAG` string annotation carrying the leaf's absolute source startOffset, instead of running the per-codepoint alpha loop at static-build time. The `revealController` parameter is dropped from the function signature (and all 5 recursive call sites) since alpha computation is no longer the static path's concern.
- **`annotatedString`** — a second `remember(...)` keyed on `(staticAnnotated, revealRanges, revealClock, baseColor)`. When the controller has active reveals, `applyRevealOverlay` walks just the cached `REVEAL_LEAF_TAG` ranges' unrevealed codepoints (bounded by `CharRevealController.BACKLOG_DEGRADE = 80`) and layers translucent `SpanStyle`s on top via `buildAnnotatedString { append(static); ... }`. Per-frame `addStyle` calls batch by alpha-equal runs — since every codepoint inside a reveal entry shares the same alpha from `alphaAt()`, an N-char word produces one `addStyle` instead of N. Otherwise passes `staticAnnotated` through unchanged. `CharReveal.kt`'s existing idle-short-circuit already keeps `nowNanos` frozen when the queue is empty, so finalized paragraphs continue to skip per-frame invalidation entirely.

Behavioral parity preserved: link / autolink / code-span / inline-math content never went through the LeafASTNode arm (they extract text directly without recursing), so they were never reveal-faded in the old code either. trim'd and BREAK_LINE_REGEX-modified text falls through to bulk append unmarked — the old code's reveal effect on those was already misaligned because static positions diverged from source content offsets, so preserved as no-fade rather than slightly-wrong fade.

5 rounds of sub-agent review converged P3+ to zero. 18 unit tests in `RevealOverlayParityTest` pin: fast-path returns (Color.Unspecified / no annotations / fully drained), overlay correctness (alpha spans on unrevealed chars only, existing spans preserved), multi-leaf processing, non-zero range.start, defensive unparseable-baseOffset skip, surrogate-pair codepoint walk, REVEAL_LEAF_TAG filter, alpha-run batching, end-to-end static-side decisions for ordinary / trim / unspecified-baseColor / break-line-regex / nested STRONG cases.

Stage 3 (drawWithCache canvas-level alpha mask) is the conditional follow-up if device measurement shows Stage 2 still leaves P95 > 16 ms. Not in this PR.

## Test plan

- [x] \`./gradlew :app:compileNotionKotlin\` — clean
- [x] \`./gradlew :app:testDebugUnitTest --tests 'me.rerere.rikkahub.ui.components.richtext.*'\` — 18/18 RevealOverlayParityTest + 2/2 MarkdownTableTest green
- [x] \`./gradlew :app:assembleNotion\` — APK builds, installed to device for dogfood
- [ ] Dogfood: confirm scroll-during-streaming jank is reduced vs the gfxinfo baseline (P95 = 28 ms, 28% janky frames cumulative)
- [ ] Decide whether Stage 3 (canvas mask) is needed based on post-Stage-2 measurements