### PR TITLE
feat(chat): V3 UI refactor — 4-theme + ResponseAPI fix + image-gen fallback

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/ProviderSetting.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/ProviderSetting.kt
@@ -367,3 +367,33 @@ sealed class ProviderSetting {
         }
     }
 }
+
+/**
+ * Provider 是否拥有可用 auth (API key / OAuth token / service account).
+ * Picker (model 选择 UI) 和 data-layer fallback (getCurrentImageGenerationModel)
+ * 都用同一份判定, 避免 fallback 兜底到一个 picker 看不到的"无 key 模型".
+ *
+ * 之前住在 UI 层 ModelList.kt:1054 — Codex review 指出 data 层 fallback 漏掉
+ * 这条 check 会把 seed 的 gpt-image-2 暴露给没配 key 的用户, 401 fail. 提到 ai
+ * 模块同包, 两层共用.
+ */
+fun ProviderSetting.hasUsableAuth(): Boolean {
+    if (!enabled) return false
+    return when (this) {
+        is ProviderSetting.OpenAI -> when (authMode) {
+            // OAuth 模式用单独 token, 不依赖用户填的 apiKey
+            OpenAIAuthMode.CODEX_OAUTH -> true
+            else -> apiKey.isNotBlank()
+        }
+        is ProviderSetting.Google -> when (authMode) {
+            GoogleAuthMode.GEMINI_CODE_ASSIST_OAUTH -> true
+            GoogleAuthMode.API_KEY -> when {
+                apiKey.isNotBlank() -> true
+                // Vertex AI + service account 用 privateKey blob 而非 apiKey
+                vertexAI && useServiceAccount && privateKey.isNotBlank() -> true
+                else -> false
+            }
+        }
+        is ProviderSetting.Claude -> apiKey.isNotBlank()
+    }
+}

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -120,9 +120,43 @@ class ResponseAPI(
         messages: List<UIMessage>,
         params: TextGenerationParams
     ): Flow<MessageChunk> = callbackFlow {
+        // V3 fix: ResponseAPI 在 delta / done / completed 各事件构造的 UIMessage 都用 fresh
+        // Uuid.random(). MessageStreamAccumulator.replaceActive 会把 active 整个换掉 (parts
+        // 全替换为 message.parts), 导致两个问题:
+        //   1) 新 id → ChatService merge by-id 找不到 → APPEND orphan node → 用户看到双
+        //      message + 多行 action button
+        //   2) replaceActive 把 acc 累积的 parts 重置 → 内容"闪一下消失", 只剩 action row
+        // 解法 (2 步):
+        //   - id 标准化: 所有 emit chunk 的 ASSISTANT id 都用流 scope sharedId
+        //   - 阻止 replaceActive: 把 done/completed 的 message=...,delta=null 转成空 delta,
+        //     accumulator 走 append 路径 (no-op 因为 parts 是空), 保留已累积内容
+        val streamAssistantId = kotlin.uuid.Uuid.random()
+        fun MessageChunk.normalizeAssistantId(): MessageChunk = copy(
+            choices = choices.map { choice ->
+                val delta = choice.delta
+                val msg = choice.message
+                when {
+                    delta != null && delta.role == MessageRole.ASSISTANT ->
+                        choice.copy(delta = delta.copy(id = streamAssistantId))
+                    // ASSISTANT "done" / "completed" event (delta=null, message=完整文本):
+                    // 转成空 delta (parts=emptyList), 阻止 replaceActive 重置 active.
+                    // delta 累积已含完整文本, message 是冗余 finish marker.
+                    delta == null && msg != null && msg.role == MessageRole.ASSISTANT ->
+                        choice.copy(
+                            delta = UIMessage(
+                                id = streamAssistantId,
+                                role = MessageRole.ASSISTANT,
+                                parts = emptyList(),
+                            ),
+                            message = null,
+                        )
+                    else -> choice
+                }
+            }
+        )
         if (providerSetting.authMode == OpenAIAuthMode.CODEX_OAUTH) {
             streamCodexText(providerSetting, messages, params).collect { chunk ->
-                trySend(chunk)
+                trySend(chunk.normalizeAssistantId())
             }
             close()
             return@callbackFlow
@@ -162,7 +196,7 @@ class ResponseAPI(
                 val json = json.parseToJsonElement(data).jsonObject
                 val chunk = parseResponseDelta(json)
                 if (chunk != null) {
-                    trySend(chunk)
+                    trySend(chunk.normalizeAssistantId())
                 }
                 if (type == "response.completed") {
                     close()

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -9,7 +9,9 @@ import kotlinx.serialization.Transient
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelType
 import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.hasUsableAuth
 import me.rerere.ai.registry.ModelRegistry
 import me.rerere.rikkahub.data.ai.mcp.McpServerConfig
 import me.rerere.rikkahub.data.ai.prompts.DEFAULT_COMPRESS_PROMPT
@@ -349,6 +351,9 @@ data class DisplaySetting(
     val chatFontFamily: ChatFontFamily = ChatFontFamily.DEFAULT,
     val enableVolumeKeyScroll: Boolean = false,
     val volumeKeyScrollRatio: Float = 1.0f,
+    // V3 Phase 4.5：用户在设置里手选的浅色聊天主题（WHISPER / PLAIN / PAPER）。
+    // 深色模式下被 MIDNIGHT 强制覆盖，与此字段无关。
+    val chatThemeChoice: String = "WHISPER",
 )
 
 @Serializable
@@ -426,9 +431,36 @@ fun Settings.getCurrentChatModel(): Model? {
  * Resolve the image-generation model for the current assistant: per-assistant
  * override first, then global setting. Returns null when neither is set, in
  * which case the generate_image tool is not exposed to the main chat model.
+ *
+ * V3 修: 全局 imageGenerationModelId 是 non-null Uuid (默认 Uuid.random()), 用户从未设置时
+ * 落到一个永远查不到 model 的随机 id 上, 然后 generate_image 工具一律抛 "not configured".
+ * 同时 SettingModelPage 的 onClear 把它重置为 DEFAULT_AUTO_MODEL_ID (sentinel uuid).
+ * 这两种情形 (随机 init uuid / DEFAULT_AUTO_MODEL_ID) 都视为"未配置", 显式返回 null,
+ * 让 ImageGenTool 走兜底: 找第一个 IMAGE-type 模型, 否则才报错.
  */
 fun Settings.getCurrentImageGenerationModel(): Model? {
-    return findModelById(this.getCurrentAssistant().imageGenerationModelId ?: this.imageGenerationModelId)
+    // V3 review P3 #10: assistant override 与 global 都可能存 DEFAULT_AUTO_MODEL_ID sentinel
+    // ("自动"语义) 或 stale Uuid. 优先级 = assistant 有效 id > global 有效 id > 兜底 IMAGE model.
+    // 关键: resolveValid 必须 `type == IMAGE` 验证 — 用户在 picker 之外 (如手加 model 默认 CHAT)
+    // 选了 chat-type id 时不要返回, 让兜底找内置 IMAGE-type (如 Codex OAuth 自带的 image model).
+    // 这是用户报"deepseek/gpt5.5 都调不来 gpt-image-2"的根因 — 手加的 gpt-image-2 type=CHAT,
+    // 命中第一/二级 → 当成"已配置"返回 → 但调 image API 失败.
+    fun Uuid?.resolveValid(): Model? {
+        if (this == null || this == DEFAULT_AUTO_MODEL_ID) return null
+        return findModelById(this)?.takeIf { it.type == ModelType.IMAGE }
+    }
+    val assistantPick = this.getCurrentAssistant().imageGenerationModelId.resolveValid()
+    if (assistantPick != null) return assistantPick
+    val globalPick = this.imageGenerationModelId.resolveValid()
+    if (globalPick != null) return globalPick
+    // 兜底: 全局任一有可用 auth 的 provider 暴露的 IMAGE 类型模型. 跟 SettingModelPage
+    // picker 同一份 hasUsableAuth 判定 (Codex review P2 修复: 之前只看 enabled 会把
+    // seed 的 gpt-image-2 暴露给没配 OpenAI key 的 user, 触发 401).
+    return this.providers
+        .asSequence()
+        .filter { it.hasUsableAuth() }
+        .flatMap { it.models.asSequence() }
+        .firstOrNull { it.type == ModelType.IMAGE }
 }
 
 fun Settings.resolveTaskChatModel(modelId: Uuid): Model? {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -25,6 +26,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -56,6 +58,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -168,10 +171,10 @@ fun ChatInput(
     val coroutineScope = rememberCoroutineScope()
     val workspace = workspaceColors()
     val hazeTintColor = workspace.paper
-    // Plan B redesign: bumped from 8dp to 22dp so the composer reads as a
-    // "floating card" and the bottom corners no longer collide visually with
-    // phones that have a heavily rounded display edge.
-    val composerShape = RoundedCornerShape(22.dp)
+    // SendOrb 自身 76dp, 顶着 Row 实际高度 = max(60, 76) = 76dp.
+    // corner 38dp = 76/2 = 单行/空状态时完美半圆胶囊.
+    // 多行扩高 N>76dp 时, 38dp < N/2, 两端不再完美半圆 (长方圆角). 这正是用户要的.
+    val composerShape = RoundedCornerShape(38.dp)
     val useComposerBlur = settings.displaySetting.enableBlurEffect && !BuildConfig.NOTION_LIKE && !timelineScrolling
     val suggestionFillPulse = remember(conversation.id) { Animatable(0f) }
 
@@ -484,8 +487,11 @@ fun ChatInput(
                 // 22dp rounded corners clear of devices with aggressive screen
                 // rounding so the card never looks "bitten" at the bottom.
                 .padding(bottom = 6.dp)
-                .padding(horizontal = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                // 调整: composer 左右 8→12dp 离屏幕边线稍远一些 (不再"贴边")
+                .padding(horizontal = 12.dp),
+            // spacedBy 控制 SandboxPeekBar 与 composer pill 之间的间距。
+            // 设计稿是预览卡紧贴输入框，2dp 足够留一条 hair 缝
+            verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             sandboxActivity?.let { activity ->
                 SandboxPeekBar(
@@ -499,9 +505,11 @@ fun ChatInput(
             }
 
             val pulseFraction = suggestionFillPulse.value
+            // V3 review P3 #8: suggestion pulse 用 chatTheme.accent (跟 4 主题色协调)
+            val chatThemeForPulse = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
             val composerBorderColor = lerp(
                 start = workspace.hairline,
-                stop = workspace.blue.copy(alpha = 0.42f),
+                stop = chatThemeForPulse.accent.copy(alpha = 0.42f),
                 fraction = pulseFraction,
             )
             val composerContainerColor = if (useComposerBlur) {
@@ -509,14 +517,46 @@ fun ChatInput(
             } else {
                 lerp(
                     start = hazeTintColor,
-                    stop = workspace.blueContainer,
+                    stop = chatThemeForPulse.accentSoft,
                     fraction = pulseFraction * 0.22f,
                 )
             }
 
+            // V3 composer pill 阴影策略：
+            //   浅色主题 (Whisper/Plain/Paper)：Material shadow 12dp + chatTheme.composerShadow
+            //     的墨灰/暖棕投影，在浅底上"浮"出 pill 感
+            //   深色主题 (Midnight)：Material shadow ambient/spot 改 Color.Black 强制黑投影，
+            //     避免 default 白色 shadow 在 Midnight #0B0E14 上变成"白晕". border 调成顶轻底重
+            //     (5% 白 → 16% 白) 模拟 pill "落"在背景上 (下沉感) 而非顶部 rim light.
+            val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+            val composerFill = chatTheme.surface
+            val composerBorder: androidx.compose.ui.graphics.Brush = if (chatTheme.isDark) {
+                androidx.compose.ui.graphics.Brush.verticalGradient(
+                    listOf(
+                        Color(0x0DE8EAEF),  // 顶 ~5% 白 (细)
+                        Color(0x29E8EAEF),  // 底 ~16% 白 (粗) - 落地感
+                    )
+                )
+            } else {
+                androidx.compose.ui.graphics.SolidColor(chatTheme.surfaceEdge)
+            }
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
+                    // Bug fix: 之前 fixed height(68.dp) 把 TextField maxHeightInLines=5 给框死了,
+                    // 用户输入多行时被遮挡. 改 heightIn(min=60dp) 让 composer 跟随 TextField 高度扩展.
+                    // 60dp 比之前 68dp 略矮一些, 单行胶囊看着不那么"高大".
+                    .heightIn(min = 60.dp)
+                    .shadow(
+                        elevation = 12.dp,
+                        shape = composerShape,
+                        clip = false,
+                        // 深色模式下 ambient/spot 必须强制 Color.Black, 否则 default 白色 shadow
+                        // 在 Midnight 上扩散成"白晕"看着像反向高光. 浅色用 chatTheme.composerShadow
+                        // (墨灰/暖棕) 保持原效果.
+                        ambientColor = if (chatTheme.isDark) Color.Black else chatTheme.composerShadow,
+                        spotColor = if (chatTheme.isDark) Color.Black else chatTheme.composerShadow,
+                    )
                     .clip(composerShape)
                     .then(
                         if (useComposerBlur) Modifier.hazeEffect(
@@ -528,160 +568,114 @@ fun ChatInput(
                 shape = composerShape,
                 tonalElevation = 0.dp,
                 shadowElevation = 0.dp,
-                border = BorderStroke(1.dp, composerBorderColor),
-                color = composerContainerColor,
+                border = BorderStroke(1.dp, composerBorder),
+                color = if (useComposerBlur) Color.Transparent else composerFill,
             ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(7.dp)
+                Row(
+                    modifier = Modifier
+                        // Bug fix: fillMaxSize() 在 Surface heightIn(min=68dp) 无 max 约束时会
+                        // 反过来撑爆 Surface 到屏幕最大. 改 fillMaxWidth() 高度跟随子内容.
+                        .fillMaxWidth()
+                        // Bug fix: 用户反复反馈光标位置仍偏右. 继续压缩:
+                        //   Row start 12 → 8dp / Row spacedBy 4 → 0dp / TextField offset(-8dp)
+                        //   抵消 M3 TextField 内部 fixed 16dp content padding.
+                        // (TextField 用 absoluteOffset 视觉左移, 不影响布局尺寸, 不会跟旁边元素重叠.)
+                        .padding(start = 8.dp, end = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(0.dp),
                 ) {
-                    if (state.messageContent.isNotEmpty()) {
-                        MediaFileInputRow(state = state)
+                    Box(
+                        modifier = Modifier
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .clickable { expandToggle(ExpandState.Files) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = if (expand == ExpandState.Files) HugeIcons.Cancel01 else HugeIcons.Add01,
+                                contentDescription = stringResource(R.string.more_options),
+                                tint = workspace.ink,
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
                     }
+
+                    Box(
+                        modifier = Modifier
+                            .width(1.dp)
+                            .height(20.dp)
+                            .background(workspace.hairline),
+                    )
 
                     TextInputRow(
                         state = state,
                         onSendMessage = { sendMessage() },
                         onUsageClick = { showUsageSheet = true },
                         onCompactContext = onCompactContext,
+                        // 用 absoluteOffset 把 TextField 整体视觉左移 8dp, 抵消 M3 TextField
+                        // 不可直接修改的 16dp leading content padding. 不影响 layout 尺寸,
+                        // 故不会跟 / 按钮 / send orb 重叠.
+                        modifier = Modifier
+                            .weight(1f)
+                            .absoluteOffset(x = (-8).dp),
+                        minimalChrome = true,
+                        onUpdateAssistant = onUpdateAssistant,
                     )
 
-                    Row(
+                    // V3: 用 Text("/") 字符替代 Canvas line, 跟 SlashCommandLeadingMark
+                    // (TextField leadingIcon 内的 "/" 字符) 用同一字体, 两个斜杠角度一致.
+                    // toggle 语义: 仅在文本为空 / 已 "/" 开头 (即 panel 已显示) 时 toggle.
+                    // 用户已输普通文本时点击 = no-op, 避免吞掉/污染用户内容 (review P2 #1 修复).
+                    Box(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp),
-                        verticalAlignment = Alignment.Bottom,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(ComposerModelGroupHeight),
-                            contentAlignment = Alignment.BottomStart,
-                        ) {
-                            Column(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalArrangement = Arrangement.spacedBy(2.dp),
-                                horizontalAlignment = Alignment.Start,
-                            ) {
-                                ContextUsageIndicator(
-                                    conversation = conversation,
-                                    contextCompacts = contextCompacts,
-                                    compactLifecycleState = compactLifecycleState,
-                                    model = chatModel,
-                                    modifier = Modifier.padding(start = 3.dp),
-                                )
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalAlignment = Alignment.Bottom,
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                ) {
-                                    // Plan A core fix: weight(1f, fill=false) lets the
-                                    // model chip take whatever leftover width remains
-                                    // after the reasoning chip claims its natural size,
-                                    // so the reasoning chip is NEVER clipped — and long
-                                    // model names ellipsize via the chip's existing
-                                    // maxLines=1 + Ellipsis overflow rule.
-                                    ModelSelector(
-                                        modelId = assistant.chatModelId ?: settings.chatModelId,
-                                        providers = settings.providers,
-                                        onSelect = {
-                                            onUpdateChatModel(it)
-                                            dismissExpand()
-                                        },
-                                        type = ModelType.CHAT,
-                                        compact = true,
-                                        modifier = Modifier.weight(1f, fill = false),
-                                    )
-                                    ReasoningLevelChip(
-                                        reasoningLevel = assistant.reasoningLevel,
-                                        model = chatModel,
-                                        provider = chatProvider,
-                                        onUpdateReasoningLevel = {
-                                            onUpdateAssistant(assistant.copy(reasoningLevel = it))
-                                        },
-                                    )
-                                }
-                            }
-                        }
-
-                        ActionIconButton(
-                            onClick = {
-                                expandToggle(ExpandState.Files)
-                            },
-                            accent = expand == ExpandState.Files,
-                        ) {
-                            Icon(
-                                imageVector = if (expand == ExpandState.Files) HugeIcons.Cancel01 else HugeIcons.Add01,
-                                contentDescription = stringResource(R.string.more_options),
-                                modifier = Modifier.size(ComposerButtonIconSize),
-                            )
-                        }
-
-                        Box(
-                            contentAlignment = Alignment.Center,
-                            modifier = Modifier
-                                .size(ComposerButtonSize)
-                                .clip(RoundedCornerShape(8.dp))
-                                .combinedClickable(
-                                    enabled = loading || !state.isEmpty(),
-                                    onClick = {
-                                        dismissExpand()
-                                        sendMessage()
-                                    }, onLongClick = {
-                                        dismissExpand()
-                                        sendMessageWithoutAnswer()
+                            .size(32.dp)
+                            .clip(CircleShape)
+                            .clickable {
+                                val cur = state.textContent.text.toString()
+                                when {
+                                    cur.isEmpty() -> state.setMessageText("/")
+                                    cur == "/" -> state.setMessageText("")  // 仅 toggle 关闭
+                                    cur.startsWith("/") -> {
+                                        // 已 "/" 开头 + 有查询字符 → 收起 panel, 保留用户输入 (去 "/")
+                                        state.setMessageText(cur.removePrefix("/"))
                                     }
-                                )
-                        ) {
-                            val isQueueSend = loading && !state.isEmpty()
-                            // Pull empty state down to nearly-transparent + heavily-faded
-                            // icon so the send button visibly recedes when there is
-                            // nothing to send. Active states (blue when ready / blue
-                            // when queueing / amber when streaming) keep full
-                            // saturation, so the transition into "go" reads as a
-                            // distinct state change instead of a faint hairline tweak.
-                            val targetContainer = when {
-                                isQueueSend -> workspace.blue
-                                loading -> workspace.amberContainer
-                                state.isEmpty() -> Color.Transparent
-                                else -> workspace.blue
-                            }
-                            val targetContent = when {
-                                isQueueSend -> Color.White
-                                loading -> workspace.amber
-                                state.isEmpty() -> workspace.faint.copy(alpha = 0.55f)
-                                else -> Color.White
-                            }
-                            val targetBorder = if (state.isEmpty()) workspace.hairline else Color.Transparent
-                            val containerColor by animateColorAsState(targetContainer, label = "sendContainer")
-                            val contentColor by animateColorAsState(targetContent, label = "sendContent")
-                            val borderColor by animateColorAsState(targetBorder, label = "sendBorder")
-                            Surface(
-                                modifier = Modifier.fillMaxSize(),
-                                shape = RoundedCornerShape(8.dp),
-                                color = containerColor,
-                                border = BorderStroke(1.dp, borderColor),
-                                content = {})
-                            if (loading && state.isEmpty()) {
-                                KeepScreenOn()
-                                Icon(
-                                    imageVector = HugeIcons.Cancel01,
-                                    contentDescription = stringResource(R.string.stop),
-                                    tint = contentColor,
-                                    modifier = Modifier.size(ComposerButtonIconSize),
-                                )
-                            } else {
-                                Icon(
-                                    imageVector = HugeIcons.ArrowUp02,
-                                    contentDescription = stringResource(R.string.send),
-                                    tint = contentColor,
-                                    modifier = Modifier.size(ComposerButtonIconSize),
-                                )
-                            }
-                        }
+                                    // 用户已输普通文本 → no-op (避免污染)
+                                }
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        androidx.compose.material3.Text(
+                            text = "/",
+                            fontSize = 22.sp,
+                            color = workspace.muted,
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                        )
                     }
+
+                    if (loading && state.isEmpty()) {
+                        KeepScreenOn()
+                    }
+                    me.rerere.rikkahub.ui.pages.chat.SendOrb(
+                        isEmpty = state.isEmpty(),
+                        loading = loading,
+                        onClick = {
+                            dismissExpand()
+                            sendMessage()
+                        },
+                        onLongClick = {
+                            dismissExpand()
+                            sendMessageWithoutAnswer()
+                        },
+                    )
                 }
+            }
+
+            if (state.messageContent.isNotEmpty()) {
+                MediaFileInputRow(state = state)
             }
 
             // Expanded content
@@ -743,8 +737,9 @@ private fun ActionIconButton(
         shape = RoundedCornerShape(8.dp),
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
-        color = if (accent) workspace.blueContainer else workspace.paper,
-        contentColor = if (accent) workspace.blue else workspace.ink,
+        // V3 review P3 #8: action icon button 切 chatTheme.accent 跟主题
+        color = if (accent) me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accentSoft else workspace.paper,
+        contentColor = if (accent) me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent else workspace.ink,
         border = BorderStroke(1.dp, workspace.hairline),
     ) {
         Box(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputComposers.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputComposers.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,7 +33,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.rerere.hugeicons.HugeIcons
@@ -50,6 +54,7 @@ import me.rerere.hugeicons.stroke.FullScreen
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.agent.subagent.SubAgentMode
 import me.rerere.rikkahub.data.datastore.getCurrentAssistant
+import me.rerere.rikkahub.data.datastore.getCurrentChatModel
 import me.rerere.rikkahub.data.datastore.getQuickMessagesOfAssistant
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.files.SkillManager
@@ -94,6 +99,11 @@ internal fun TextInputRow(
     onSendMessage: () -> Unit,
     onUsageClick: () -> Unit,
     onCompactContext: () -> Unit,
+    modifier: Modifier = Modifier,
+    minimalChrome: Boolean = false,
+    // V3: SlashCommandPanel footer 需要 commit reasoningLevel 到当前 assistant.
+    // 为 null 时 (sandbox / 历史预览等场景) footer 不渲染. ChatInput 调用处必传.
+    onUpdateAssistant: ((me.rerere.rikkahub.data.model.Assistant) -> Unit)? = null,
 ) {
     val settings = LocalSettings.current
     val filesManager: FilesManager = koinInject()
@@ -120,10 +130,15 @@ internal fun TextInputRow(
     }
 
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        if (state.isEditing()) {
+        // V3: 删除"编辑中"小框 — 之前用 workspace.blueContainer/blue 硬编码蓝色 + 直接挤在 TextField
+        // 上方看着像"顶在输入框里". 用户编辑路径已经清晰 (长按 user 消息 → 编辑), 这个框冗余.
+        // 如果以后想恢复, 改 SHOW_EDITING_BANNER = true 即可.
+        @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+        val SHOW_EDITING_BANNER = false
+        if (SHOW_EDITING_BANNER && state.isEditing()) {
             Surface(
                 shape = RoundedCornerShape(6.dp),
                 color = workspace.blueContainer,
@@ -205,40 +220,86 @@ internal fun TextInputRow(
                 }
             }
         }
-        val slashVisible = isFocused && slashQuery != null
-        androidx.compose.animation.AnimatedVisibility(
-            visible = slashVisible,
-            enter = androidx.compose.animation.fadeIn(
-                animationSpec = androidx.compose.animation.core.tween(150)
-            ) + androidx.compose.animation.slideInVertically(
-                animationSpec = androidx.compose.animation.core.tween(150),
-                initialOffsetY = { it / 4 }
-            ),
-            exit = androidx.compose.animation.fadeOut(
-                animationSpec = androidx.compose.animation.core.tween(100)
-            ) + androidx.compose.animation.slideOutVertically(
-                animationSpec = androidx.compose.animation.core.tween(100),
-                targetOffsetY = { it / 4 }
-            ),
-        ) {
-            SlashCommandPanel(
-                commands = slashCommands,
-                hasAnyCommand = allSlashCommands.isNotEmpty(),
-                onSelect = { command ->
-                    when (val action = command.action) {
-                        SlashCommandAction.ClearInput -> state.clearInput()
-                        SlashCommandAction.CompactContext -> {
-                            state.clearInput()
-                            onCompactContext()
-                        }
-                        is SlashCommandAction.InsertText -> state.setMessageText(action.text)
-                        SlashCommandAction.OpenUsage -> {
-                            state.clearInput()
-                            onUsageClick()
-                        }
+        // V3: 修两处:
+        //   1) 用 Popup 让 panel 浮在 TextField 上方, 不占布局空间 → 不再顶起 composer.
+        //   2) 去掉 isFocused 条件 — 点 "/" 按钮 append 了斜杠但 TextField 没获焦, 之前 panel 不弹.
+        //      只要 text 开头是 "/" 就显示 panel.
+        val slashVisible = slashQuery != null
+        if (slashVisible) {
+            androidx.compose.ui.window.Popup(
+                properties = androidx.compose.ui.window.PopupProperties(focusable = false),
+                popupPositionProvider = object : androidx.compose.ui.window.PopupPositionProvider {
+                    override fun calculatePosition(
+                        anchorBounds: androidx.compose.ui.unit.IntRect,
+                        windowSize: androidx.compose.ui.unit.IntSize,
+                        layoutDirection: androidx.compose.ui.unit.LayoutDirection,
+                        popupContentSize: androidx.compose.ui.unit.IntSize,
+                    ): androidx.compose.ui.unit.IntOffset {
+                        // panel 水平居中 = composer 一致左右 12dp margin
+                        // 垂直在 anchor 上方 8dp gap
+                        val gapPx = 8
+                        val x = ((windowSize.width - popupContentSize.width) / 2).coerceAtLeast(0)
+                        val y = (anchorBounds.top - popupContentSize.height - gapPx).coerceAtLeast(0)
+                        return androidx.compose.ui.unit.IntOffset(x, y)
                     }
                 },
-            )
+            ) {
+                // V3: 入场动画. Popup 不在 layout tree 中, AnimatedVisibility 无效, 用
+                // Animatable + graphicsLayer 驱动 alpha + scale. transformOrigin 偏右下,
+                // 接近 composer 上 "/" 按钮位置 (panel 在 anchor 上方居中, "/" 按钮在 anchor 右侧).
+                // 跟 ContextRing 同一套. 出场动画暂不做 (Popup visible=false 即销毁, 跟 ContextRing 一致).
+                val anim = remember { androidx.compose.animation.core.Animatable(0f) }
+                LaunchedEffect(Unit) {
+                    anim.animateTo(
+                        targetValue = 1f,
+                        animationSpec = androidx.compose.animation.core.tween(180)
+                    )
+                }
+                androidx.compose.foundation.layout.Box(
+                    modifier = Modifier.graphicsLayer {
+                        alpha = anim.value
+                        val s = 0.94f + 0.06f * anim.value
+                        scaleX = s
+                        scaleY = s
+                        transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0.85f, 1f)
+                    }
+                ) {
+                    SlashCommandPanel(
+                        commands = slashCommands,
+                        hasAnyCommand = allSlashCommands.isNotEmpty(),
+                        onSelect = { command ->
+                            when (val action = command.action) {
+                                SlashCommandAction.ClearInput -> state.clearInput()
+                                SlashCommandAction.CompactContext -> {
+                                    state.clearInput()
+                                    onCompactContext()
+                                }
+                                is SlashCommandAction.InsertText -> state.setMessageText(action.text)
+                                SlashCommandAction.OpenUsage -> {
+                                    state.clearInput()
+                                    onUsageClick()
+                                }
+                            }
+                        },
+                        // V3: thinking footer 数据来自当前 settings, 不为空且 model 支持 reasoning 时渲染
+                        thinkingFooter = onUpdateAssistant?.let { update ->
+                            {
+                                val currentModel = settings.getCurrentChatModel()
+                                val hasReasoning = currentModel?.abilities?.contains(
+                                    me.rerere.ai.provider.ModelAbility.REASONING
+                                ) == true
+                                if (hasReasoning) {
+                                    SlashCommandThinkingFooter(
+                                        currentLevel = assistant.reasoningLevel,
+                                        levels = me.rerere.rikkahub.ui.components.ai.reasoningLevelsForModel(currentModel),
+                                        onChange = { update(assistant.copy(reasoningLevel = it)) },
+                                    )
+                                }
+                            }
+                        },
+                    )
+                }
+            }
         }
         // @role mention: subagents and Model Council share the same lightweight picker.
         // Detection result is
@@ -303,10 +364,10 @@ internal fun TextInputRow(
                 .onFocusChanged {
                     isFocused = it.isFocused
                 },
-            shape = RoundedCornerShape(8.dp),
+            shape = if (minimalChrome) RoundedCornerShape(0.dp) else RoundedCornerShape(8.dp),
             placeholder = {
                 Text(
-                    text = stringResource(R.string.chat_input_placeholder),
+                    text = if (minimalChrome) "输入消息" else stringResource(R.string.chat_input_placeholder),
                     color = workspace.faint,
                 )
             },
@@ -322,14 +383,14 @@ internal fun TextInputRow(
             colors = TextFieldDefaults.colors().copy(
                 unfocusedIndicatorColor = Color.Transparent,
                 focusedIndicatorColor = Color.Transparent,
-                focusedContainerColor = workspace.paper,
-                unfocusedContainerColor = workspace.paper,
+                focusedContainerColor = if (minimalChrome) Color.Transparent else workspace.paper,
+                unfocusedContainerColor = if (minimalChrome) Color.Transparent else workspace.paper,
                 focusedTextColor = workspace.ink,
                 unfocusedTextColor = workspace.ink,
                 focusedPlaceholderColor = workspace.faint,
                 unfocusedPlaceholderColor = workspace.faint,
             ),
-            trailingIcon = if (isFocused) {
+            trailingIcon = if (isFocused && !minimalChrome) {
                 {
                     IconButton(
                         onClick = {
@@ -342,7 +403,9 @@ internal fun TextInputRow(
             } else {
                 null
             },
-            leadingIcon = if (quickMessages.isNotEmpty()) {
+            leadingIcon = if (minimalChrome) {
+                null
+            } else if (quickMessages.isNotEmpty()) {
                 {
                     QuickMessageButton(quickMessages = quickMessages, state = state)
                 }
@@ -365,15 +428,19 @@ private fun SlashCommandPanel(
     commands: List<SlashCommandItem>,
     hasAnyCommand: Boolean,
     onSelect: (SlashCommandItem) -> Unit,
+    thinkingFooter: (@Composable () -> Unit)? = null,
 ) {
     val workspace = workspaceColors()
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3: panel 宽度跟 composer 一致 — screen 宽减去 24dp (composer 父级 horizontal padding 12dp 左右)
+    val screenWidth = androidx.compose.ui.platform.LocalConfiguration.current.screenWidthDp.dp
     Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(10.dp),
+        modifier = Modifier.width(screenWidth - 24.dp),
+        shape = RoundedCornerShape(14.dp),
         tonalElevation = 0.dp,
-        shadowElevation = 1.dp,
-        color = workspace.paper,
-        border = BorderStroke(1.dp, workspace.hairline),
+        shadowElevation = 8.dp,
+        color = chatTheme.surface,
+        border = BorderStroke(1.dp, chatTheme.surfaceEdge),
     ) {
         Column(modifier = Modifier.padding(vertical = 4.dp)) {
             when {
@@ -401,6 +468,37 @@ private fun SlashCommandPanel(
                     }
                 }
             }
+            // V3: thinking-level footer — 跟着 panel 一起出现, 仅当 model 支持 reasoning 时显示
+            thinkingFooter?.invoke()
+        }
+    }
+}
+
+@Composable
+private fun SlashCommandThinkingFooter(
+    currentLevel: me.rerere.ai.core.ReasoningLevel,
+    levels: List<Pair<me.rerere.ai.core.ReasoningLevel, String>>,
+    onChange: (me.rerere.ai.core.ReasoningLevel) -> Unit,
+) {
+    val workspace = workspaceColors()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 6.dp),
+    ) {
+        HorizontalDivider(color = workspace.hairline)
+        Text(
+            text = "思考等级",
+            color = workspace.faint,
+            fontSize = 12.sp,
+            modifier = Modifier.padding(start = 12.dp, top = 8.dp, bottom = 6.dp),
+        )
+        Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)) {
+            me.rerere.rikkahub.ui.components.ai.ThinkingLevelSegment(
+                levels = levels,
+                current = currentLevel,
+                onChange = onChange,
+            )
         }
     }
 }
@@ -421,15 +519,14 @@ private fun SlashCommandRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
+            // V3: 跟主题色 (scheme.primary/primaryContainer), 边框降到 hair 极淡, 不再粗硬蓝勾边
+            val scheme = MaterialTheme.colorScheme
             Surface(
                 modifier = Modifier.size(30.dp),
                 shape = RoundedCornerShape(6.dp),
-                color = if (command.accent) workspace.blueContainer else workspace.row,
-                contentColor = if (command.accent) workspace.blue else workspace.muted,
-                border = BorderStroke(
-                    1.dp,
-                    if (command.accent) workspace.blue.copy(alpha = 0.14f) else workspace.hairline
-                ),
+                color = if (command.accent) scheme.primaryContainer else workspace.row,
+                contentColor = if (command.accent) scheme.primary else workspace.muted,
+                border = BorderStroke(1.dp, workspace.hairline),
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     Text(
@@ -542,11 +639,13 @@ private fun QuickMessageButton(
 @Composable
 private fun SlashCommandLeadingMark() {
     val workspace = workspaceColors()
+    val scheme = MaterialTheme.colorScheme
+    // V3: 跟主题色 (scheme.primaryContainer/primary), 替代硬编码 workspace.blue
     Surface(
         modifier = Modifier.size(24.dp),
         shape = RoundedCornerShape(5.dp),
-        color = workspace.blueContainer,
-        contentColor = workspace.blue,
+        color = scheme.primaryContainer,
+        contentColor = scheme.primary,
         border = BorderStroke(1.dp, workspace.hairline),
     ) {
         Box(contentAlignment = Alignment.Center) {
@@ -559,7 +658,9 @@ private fun SlashCommandLeadingMark() {
 }
 
 private fun String.slashCommandQuery(): String? {
-    if (!startsWith("/")) return null
+    // V3 修: 中文 IME 默认输入全角"／" (U+FF0F), ASCII "/" 检查会漏 → user 用中文输入法
+    // 直接打"/"唤不出 slash panel. 同时接受半角和全角.
+    if (!startsWith("/") && !startsWith("／")) return null
     val query = drop(1)
     return query.takeIf { it.none { char -> char.isWhitespace() } }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputSandbox.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputSandbox.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
@@ -418,18 +419,24 @@ internal fun SandboxPeekBar(
     onNext: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
+    // V3 convo-tool-result.jsx ToolResultPreview spec:
+    //   设计稿 asymmetric padding (start=14 end=32 top=10 bottom=8); 父级 ChatInput
+    //   已加 horizontal=8 padding + spacedBy 8dp, 我们只控 horizontal (start=6 end=24).
+    //   bottom 给 0 (让卡片紧贴下面的 ChatInput 输入框), top 维持轻量缓冲.
+    //   gap=10, align Bottom; 缩略图 72×96 (3:4 竖向); ResultPill 22dp 高 999 圆角
     Row(
         modifier = modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .padding(start = 6.dp, end = 24.dp, top = 4.dp, bottom = 0.dp),
         verticalAlignment = Alignment.Bottom,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         AgentOperationPreviewPeek(
             activity = activity,
             onOpen = onOpen,
             modifier = Modifier
-                .width(118.dp)
-                .height(78.dp),
+                .width(72.dp)
+                .height(96.dp),
         )
         SandboxStepPeek(
             activity = activity,
@@ -437,9 +444,7 @@ internal fun SandboxPeekBar(
             onCancel = onCancel,
             onPrevious = onPrevious,
             onNext = onNext,
-            modifier = Modifier
-                .weight(1f)
-                .height(38.dp),
+            modifier = Modifier.weight(1f),
         )
     }
 }
@@ -452,11 +457,12 @@ private fun AgentOperationPreviewPeek(
 ) {
     val previewUrl = activity.operationPreviewUrl()
     val workspace = workspaceColors()
+    // V3 convo-tool-result.jsx PreviewThumb: 8dp 圆角 + previewBg surface + 1dp hair edge + 单层柔影 0.06
     Surface(
         modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
+            .clip(RoundedCornerShape(8.dp))
             .clickable { onOpen() },
-        shape = RoundedCornerShape(10.dp),
+        shape = RoundedCornerShape(8.dp),
         color = workspace.paper,
         contentColor = workspace.ink,
         shadowElevation = 1.dp,
@@ -657,46 +663,55 @@ private fun SandboxStepPeek(
     modifier: Modifier = Modifier,
 ) {
     val workspace = workspaceColors()
+    val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3 convo-tool-result.jsx ResultPill spec:
+    //   高度 22dp (3dp 上下 padding + 16dp leading badge)
+    //   999 圆角 fillMaxWidth + toolPillBg + 1dp toolPillEdge
+    //   inline "tool · query" 11.5sp letter 0.2 W500/W400
+    //   右侧 9dp chevrons + 10.5sp tabular-nums
     Surface(
         modifier = modifier
-            .clip(RoundedCornerShape(10.dp))
+            .clip(CircleShape)
             .clickable { onOpen() },
-        shape = RoundedCornerShape(10.dp),
-        color = workspace.paper,
+        shape = CircleShape,
+        color = theme.toolPillBg,
         contentColor = workspace.ink,
-        shadowElevation = 1.dp,
+        shadowElevation = 0.dp,
         tonalElevation = 0.dp,
-        border = BorderStroke(1.dp, workspace.hairline),
+        border = BorderStroke(1.dp, theme.toolPillEdge),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            modifier = Modifier.padding(start = 3.dp, end = 10.dp, top = 3.dp, bottom = 3.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             SandboxStepStatusIcon(status = activity.status)
             Text(
                 text = activity.title,
                 modifier = Modifier.weight(1f),
-                style = MaterialTheme.typography.labelMedium,
+                fontSize = 10.5.sp,
+                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+                letterSpacing = 0.2.sp,
+                color = theme.toolLabelInk,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
             if (onCancel != null) {
                 IconButton(
                     onClick = onCancel,
-                    modifier = Modifier.size(22.dp),
+                    modifier = Modifier.size(18.dp),
                 ) {
                     Icon(
                         imageVector = HugeIcons.Cancel01,
                         contentDescription = stringResource(R.string.stop),
-                        tint = Color(0xFFE09A1B),
-                        modifier = Modifier.size(12.dp),
+                        tint = workspace.amber,
+                        modifier = Modifier.size(10.dp),
                     )
                 }
             }
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 SandboxStepArrow(
                     enabled = onPrevious != null,
@@ -705,8 +720,9 @@ private fun SandboxStepPeek(
                 )
                 Text(
                     text = activity.stepProgressText(),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = workspace.muted,
+                    fontSize = 9.5.sp,
+                    letterSpacing = 0.4.sp,
+                    color = theme.inkSoft,
                     maxLines = 1,
                 )
                 SandboxStepArrow(
@@ -725,9 +741,11 @@ private fun SandboxStepArrow(
     onClick: (() -> Unit)?,
     left: Boolean,
 ) {
+    val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3 spec: 9dp chevrons stroke 2.4 inkSoft
     Box(
         modifier = Modifier
-            .size(20.dp)
+            .size(16.dp)
             .clip(CircleShape)
             .clickable(enabled = enabled && onClick != null) { onClick?.invoke() },
         contentAlignment = Alignment.Center,
@@ -735,19 +753,28 @@ private fun SandboxStepArrow(
         Icon(
             imageVector = if (left) HugeIcons.ArrowLeft01 else HugeIcons.ArrowRight01,
             contentDescription = null,
-            modifier = Modifier.size(12.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (enabled) 0.92f else 0.28f),
+            modifier = Modifier.size(9.dp),
+            tint = theme.inkSoft.copy(alpha = if (enabled) 1f else 0.28f),
         )
     }
 }
 
 @Composable
 private fun SandboxStepStatusIcon(status: ToolActivityStatus) {
+    // V3 ResultPill spec: 16dp accent 实心圆 + 10dp 白勾。失败/取消保留状态色映射。
+    val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val workspace = workspaceColors()
+    val (bg, ink) = when (status) {
+        ToolActivityStatus.SUCCEEDED -> theme.toolDoneBg to theme.toolDoneBadgeInk
+        ToolActivityStatus.FAILED -> workspace.red to Color.White
+        ToolActivityStatus.CANCELLED -> workspace.muted to Color.White
+        else -> theme.toolDoneBg to theme.toolDoneBadgeInk // RUNNING / WAITING 用 accent 表示进行中
+    }
     Surface(
-        modifier = Modifier.size(20.dp),
+        modifier = Modifier.size(16.dp),
         shape = CircleShape,
-        color = sandboxStatusContainerColor(status),
-        contentColor = sandboxStatusOnContainerColor(status),
+        color = bg,
+        contentColor = ink,
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
@@ -755,10 +782,11 @@ private fun SandboxStepStatusIcon(status: ToolActivityStatus) {
                     ToolActivityStatus.SUCCEEDED -> HugeIcons.Tick01
                     ToolActivityStatus.FAILED,
                     ToolActivityStatus.CANCELLED -> HugeIcons.Cancel01
-                    else -> HugeIcons.Code
+                    else -> HugeIcons.Tick01 // 运行中也显示勾 (表示已开始/在进行)
                 },
                 contentDescription = null,
-                modifier = Modifier.size(12.dp),
+                tint = ink,
+                modifier = Modifier.size(10.dp),
             )
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
@@ -2,6 +2,8 @@ package me.rerere.rikkahub.ui.components.ai
 
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -14,8 +16,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -58,6 +63,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -77,15 +83,19 @@ import me.rerere.ai.provider.OpenAIAuthMode
 import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.providers.isCodexOAuthReviewModel
 import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.AiMagic
+import me.rerere.hugeicons.stroke.ArrowDown01
 import me.rerere.hugeicons.stroke.ArrowRight01
 import me.rerere.hugeicons.stroke.Brain02
 import me.rerere.hugeicons.stroke.Cancel01
 import me.rerere.hugeicons.stroke.DragDropHorizontal
 import me.rerere.hugeicons.stroke.Favourite
 import me.rerere.hugeicons.stroke.Image03
+import me.rerere.hugeicons.stroke.Message01
 import me.rerere.hugeicons.stroke.Search01
 import me.rerere.hugeicons.stroke.Text
 import me.rerere.hugeicons.stroke.Tools
+import me.rerere.hugeicons.stroke.Wrench01
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.Screen
 import me.rerere.rikkahub.data.datastore.findModelById
@@ -112,11 +122,19 @@ fun ModelSelector(
     modifier: Modifier = Modifier,
     onlyIcon: Boolean = false,
     compact: Boolean = false,
+    minimalText: Boolean = false,
+    /** V3 settings-models.jsx inline 触发器：logo 块 + accent 模型名 + chevron-down。
+     *  优先级排在 minimalText / compact 之后（互斥）。 */
+    inline: Boolean = false,
     allowClear: Boolean = false,
     emptyLabel: String? = null,
     clearContentDescription: String? = null,
     preferredInputModality: Modality? = null,
     onClear: (() -> Unit)? = null,
+    // Phase 3.5 thinking-level segment：仅 chat 主入口（ChatPage TopBar / ChatInput）传入这两个
+    // 参数即可在 active model 卡片下显示 reasoning 切换段；其他调用方默认 null 即不渲染
+    currentAssistant: me.rerere.rikkahub.data.model.Assistant? = null,
+    onUpdateAssistant: ((me.rerere.rikkahub.data.model.Assistant) -> Unit)? = null,
     onSelect: (Model) -> Unit
 ) {
     var popup by remember { mutableStateOf(false) }
@@ -128,7 +146,73 @@ fun ModelSelector(
     val model = modelId?.let { modelIndex[it]?.model }
 
     if (!onlyIcon) {
-        if (compact) {
+        if (minimalText) {
+            // V3: 去掉 "⌄" chevron 字符 (用户反馈不需要), 同时把 ripple 改成胶囊形
+            // (.clip(CircleShape) before .clickable 让 ripple 跟随胶囊裁剪而非矩形)
+            Row(
+                modifier = modifier
+                    .clip(androidx.compose.foundation.shape.CircleShape)
+                    .clickable { popup = true }
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = model?.displayName
+                        ?: emptyLabel
+                        ?: stringResource(R.string.model_list_select_model),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 0.2.sp,
+                    ),
+                    color = workspaceColors().ink,
+                )
+            }
+        } else if (inline) {
+            // settings-models.jsx 设计稿：22dp logo + 14.5sp accent W500 model name + 12dp chevron-down
+            val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+            Row(
+                modifier = modifier.clickable { popup = true },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                // V3: 去掉 logo 小方框 (用户反馈"图标太小不匹配方框, 去掉"). 直接 model 名 + 下拉.
+                Text(
+                    text = model?.displayName
+                        ?: emptyLabel
+                        ?: stringResource(R.string.model_list_select_model),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    fontSize = 14.5.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 0.2.sp,
+                    color = theme.accent,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                Icon(
+                    imageVector = HugeIcons.ArrowDown01,
+                    contentDescription = null,
+                    tint = theme.accent,
+                    modifier = Modifier.size(12.dp),
+                )
+                if (allowClear && model != null) {
+                    IconButton(
+                        onClick = { onClear?.invoke() ?: onSelect(Model()) },
+                        modifier = Modifier.size(28.dp),
+                    ) {
+                        Icon(
+                            imageVector = HugeIcons.Cancel01,
+                            contentDescription = clearContentDescription ?: "Clear",
+                            tint = theme.inkFaint,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                }
+            }
+        } else if (compact) {
             val workspace = workspaceColors()
             val chipShape = RoundedCornerShape(8.dp)
             CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
@@ -224,11 +308,32 @@ fun ModelSelector(
 
     if (popup) {
         val state = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        // V3 Whisper：28dp 顶圆角 + 白底 + 自定义 36dp/4dp 拖拽手柄；模型列表本身
+        // 暂保留旧实现，后续 phase 再按 model-picker.jsx 重做 active card / segment。
         ModalBottomSheet(
             onDismissRequest = {
                 popup = false
             },
             sheetState = state,
+            shape = RoundedCornerShape(
+                topStart = 28.dp,
+                topEnd = 28.dp,
+                bottomStart = 0.dp,
+                bottomEnd = 0.dp,
+            ),
+            containerColor = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.surface,
+            scrimColor = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.sheetBackdrop,
+            dragHandle = {
+                // V3 model-picker.jsx:57 drag handle 40×4dp
+                Box(
+                    modifier = Modifier
+                        .padding(top = 10.dp, bottom = 4.dp)
+                        .width(40.dp)
+                        .height(4.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.dragHandle),
+                )
+            },
         ) {
             Column(
                 modifier = Modifier
@@ -245,8 +350,13 @@ fun ModelSelector(
                     providers = filteredProviderSettings,
                     modelType = type,
                     preferredInputModality = preferredInputModality,
-                    onSelect = {
-                        onSelect(it)
+                    currentAssistant = currentAssistant,
+                    onUpdateAssistant = onUpdateAssistant,
+                    onSelect = { selectedModel ->
+                        // V3 改: 之前为了"切 model 顺手改 reasoning"保持 picker 不关,
+                        // 但 reasoning 已搬到 slash panel footer, 这里恢复"选即关".
+                        // 副作用: 生图 picker 第一次选模型不再卡住, 不会被误点 × 清成 sentinel.
+                        onSelect(selectedModel)
                         scope.launch {
                             state.hide()
                             popup = false
@@ -327,6 +437,8 @@ private fun ColumnScope.ModelList(
     providers: List<ProviderSetting>,
     modelType: ModelType,
     preferredInputModality: Modality? = null,
+    currentAssistant: me.rerere.rikkahub.data.model.Assistant? = null,
+    onUpdateAssistant: ((me.rerere.rikkahub.data.model.Assistant) -> Unit)? = null,
     onSelect: (Model) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -462,26 +574,12 @@ private fun ColumnScope.ModelList(
             .fillMaxWidth()
             .padding(horizontal = 8.dp),
     ) {
-        OutlinedTextField(
+        // V3: 统一 drawer Amber 下方搜索栏样式 (WorkspaceSearchField)
+        me.rerere.rikkahub.ui.components.ui.WorkspaceSearchField(
             value = searchKeywords,
             onValueChange = { searchKeywords = it },
+            placeholder = stringResource(R.string.model_list_search_placeholder),
             modifier = Modifier.fillMaxWidth(),
-            placeholder = {
-                Text(
-                    text = stringResource(R.string.model_list_search_placeholder),
-                )
-            },
-            shape = RoundedCornerShape(50),
-            colors = TextFieldDefaults.colors(
-                unfocusedIndicatorColor = Color.Transparent,
-                focusedIndicatorColor = Color.Transparent,
-                focusedContainerColor = Color.Transparent,
-                unfocusedContainerColor = Color.Transparent,
-            ),
-            leadingIcon = {
-                Icon(HugeIcons.Search01, null)
-            },
-            maxLines = 1,
         )
     }
 
@@ -519,126 +617,114 @@ private fun ColumnScope.ModelList(
                 items = favoriteModels,
                 key = { "favorite:" + it.first.id.toString() }
             ) { (model, provider) ->
-                ReorderableItem(
-                    state = reorderableState,
-                    key = "favorite:" + model.id.toString()
-                ) { isDragging ->
-                    ModelItem(
-                        model = model,
-                        onSelect = onSelect,
-                        modifier = Modifier
-                            .scale(if (isDragging) 0.95f else 1f)
-                            .animateItem(),
-                        providerSetting = provider,
-                        select = model.id == currentModel,
-                        onDismiss = {
-                            onDismiss()
-                        },
-                        tail = {
-                            IconButton(
-                                onClick = {
-                                    coroutineScope.launch {
-                                        settingsStore.update { settings ->
-                                            settings.copy(
-                                                favoriteModels = settings.favoriteModels.filter { it != model.id }
-                                            )
-                                        }
-                                    }
-                                }
-                            ) {
-                                Icon(
-                                    HeartIcon,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
-                                    tint = MaterialTheme.colorScheme.primary,
-                                )
-                            }
-                        },
-                        dragHandle = {
-                            Icon(
-                                imageVector = HugeIcons.DragDropHorizontal,
-                                contentDescription = null,
-                                modifier = Modifier.longPressDraggableHandle(
-                                    onDragStarted = {
-                                        haptic.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
-                                    },
-                                    onDragStopped = {
-                                        haptic.performHapticFeedback(HapticFeedbackType.GestureEnd)
-                                    }
-                                )
-                            )
-                        }
-                    )
-                }
-            }
-        }
-
-        providers.fastForEach { providerSetting ->
-            item(key = "header:${providerSetting.id}") {
-                Row(
-                    modifier = Modifier
-                        .padding(horizontal = 8.dp)
-                        .padding(bottom = 4.dp, top = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = providerSetting.name,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            }
-
-            items(
-                items = searchFilteredModelsByProvider[providerSetting.id].orEmpty(),
-                key = { it.id }
-            ) { model ->
-                val favorite = settings.value.favoriteModels.contains(model.id)
+                // V3: 移除拖拽 handle（用户反馈实用性低）—— 不再包 ReorderableItem
                 ModelItem(
                     model = model,
                     onSelect = onSelect,
                     modifier = Modifier.animateItem(),
-                    providerSetting = providerSetting,
-                    select = currentModel == model.id,
-                    onDismiss = {
-                        onDismiss()
-                    },
+                    providerSetting = provider,
+                    select = model.id == currentModel,
+                    onDismiss = { onDismiss() },
                     tail = {
                         IconButton(
                             onClick = {
                                 coroutineScope.launch {
                                     settingsStore.update { settings ->
-                                        if (favorite) {
-                                            settings.copy(
-                                                favoriteModels = settings.favoriteModels.filter { it != model.id }
-                                            )
-
-                                        } else {
-                                            settings.copy(
-                                                favoriteModels = settings.favoriteModels + model.id
-                                            )
-                                        }
+                                        settings.copy(
+                                            favoriteModels = settings.favoriteModels.filter { it != model.id }
+                                        )
                                     }
                                 }
                             }
                         ) {
-                            if (favorite) {
-                                Icon(
-                                    HeartIcon,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp),
-                                    tint = MaterialTheme.colorScheme.primary,
+                            Icon(
+                                HeartIcon,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent,
+                            )
+                        }
+                    },
+                )
+            }
+        }
+
+        // V3 重构 v2: 不分家 — active 和同 provider 其他 model 都在一张 group card 内
+        // 只有 active 行用 accentSoft 高亮 + 段控内嵌；非 active 行 surface 普通样式
+        providers.fastForEach { providerSetting ->
+            val groupModels = searchFilteredModelsByProvider[providerSetting.id].orEmpty()
+            if (groupModels.isEmpty()) return@fastForEach
+
+            // provider 名 accent label —— 与卡片左边线对齐 (4dp 偏移让视觉略缩进)
+            item(key = "header:${providerSetting.id}") {
+                Text(
+                    text = providerSetting.name,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    letterSpacing = 0.3.sp,
+                    modifier = Modifier.padding(start = 4.dp, bottom = 4.dp, top = 8.dp),
+                )
+            }
+
+            // 单张 group 卡 + 内部 hairline 分隔; active 行 accentSoft 高亮 + 段控
+            // 不加 horizontal padding，让宽度跟 LazyColumn content padding 走，与 收藏 卡对齐
+            item(key = "group:${providerSetting.id}") {
+                val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+                Card(
+                    modifier = Modifier.animateItem(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = chatTheme.surface,
+                        contentColor = chatTheme.ink,
+                    ),
+                    border = BorderStroke(1.dp, chatTheme.hair),
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+                ) {
+                    Column {
+                        groupModels.forEachIndexed { idx, model ->
+                            val isActive = model.id == currentModel
+                            val hasReasoning = model.abilities.contains(me.rerere.ai.provider.ModelAbility.REASONING)
+                            if (idx > 0) {
+                                Box(
+                                    modifier = Modifier
+                                        .padding(start = 14.dp)
+                                        .fillMaxWidth()
+                                        .height(1.dp)
+                                        .background(chatTheme.hair),
                                 )
-                            } else {
-                                Icon(
-                                    imageVector = HugeIcons.Favourite,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(20.dp)
+                            }
+                            val favorite = settings.value.favoriteModels.contains(model.id)
+                            Column(
+                                modifier = if (isActive) Modifier.background(chatTheme.accentSoft) else Modifier,
+                            ) {
+                                ModelItemRow(
+                                    model = model,
+                                    providerSetting = providerSetting,
+                                    isActive = isActive,
+                                    onSelect = onSelect,
+                                    onDismiss = onDismiss,
+                                    tail = {
+                                        FavoriteToggleIcon(
+                                            favorite = favorite,
+                                            isActive = isActive,
+                                            onToggle = {
+                                                coroutineScope.launch {
+                                                    settingsStore.update { s ->
+                                                        if (favorite) s.copy(favoriteModels = s.favoriteModels.filter { it != model.id })
+                                                        else s.copy(favoriteModels = s.favoriteModels + model.id)
+                                                    }
+                                                }
+                                            },
+                                        )
+                                    },
                                 )
+                                // V3: thinking-level segment 已搬到 SlashCommandPanel footer,
+                                // 这里不再渲染. 保留 currentAssistant / onUpdateAssistant 入参以兼容
+                                // 旧 callsite (避免 ripple). hasReasoning 也保留 (将来 picker tail 可能再用).
+                                @Suppress("UNUSED_VARIABLE") val _hasReasoning = hasReasoning
                             }
                         }
                     }
-                )
+                }
             }
         }
     }
@@ -667,27 +753,54 @@ private fun ColumnScope.ModelList(
             }
     }
     if (providers.isNotEmpty()) {
-        LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(horizontal = 8.dp),
-            state = providerBadgeListState
-        ) {
-            items(providers) { provider ->
-                AssistChip(
-                    onClick = {
-                        val position = providerPositions[provider.id] ?: 0
-                        coroutineScope.launch {
-                            lazyListState.animateScrollToItem(position)
-                        }
-                    },
-                    label = {
-                        Text(provider.name)
-                    },
-                    leadingIcon = {
-                        AutoAIIcon(name = provider.name, modifier = Modifier.size(16.dp))
-                    },
-                )
+        val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+        // V3 model-picker.jsx ProviderChips: 12dp 圆角矩形 + 18×18 logo + 名 + hairline 边
+        // 顶部 hairline 分隔 chip 区 与 model list
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(chatTheme.hair),
+            )
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp, bottom = 14.dp),
+                contentPadding = PaddingValues(horizontal = 12.dp),
+                state = providerBadgeListState,
+            ) {
+                items(providers) { provider ->
+                    // V3: 简化层级 — 999 capsule 外框 + logo (无内嵌 18dp Box + 5dp 圆角矩形).
+                    Row(
+                        modifier = Modifier
+                            .clip(androidx.compose.foundation.shape.CircleShape)
+                            .background(chatTheme.surface)
+                            .border(
+                                BorderStroke(1.dp, chatTheme.hair),
+                                androidx.compose.foundation.shape.CircleShape,
+                            )
+                            .clickable {
+                                val position = providerPositions[provider.id] ?: 0
+                                coroutineScope.launch {
+                                    lazyListState.animateScrollToItem(position)
+                                }
+                            }
+                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        // V3: 去掉 provider 图标, 胶囊只剩 provider 名 (用户偏好)
+                        Text(
+                            text = provider.name,
+                            fontSize = 12.5.sp,
+                            color = chatTheme.ink,
+                            letterSpacing = 0.2.sp,
+                            maxLines = 1,
+                        )
+                    }
+                }
             }
         }
     }
@@ -702,82 +815,130 @@ private fun ModelItem(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
     tail: @Composable RowScope.() -> Unit = {},
-    dragHandle: @Composable (RowScope.() -> Unit)? = null
+    dragHandle: @Composable (RowScope.() -> Unit)? = null,
+    // V3 active 模型的 thinking-level segment（slot）
+    thinkingSegment: (@Composable () -> Unit)? = null,
 ) {
     val navController = LocalNavController.current
     val interactionSource = remember { MutableInteractionSource() }
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3 model-picker.jsx: active 卡片 accentSoft 填底 + accent 文字 + 边线 22% accent
+    // 非 active 用 surface + ink + hair 边线
+    // V3: clickable 移到 Card 外层 modifier — 之前在内部 Column 上, 选中 ripple 只在 padding
+    //   之内, Card border 内但 padding 外的边角区域点不到, 看着"选中区分裂".
     Card(
-        modifier = modifier,
+        modifier = modifier.combinedClickable(
+            enabled = true,
+            onLongClick = {
+                onDismiss()
+                navController.navigate(
+                    Screen.SettingProviderDetail(providerSetting.id.toString())
+                )
+            },
+            onClick = { onSelect(model) },
+            interactionSource = interactionSource,
+            indication = LocalIndication.current,
+        ),
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
         colors = CardDefaults.cardColors(
-            containerColor = if (select) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surface,
-            contentColor = if (select) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
-        )
+            containerColor = if (select) chatTheme.accentSoft else chatTheme.surface,
+            contentColor = if (select) chatTheme.accent else chatTheme.ink,
+        ),
+        border = if (select) {
+            androidx.compose.foundation.BorderStroke(
+                1.dp,
+                chatTheme.accent.copy(alpha = 0.22f),
+            )
+        } else {
+            androidx.compose.foundation.BorderStroke(1.dp, chatTheme.hair)
+        },
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 12.dp, horizontal = 16.dp)
+                .padding(horizontal = 14.dp, vertical = 8.dp),
         ) {
             Row(
-                modifier = Modifier
-                    .weight(1f)
-                    .combinedClickable(
-                        enabled = true,
-                        onLongClick = {
-                            onDismiss()
-                            navController.navigate(
-                                Screen.SettingProviderDetail(
-                                    providerSetting.id.toString()
-                                )
-                            )
-                        },
-                        onClick = { onSelect(model) },
-                        interactionSource = interactionSource,
-                        indication = LocalIndication.current
-                    ),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                Surface(
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    shape = MaterialTheme.shapes.small,
-                ) {
-                    AutoAIIcon(
-                        name = model.modelId,
-                        modifier = Modifier
-                            .padding(4.dp)
-                            .size(32.dp)
-                    )
-                }
-                Column(
+                AutoAIIcon(
+                    name = model.modelId,
+                    modifier = Modifier.size(28.dp),
+                )
+                // V3: model 名 12.5sp + 删 V3CapabilityIcons (能力图标对用户意义不大)
+                Text(
+                    text = model.displayName,
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        fontSize = 12.5.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 0.2.sp,
+                        lineHeight = 15.sp,
+                    ),
+                    color = if (select) chatTheme.accent else chatTheme.ink,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    Text(
-                        text = model.displayName,
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-
-                    FlowRow(
-                        modifier = Modifier
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
-                    ) {
-                        ModelTypeTag(model = model)
-
-                        ModelModalityTag(model = model)
-
-                        ModelAbilityTag(model = model)
-                    }
-                }
+                )
                 tail()
             }
-            dragHandle?.let { it() }
+            // ── 第二行：thinking-level segment（仅 active + REASONING 时显示）
+            thinkingSegment?.let {
+                Box(modifier = Modifier.padding(top = 6.dp)) {
+                    it()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * V3 model-picker.jsx CapIcon —— 14dp monochrome stroke 风的 capability 图标行。
+ * 每个模型固定显示 chat，按 abilities 加 tool/sci，按 modalities 加 T>I/I>T 等。
+ */
+@Composable
+private fun V3CapabilityIcons(model: Model, tint: Color) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // chat — 所有 CHAT 模型默认显示
+        if (model.type == ModelType.CHAT) {
+            Icon(
+                imageVector = HugeIcons.Message01,
+                contentDescription = "chat",
+                modifier = Modifier.size(14.dp),
+                tint = tint,
+            )
+        }
+        // T>T or T>I —— 按 input/output modalities 推断
+        val hasImg = model.outputModalities.fastAny { it == Modality.IMAGE } ||
+            model.inputModalities.fastAny { it == Modality.IMAGE }
+        Icon(
+            imageVector = if (hasImg) HugeIcons.Image03 else HugeIcons.Text,
+            contentDescription = if (hasImg) "image" else "text",
+            modifier = Modifier.size(14.dp),
+            tint = tint,
+        )
+        // tool wrench —— TOOL ability
+        if (model.abilities.contains(me.rerere.ai.provider.ModelAbility.TOOL)) {
+            Icon(
+                imageVector = HugeIcons.Wrench01,
+                contentDescription = "tool",
+                modifier = Modifier.size(14.dp),
+                tint = tint,
+            )
+        }
+        // sci/magic —— REASONING ability（设计稿是原子/sci 图标，库里最接近 AiMagic）
+        if (model.abilities.contains(me.rerere.ai.provider.ModelAbility.REASONING)) {
+            Icon(
+                imageVector = HugeIcons.AiMagic,
+                contentDescription = "reasoning",
+                modifier = Modifier.size(14.dp),
+                tint = tint,
+            )
         }
     }
 }
@@ -877,38 +1038,187 @@ private fun ProviderSetting.isHiddenCodexOAuthModel(model: Model): Boolean {
     return isCodexOAuthProvider() && model.isCodexOAuthReviewModel()
 }
 
+// V3: hasUsableAuth 已迁到 me.rerere.ai.provider.hasUsableAuth (ai/ProviderSetting.kt),
+// picker (这里) 和 data 层 fallback 共用同一份判定 (避免 picker 显示但 fallback 漏选
+// 出无 auth 的模型). 调用方直接 import me.rerere.ai.provider.hasUsableAuth.
+
 /**
- * True when the provider has enough credentials to actually serve a request.
+ * Phase 3.5 thinking-level segment —— model-picker.jsx 的 ThinkingLevel 段控。
  *
- * Used by the image-generation model picker so that auto-seeded entries
- * (gpt-image-2 in the default OpenAI provider, gemini-3.1-flash-image-preview
- * in the default Gemini provider) stay hidden until the user has filled in
- * an API key — without this, a fresh install shows "Nano Banana 2" as a
- * pickable option even though selecting it would 401 on every call.
+ * 设计稿用 off/on/low/med/high/xhigh/max 等不同模型不同段集。Kotlin 这边统一用
+ * [ReasoningLevel] 7 个值，但 XHIGH 跟 HIGH 视觉太接近，UI 上跳过；展示 6 段：
+ *   OFF | AUTO | LOW | MEDIUM | HIGH | MAX
  *
- * Chat / OCR / translation pickers deliberately don't apply this filter
- * (those have always shown models from key-less providers, presumably for
- * exploratory configuration).
+ * 主题感知：active 段填 chatTheme.accent + onAccent 文字；非 active 文字 chatTheme.ink；
+ *           容器 chatTheme.searchBarBg + hair 1dp 描边。
  */
-internal fun ProviderSetting.hasUsableAuth(): Boolean {
-    if (!enabled) return false
-    return when (this) {
-        is ProviderSetting.OpenAI -> when (authMode) {
-            // OAuth modes use a separately-managed token; the user-typed key
-            // field is irrelevant for these.
-            OpenAIAuthMode.CODEX_OAUTH -> true
-            else -> apiKey.isNotBlank()
-        }
-        is ProviderSetting.Google -> when (authMode) {
-            GoogleAuthMode.GEMINI_CODE_ASSIST_OAUTH -> true
-            GoogleAuthMode.API_KEY -> when {
-                apiKey.isNotBlank() -> true
-                // Vertex AI + service-account path uses a private-key blob
-                // instead of an API key. Treat that as configured too.
-                vertexAI && useServiceAccount && privateKey.isNotBlank() -> true
-                else -> false
+/**
+ * 按模型推断 reasoning level 段集。
+ *
+ * 来源：
+ *  - DeepSeek: off/high/max (https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)
+ *  - OpenAI gpt-5: low/medium/high/xhigh
+ *  - Anthropic claude: low/medium/high/xhigh/max
+ *  - Kimi / GLM: off/auto (2 段)
+ *  - 默认: off/auto/low/med/high/max (6 段)
+ */
+internal fun reasoningLevelsForModel(model: Model): List<Pair<me.rerere.ai.core.ReasoningLevel, String>> {
+    val id = model.modelId.lowercase()
+    return when {
+        id.contains("deepseek") -> listOf(
+            me.rerere.ai.core.ReasoningLevel.OFF to "off",
+            me.rerere.ai.core.ReasoningLevel.HIGH to "high",
+            me.rerere.ai.core.ReasoningLevel.MAX to "max",
+        )
+        // Claude (Anthropic) extended thinking + adaptive auto：
+        // Anthropic 在 claude-sonnet-4.5 / opus-4.1 起暴露 thinking_budget=auto，模型自己
+        // 决定多少 token 用来思考（无人工指定 budget）。设计稿 model-picker.jsx 标 auto
+        // 作为首段，方便用户日常聊天直接选 "让 Claude 自己决定" 而不用挑 low/med/high。
+        // 段集：auto / low / med / high / xhigh / max (6 段)
+        id.contains("claude") -> listOf(
+            me.rerere.ai.core.ReasoningLevel.AUTO to "auto",
+            me.rerere.ai.core.ReasoningLevel.LOW to "low",
+            me.rerere.ai.core.ReasoningLevel.MEDIUM to "med",
+            me.rerere.ai.core.ReasoningLevel.HIGH to "high",
+            me.rerere.ai.core.ReasoningLevel.XHIGH to "xhigh",
+            me.rerere.ai.core.ReasoningLevel.MAX to "max",
+        )
+        id.contains("gpt") || id.contains("o1") || id.contains("o3") || id.contains("o4") -> listOf(
+            me.rerere.ai.core.ReasoningLevel.LOW to "low",
+            me.rerere.ai.core.ReasoningLevel.MEDIUM to "med",
+            me.rerere.ai.core.ReasoningLevel.HIGH to "high",
+            me.rerere.ai.core.ReasoningLevel.XHIGH to "xhigh",
+        )
+        id.contains("kimi") || id.contains("glm") || id.contains("zhipu") -> listOf(
+            me.rerere.ai.core.ReasoningLevel.OFF to "off",
+            me.rerere.ai.core.ReasoningLevel.AUTO to "auto",
+        )
+        else -> listOf(
+            me.rerere.ai.core.ReasoningLevel.OFF to "off",
+            me.rerere.ai.core.ReasoningLevel.AUTO to "auto",
+        )
+    }
+}
+
+@Composable
+internal fun ThinkingLevelSegment(
+    levels: List<Pair<me.rerere.ai.core.ReasoningLevel, String>>,
+    current: me.rerere.ai.core.ReasoningLevel,
+    onChange: (me.rerere.ai.core.ReasoningLevel) -> Unit,
+) {
+    val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3 紧凑段控: 外 padding 1.5dp + 内段 vertical 1dp + 字号 10sp (再压扁一档)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(androidx.compose.foundation.shape.CircleShape)
+            .background(theme.surface)
+            .border(
+                BorderStroke(1.dp, theme.hair),
+                shape = androidx.compose.foundation.shape.CircleShape,
+            )
+            .padding(3.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        levels.forEach { (level, label) ->
+            val isActive = level == current
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(androidx.compose.foundation.shape.CircleShape)
+                    .background(if (isActive) theme.accent else androidx.compose.ui.graphics.Color.Transparent)
+                    .clickable { onChange(level) }
+                    .padding(vertical = 5.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = label,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 0.2.sp,
+                    lineHeight = 13.sp,
+                    color = if (isActive) theme.onAccent else theme.ink,
+                    maxLines = 1,
+                )
             }
         }
-        is ProviderSetting.Claude -> apiKey.isNotBlank()
+    }
+}
+
+/** V3 grouped 卡内的 model 行 —— ModelItem 但去掉外层 Card 包装，仅渲染内容行。
+ *  设计稿：同 provider 多 model 在一张 SubCard 内用 hairline 分隔，所以单行不需要自己的 Card。
+ */
+@Composable
+private fun ModelItemRow(
+    model: Model,
+    providerSetting: ProviderSetting,
+    onSelect: (Model) -> Unit,
+    onDismiss: () -> Unit,
+    isActive: Boolean = false,
+    tail: @Composable RowScope.() -> Unit = {},
+) {
+    val navController = LocalNavController.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                enabled = true,
+                onLongClick = {
+                    onDismiss()
+                    navController.navigate(
+                        Screen.SettingProviderDetail(providerSetting.id.toString())
+                    )
+                },
+                onClick = { onSelect(model) },
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
+            )
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        AutoAIIcon(
+            name = model.modelId,
+            modifier = Modifier.size(28.dp),
+        )
+        // V3: model 名 12.5sp + 删 V3CapabilityIcons (能力图标对用户意义不大)
+        Text(
+            text = model.displayName,
+            style = MaterialTheme.typography.titleSmall.copy(
+                fontSize = 12.5.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.2.sp,
+                lineHeight = 15.sp,
+            ),
+            color = if (isActive) chatTheme.accent else chatTheme.ink,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        tail()
+    }
+}
+
+/** 收藏图标 —— 主题色感知的心形 */
+@Composable
+private fun FavoriteToggleIcon(
+    favorite: Boolean,
+    isActive: Boolean,
+    onToggle: () -> Unit,
+) {
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    IconButton(onClick = onToggle) {
+        Icon(
+            imageVector = if (favorite) HeartIcon else HugeIcons.Favourite,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = when {
+                favorite -> chatTheme.accent
+                isActive -> chatTheme.accent
+                else -> chatTheme.inkSoft
+            },
+        )
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
@@ -41,6 +41,7 @@ import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.theme.JetbrainsMono
 import me.rerere.rikkahub.ui.theme.NotoSerifSC
 import me.rerere.rikkahub.ui.utils.amberTraceMeasure
+import me.rerere.rikkahub.utils.copyMessageToClipboard
 import me.rerere.rikkahub.data.datastore.ChatFontFamily
 import me.rerere.rikkahub.utils.base64Encode
 import java.util.Locale
@@ -113,12 +114,18 @@ fun ChatMessage(
                 }
 
                 MessageRole.USER -> {
-                    ChatMessageUserAvatar(
-                        message = message,
-                        avatar = settings.userAvatar,
-                        nickname = settings.userNickname,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                    // V3: 隐藏 user 头像 / 昵称——用户跟自己的 AI 聊天不需要展示"我是谁".
+                    // 不删代码: 如果以后想恢复, 把 SHOW_USER_AVATAR 改 true 即可.
+                    @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+                    val SHOW_USER_AVATAR = false
+                    if (SHOW_USER_AVATAR) {
+                        ChatMessageUserAvatar(
+                            message = message,
+                            avatar = settings.userAvatar,
+                            nickname = settings.userNickname,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
 
                 else -> Unit
@@ -136,6 +143,9 @@ fun ChatMessage(
                 onToolAnswer = onToolAnswer,
                 onOpenWorkspaceFile = onOpenWorkspaceFile,
                 onUserMessageClick = if (message.role == MessageRole.USER) onEdit else null,
+                onUserMessageLongClick = if (message.role == MessageRole.USER) {
+                    { showActionsSheet = true }
+                } else null,
                 onGenerativeWidgetAction = onGenerativeWidgetAction,
                 onMiniAppModify = onMiniAppModify,
             )
@@ -155,7 +165,11 @@ fun ChatMessage(
         }
 
         if (message.role == MessageRole.USER) {
-            if (showActions) {
+            // V3: user 消息下方不显示 复制/重试/菜单 按钮行——这些操作改为长按消息胶囊弹 menu sheet.
+            // 不删代码: 如果以后想恢复, 把 SHOW_USER_ACTION_BUTTONS 改 true 即可.
+            @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+            val SHOW_USER_ACTION_BUTTONS = false
+            if (SHOW_USER_ACTION_BUTTONS && showActions) {
                 ChatMessageActionButtons(
                     message = message,
                     onRegenerate = onRegenerate,
@@ -192,8 +206,14 @@ fun ChatMessage(
             }
         }
 
-        ProvideTextStyle(textStyle) {
-            ChatMessageNerdLine(message = message)
+        // V3: 隐藏 "7.3K tokens / 3.3K cached / 196 tokens / 87.1 tok/s / 2.3s" Nerd Line.
+        // 这些数据顶栏 ContextRing popover 已有, 消息下方再展示一行有点冗余. 改 SHOW_NERD_LINE = true 恢复.
+        @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+        val SHOW_NERD_LINE = false
+        if (SHOW_NERD_LINE) {
+            ProvideTextStyle(textStyle) {
+                ChatMessageNerdLine(message = message)
+            }
         }
     }
     if (showActionsSheet) {
@@ -207,22 +227,12 @@ fun ChatMessage(
             onSelectAndCopy = {
                 showSelectCopySheet = true
             },
+            onCopy = {
+                context.copyMessageToClipboard(message)
+            },
+            onRegenerate = onRegenerate,
             isFavorite = isFavorite,
             onToggleFavorite = onToggleFavorite,
-            onWebViewPreview = {
-                val textContent = message.parts
-                    .filterIsInstance<UIMessagePart.Text>()
-                    .joinToString("\n\n") { it.text }
-                    .trim()
-                if (textContent.isNotBlank()) {
-                    val htmlContent = buildMarkdownPreviewHtml(
-                        context = context,
-                        markdown = textContent,
-                        colorScheme = colorScheme
-                    )
-                    navController.navigate(Screen.WebView(content = htmlContent.base64Encode()))
-                }
-            },
             onDismissRequest = {
                 showActionsSheet = false
             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -93,6 +93,18 @@ fun ColumnScope.ChatMessageActionButtons(
         }
     }
 
+    // V3 instrumentation (DEBUG only): 用户报 SVG 类 message 下方 actions 重复出现两行.
+    // 代码路径互斥 (Message vs VirtualMessage entry) — 双行只能来自上游 MessageNode 重复.
+    // gate 在 BuildConfig.DEBUG 后 release 不再写 logcat (review P3 #9 修复).
+    if (me.rerere.rikkahub.BuildConfig.DEBUG) {
+        androidx.compose.runtime.SideEffect {
+            android.util.Log.w(
+                "AmberActions",
+                "render msg=${message.id} role=${message.role} parts=${message.parts.size}"
+            )
+        }
+    }
+
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         itemVerticalAlignment = Alignment.CenterVertically,
@@ -139,7 +151,10 @@ fun ColumnScope.ChatMessageActionButtons(
                 },
             )
 
-            if (onTranslate != null) {
+            // V3: 隐藏翻译按钮 (用户暂不需要). 改 SHOW_TRANSLATE = true 即可恢复.
+            @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+            val SHOW_TRANSLATE = false
+            if (SHOW_TRANSLATE && onTranslate != null) {
                 MessageActionIconButton(
                     imageVector = HugeIcons.Translate,
                     contentDescription = stringResource(R.string.translate),
@@ -227,9 +242,12 @@ fun ChatMessageActionsSheet(
     onShare: () -> Unit,
     onFork: () -> Unit,
     onSelectAndCopy: () -> Unit,
+    /** V3: 一键复制整条消息到剪贴板 (跟旧 actions row 上的 copy 按钮等价). */
+    onCopy: (() -> Unit)? = null,
+    /** V3: 重新生成 / 重试 (user 消息时即从该位置重发, assistant 时即重新生成). */
+    onRegenerate: (() -> Unit)? = null,
     isFavorite: Boolean = false,
     onToggleFavorite: (() -> Unit)? = null,
-    onWebViewPreview: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     ModalBottomSheet(
@@ -259,6 +277,31 @@ fun ChatMessageActionsSheet(
                 shadowElevation = 0.dp,
             ) {
                 Column {
+                    // V3: copy 提到第一项 (跟旧 actions row 顺序一致)
+                    if (onCopy != null) {
+                        MessageActionRow(
+                            icon = HugeIcons.Copy01,
+                            text = stringResource(R.string.copy),
+                            workspace = workspace,
+                            onClick = {
+                                onDismissRequest()
+                                onCopy()
+                            },
+                        )
+                        MessageActionDivider(workspace)
+                    }
+                    if (onRegenerate != null) {
+                        MessageActionRow(
+                            icon = HugeIcons.Refresh03,
+                            text = stringResource(R.string.regenerate),
+                            workspace = workspace,
+                            onClick = {
+                                onDismissRequest()
+                                onRegenerate()
+                            },
+                        )
+                        MessageActionDivider(workspace)
+                    }
                     MessageActionRow(
                         icon = HugeIcons.TextSelection,
                         text = stringResource(R.string.select_and_copy),
@@ -268,18 +311,7 @@ fun ChatMessageActionsSheet(
                             onSelectAndCopy()
                         },
                     )
-                    if (hasTextContent) {
-                        MessageActionDivider(workspace)
-                        MessageActionRow(
-                            icon = HugeIcons.WebDesign01,
-                            text = stringResource(R.string.render_with_webview),
-                            workspace = workspace,
-                            onClick = {
-                                onDismissRequest()
-                                onWebViewPreview()
-                            },
-                        )
-                    }
+                    // V3: 移除 "render_with_webview" (网页视图渲染) 项
                     MessageActionDivider(workspace)
                     MessageActionRow(
                         icon = HugeIcons.Edit01,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAskUserStep.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAskUserStep.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -366,33 +367,26 @@ private fun AskOptionChip(
     label: String,
     onClick: () -> Unit,
 ) {
-    val shape = RoundedCornerShape(20.dp)
+    // V3 claude design spec: 999 圆角胶囊 / 白底 + 6% 墨灰边 + 极淡 1px 2px 接触阴影
+    // 13.5sp ink + 字距 0.2 + padding 8/14
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val shape = androidx.compose.foundation.shape.CircleShape
     Surface(
         onClick = onClick,
         shape = shape,
-        color = if (selected) {
-            MaterialTheme.colorScheme.primary
-        } else {
-            MaterialTheme.colorScheme.surface.copy(alpha = 0.85f)
-        },
-        contentColor = if (selected) {
-            MaterialTheme.colorScheme.onPrimary
-        } else {
-            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
-        },
+        color = if (selected) chatTheme.accent else chatTheme.surface,
+        contentColor = if (selected) chatTheme.onAccent else chatTheme.ink,
         border = if (selected) {
             null
         } else {
-            BorderStroke(
-                width = 0.5.dp,
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.55f),
-            )
+            BorderStroke(width = 1.dp, color = chatTheme.surfaceEdge)
         },
         tonalElevation = 0.dp,
-        shadowElevation = if (selected) 1.dp else 0.dp,
+        // V3: 选中态去掉强阴影，未选中保留极淡 1dp 接触阴影
+        shadowElevation = if (selected) 0.dp else 1.dp,
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 13.dp, vertical = 7.dp),
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(5.dp),
         ) {
@@ -406,6 +400,10 @@ private fun AskOptionChip(
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodyMedium.copy(
+                    // V3 spec: 13.5sp + 字距 0.2 + 行高 1.3
+                    fontSize = 13.5.sp,
+                    letterSpacing = 0.2.sp,
+                    lineHeight = 17.5.sp,
                     fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
                 ),
             )

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAvatar.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAvatar.kt
@@ -1,11 +1,15 @@
 package me.rerere.rikkahub.ui.components.message
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,6 +30,10 @@ import me.rerere.rikkahub.ui.components.ui.UIAvatar
 import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.utils.formatNumber
 import me.rerere.rikkahub.utils.toLocalString
+
+/** 6dp 圆点 background helper（避免在 inline block 里链 background+CircleShape）。 */
+private fun Modifier.androidxBackgroundCircle(color: Color): Modifier =
+    background(color = color, shape = CircleShape)
 
 @Composable
 fun ChatMessageUserAvatar(
@@ -116,11 +124,15 @@ fun ChatMessageAssistantAvatar(
                     }
                 }
             } else if (model != null) {
+                // V3 Whisper: model 名 + 6px 绿点状态（取代 provider 图标）。
+                // chat1.md L463：'纯黑 DeepSeek V4 Pro，去掉 on 胶囊；改用 6px 绿色状态点做轻量信号'。
                 if (showIcon) {
-                    AutoAIIcon(
-                        name = model.modelId,
-                        modifier = Modifier.size(32.dp),
-                        loading = loading
+                    androidx.compose.foundation.layout.Box(
+                        modifier = Modifier
+                            .size(6.dp)
+                            .androidxBackgroundCircle(
+                                me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.modelStatusDot
+                            ),
                     )
                 }
                 Column(
@@ -128,14 +140,23 @@ fun ChatMessageAssistantAvatar(
                 ) {
                     if(settings.displaySetting.showModelName) {
                         Text(
-                            text = model.displayName,
-                            style = MaterialTheme.typography.titleSmallEmphasized,
+                            // V3: 固定显示 "Amber" 而非具体模型名 —— 用户对话的对象是 Amber Agent
+                            // 整体, 不是底下哪个 model. 想看具体 model 可以从 TopBar 切换器看.
+                            text = "Amber",
+                            // V3 convo-agent.jsx:11 → 17sp/W500 (比 15sp 更醒目，是消息组的标识)
+                            style = MaterialTheme.typography.titleSmall.copy(
+                                fontSize = 17.sp,
+                                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+                                letterSpacing = 0.2.sp,
+                            ),
+                            color = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.ink,
+                            maxLines = 1,
                         )
                         if (settings.displaySetting.showDateBelowName) {
                             Text(
                                 text = message.createdAt.toJavaLocalDateTime().toLocalString(),
                                 style = MaterialTheme.typography.labelSmall,
-                                color = LocalContentColor.current.copy(alpha = 0.8f)
+                                color = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.inkFaint,
                             )
                         }
                     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageCouncilStep.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageCouncilStep.kt
@@ -405,22 +405,24 @@ private fun CouncilRoundDivider(label: String) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // V3 review P3 #8: Council marker 切 chatTheme.accent 适配 Paper/Midnight
+        val chatAccent = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent
         Surface(
             shape = RoundedCornerShape(50),
-            color = workspace.blue.copy(alpha = 0.12f),
-            border = BorderStroke(1.dp, workspace.blue.copy(alpha = 0.24f)),
+            color = chatAccent.copy(alpha = 0.12f),
+            border = BorderStroke(1.dp, chatAccent.copy(alpha = 0.24f)),
         ) {
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,
-                color = workspace.blue,
+                color = chatAccent,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
             )
         }
         HorizontalDivider(
             modifier = Modifier.weight(1f),
-            color = workspace.blue.copy(alpha = 0.20f),
+            color = chatAccent.copy(alpha = 0.20f),
         )
     }
 }
@@ -459,7 +461,7 @@ private fun CouncilObjectiveCard(objective: String) {
                     Text(
                         text = if (expanded) "收起" else "展开",
                         style = MaterialTheme.typography.labelSmall,
-                        color = workspace.blue,
+                        color = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent,
                     )
                 }
             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageMessagePartsBlock.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageMessagePartsBlock.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.ui.components.message
 import android.content.Intent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -83,6 +84,8 @@ internal fun MessagePartsBlock(
     onToolAnswer: ((toolCallId: String, answer: String) -> Unit)? = null,
     onOpenWorkspaceFile: ((String) -> Unit)? = null,
     onUserMessageClick: (() -> Unit)? = null,
+    /** V3: 长按 user 消息胶囊触发 menu sheet（复制/重试/编辑/分享/收藏/删除）. */
+    onUserMessageLongClick: (() -> Unit)? = null,
     onGenerativeWidgetAction: (String) -> Unit = {},
     onMiniAppModify: (String) -> Boolean = { false },
 ) {
@@ -144,6 +147,10 @@ internal fun MessagePartsBlock(
                         steps = block.steps,
                         collapsedAdaptiveWidth = isReasoningOnlyBlock,
                         animateContentChanges = loading,
+                        // V3: wrapper 不画 timeline. 改由 ReasoningContent 内部自带 quote
+                        // line, 这样 reasoning step 有竖线、tool call step 没竖线 (符合
+                        // 语义 — tool 是平级独立调用, 不该被串起来).
+                        drawTimeline = false,
                     ) { step ->
                         when (step) {
                             is ThinkingStep.ReasoningStep -> {
@@ -208,32 +215,42 @@ internal fun MessagePartsBlock(
                     is UIMessagePart.Text -> {
                         MessageSelectionContainer {
                                 if (role == MessageRole.USER) {
-                                    // 2026-05-14: removed `.animateContentSizeIf(loading)` —
-                                    // user messages don't change after send, so the loading
-                                    // gate here was always inert except during the brief moment
-                                    // before the assistant reply started. Cost > benefit.
+                                    // V3 Whisper user bubble: full capsule, neutral gray #F2F4F7,
+                                    // subtle rgba(15,20,25,0.06) 1px edge, no left stripe.
+                                    // chat1.md L549 final: borderRadius 999 + padding 10/18.
+                                    // V3: 长按弹 menu sheet（复制/重试/编辑/分享/...). 短按维持 edit 兼容旧行为.
+                                    // DisableSelection 屏蔽 Android 系统的 text selection toolbar
+                                    // (复制/全选/朗读/搜索) ——避免跟我们的 menu sheet 两个面板同时出现.
+                                    androidx.compose.foundation.text.selection.DisableSelection {
+                                    // V3 修: CircleShape (radius = height/2) 多行时 radius 跟随高度暴涨,
+                                    // 让整个 bubble 变成大圆球 (user 报"修改小程序"长消息变球). 改用
+                                    // RoundedCornerShape 固定 19dp ≈ single-line 高度/2, 单行视觉仍是
+                                    // capsule, 多行只是高度增加 (圆角形状不变).
+                                    val userBubbleShape = androidx.compose.foundation.shape.RoundedCornerShape(19.dp)
                                     Surface(
                                         modifier = Modifier
-                                            .widthIn(max = 560.dp),
-                                        shape = RoundedCornerShape(6.dp),
-                                        color = workspace.note,
-                                        contentColor = workspace.ink,
+                                            // V3 convo-user.jsx:paddingLeft:60 —— 长消息保留 60dp
+                                            // 最小左留白避免铺满至左边线，保持右对齐 editorial 感
+                                            .padding(start = 60.dp)
+                                            .widthIn(max = 560.dp)
+                                            .clip(userBubbleShape)
+                                            .combinedClickable(
+                                                onClick = { onUserMessageClick?.invoke() },
+                                                onLongClick = { onUserMessageLongClick?.invoke() },
+                                            ),
+                                        shape = userBubbleShape,
+                                        color = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.userBubble,
+                                        contentColor = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.ink,
                                         tonalElevation = 0.dp,
                                         shadowElevation = 0.dp,
-                                        border = BorderStroke(1.dp, workspace.hairline),
-                                        onClick = { onUserMessageClick?.invoke() },
+                                        border = BorderStroke(
+                                            1.dp,
+                                            me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.userBubbleEdge,
+                                        ),
                                     ) {
                                         Column(
                                             modifier = Modifier
-                                                .drawWithContent {
-                                                    drawRoundRect(
-                                                        color = workspace.blue,
-                                                        topLeft = Offset.Zero,
-                                                        size = Size(width = 3.dp.toPx(), height = size.height),
-                                                    )
-                                                    drawContent()
-                                                }
-                                                .padding(start = 15.dp, end = 12.dp, top = 9.dp, bottom = 9.dp)
+                                                .padding(horizontal = 18.dp, vertical = 10.dp)
                                         ) {
                                             MarkdownBlock(
                                                 content = GenerativeUiPlanner.stripVisualRouteTagsForDisplay(
@@ -248,6 +265,7 @@ internal fun MessagePartsBlock(
                                             )
                                         }
                                     }
+                                    } // end DisableSelection
                                 } else {
                                     // True only when this Text block is the very last block
                                     // in the message AND generation is ongoing. See lastBlockIdx
@@ -347,9 +365,10 @@ internal fun MessagePartsBlock(
                             },
                             modifier = Modifier,
                             shape = RoundedCornerShape(50),
-                            color = workspace.blueContainer.copy(alpha = 0.72f),
-                            contentColor = workspace.blue,
-                            border = BorderStroke(1.dp, workspace.blue.copy(alpha = 0.12f)),
+                            // V3 review P3 #8: 切 chatTheme.accent 系列, 适配 Paper/Midnight
+                            color = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accentSoft,
+                            contentColor = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent,
+                            border = BorderStroke(1.dp, me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent.copy(alpha = 0.12f)),
                         ) {
                             ProvideTextStyle(MaterialTheme.typography.labelSmall) {
                                 Row(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
@@ -31,7 +31,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
@@ -203,26 +205,39 @@ private fun ReasoningContent(
             }
     ) {
         SelectionContainer {
-            Surface(
-                shape = RoundedCornerShape(8.dp),
-                color = workspace.row,
-                contentColor = workspace.muted,
-                border = BorderStroke(1.dp, workspace.hairline),
+            // V3 修: ReasoningContent 自带左竖线 — 让 reasoning step 有线、tool step 没线
+            // (wrapper 不画). 线 X=0 (ReasoningContent 起始, 跟 flushContent=true 的 wrapper
+            // step icon center 12dp 对齐), padding(start=14) 让文字距线 14dp.
+            val thinkRuleColor = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.thinkRule
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .drawBehind {
+                        val strokePx = 2.dp.toPx()
+                        drawLine(
+                            color = thinkRuleColor,
+                            start = Offset(strokePx / 2f, 0f),
+                            end = Offset(strokePx / 2f, size.height),
+                            strokeWidth = strokePx,
+                        )
+                    }
+                    .padding(start = 14.dp),
             ) {
-                // ChainOfThought.animateContentChanges already drives a spring on the
-                // step list; reasoning text rides on that motion. (Char-level fade was
-                // removed across the app 2026-05-15, so there's no fade to consider
-                // forwarding here anyway.)
                 MarkdownBlock(
                     content = MessageRenderCache.visualRegexText(
                         text = displayText,
                         assistant = assistant,
                         scope = AssistantAffectScope.ASSISTANT,
                     ),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.thinkBodyInk,
+                        fontSize = 13.5.sp,
+                        lineHeight = 23.sp,
+                        letterSpacing = 0.2.sp,
+                    ),
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(horizontal = 10.dp, vertical = 8.dp),
+                        .padding(vertical = 2.dp),
                 )
             }
         }
@@ -253,6 +268,9 @@ fun ChainOfThoughtScope.ChatMessageReasoningStep(
     }
     val budgetLabel = reasoningLevel.reasoningBudgetLabel()
 
+    // V3 主题感知 + 设计稿对齐: brain 图标 (替代默认灰圆豆 dot, 让"小图标"代表思考 step) +
+    //   flushContent=true 让 content 引用竖线 X 对齐 step icon center (12dp)
+    val chatThemeForReasoning = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
     ControlledChainOfThoughtStep(
         expanded = state.expandState == ReasoningCardState.Expanded,
         onExpandedChange = { state.onExpandedChange(it, reasoningLoading) },
@@ -260,53 +278,59 @@ fun ChainOfThoughtScope.ChatMessageReasoningStep(
             Icon(
                 imageVector = HugeIcons.Brain02,
                 contentDescription = null,
+                tint = chatThemeForReasoning.thinkHeaderInk,
                 modifier = Modifier.size(14.dp),
-                tint = workspace.blue.copy(alpha = 0.72f),
             )
         },
         label = {
             if (thinkingTitle != null) {
                 ReasoningTitle(title = thinkingTitle)
             } else {
+                val baseText = if (showReasoningDuration) {
+                    stringResource(
+                        R.string.deep_thinking_seconds,
+                        state.duration.toDouble(DurationUnit.SECONDS).toFloat()
+                    )
+                } else {
+                    stringResource(R.string.deep_thinking)
+                }
+                // V3 设计稿: "思考了 5.4 秒 · auto" 一体显示，不分 extra
+                val combinedText = if (budgetLabel != null) "$baseText · $budgetLabel" else baseText
                 Text(
-                    text = if (showReasoningDuration) {
-                        stringResource(
-                            R.string.deep_thinking_seconds,
-                            state.duration.toDouble(DurationUnit.SECONDS).toFloat()
-                        )
-                    } else {
-                        stringResource(R.string.deep_thinking)
-                    },
+                    text = combinedText,
                     style = MaterialTheme.typography.labelSmall.copy(
-                        fontSize = 12.sp,
+                        // V3 设计稿: 头部 13sp + 字距 0.2
+                        fontSize = 13.sp,
                         fontWeight = FontWeight.Normal,
+                        letterSpacing = 0.2.sp,
                     ),
-                    color = workspace.blue.copy(alpha = 0.72f),
+                    color = chatThemeForReasoning.thinkHeaderInk,  // 鲜亮 accent，不再 0.72 alpha
                     modifier = Modifier.shimmer(isLoading = reasoningLoading),
                 )
             }
         },
         extra = {
+            // V3 设计稿: 流式 title 时仅显示 duration 在右侧
             val durationLabel = if (showThinkingTitle && state.duration > 0.seconds) {
                 state.duration.toString(DurationUnit.SECONDS, 1)
             } else {
                 null
             }
-            val metaText = listOfNotNull(durationLabel, budgetLabel).joinToString(" · ")
-            if (metaText.isNotBlank()) {
+            if (durationLabel != null) {
                 Text(
-                    text = metaText,
+                    text = durationLabel,
                     style = MaterialTheme.typography.labelSmall.copy(
                         fontSize = 10.sp,
                         fontWeight = FontWeight.Normal,
                     ),
-                    color = workspace.blue.copy(alpha = 0.56f),
+                    color = chatThemeForReasoning.thinkHeaderInk.copy(alpha = 0.56f),
                     modifier = Modifier.shimmer(isLoading = reasoningLoading),
                 )
             }
         },
         collapsedAdaptiveWidth = collapsedAdaptiveWidth,
         contentVisible = state.expandState != ReasoningCardState.Collapsed,
+        flushContent = true,  // V3: content 竖线 X 跟 step icon center 对齐
         content = {
             ReasoningContent(
                 reasoning = reasoning,
@@ -361,7 +385,7 @@ private fun reasoningDisplayLimit(
 
 @Composable
 private fun ReasoningTitle(title: String) {
-    val workspace = workspaceColors()
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
     AnimatedContent(
         targetState = title,
         transitionSpec = {
@@ -376,7 +400,8 @@ private fun ReasoningTitle(title: String) {
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Normal,
             ),
-            color = workspace.blue.copy(alpha = 0.72f),
+            // V3 主题感知 (Paper 砖红 / Plain 黑 / Midnight 靛蓝)
+            color = chatTheme.thinkHeaderInk.copy(alpha = 0.72f),
             modifier = Modifier
                 .padding(horizontal = 4.dp)
                 .shimmer(true),

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -345,11 +346,16 @@ internal fun AgentToolCallCapsule(
     subtitle: String? = null,
 ) {
     val workspace = workspaceColors()
-    val tone = toolStatusTone(status)
-    val shape = RoundedCornerShape(10.dp)
-    val kindDescription = toolKindLabel(kind, toolName)
+    val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3 ResultPill spec (convo-tool-result.jsx:80):
+    //   padding 3/10/3/3, fillMaxWidth, 999 圆角, toolPillBg + 1dp toolPillEdge
+    //   左侧 16dp accent 圆 + 10dp 白勾 (替代旧 15dp tool 图标)
+    //   inline "tool · query" 11.5sp letter 0.2  toolLabelInk W500 / inkSoft W400
+    //   高度 ~22dp (3+16+3)
+    val shape = androidx.compose.foundation.shape.CircleShape
     Surface(
         modifier = modifier
+            // V3: 改 wrapContentWidth, 胶囊自适应内容长度而非顶满整行
             .wrapContentWidth(align = Alignment.Start)
             .widthIn(max = 460.dp)
             .clip(shape)
@@ -362,54 +368,95 @@ internal fun AgentToolCallCapsule(
             )
             .animateContentSize(animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec()),
         shape = shape,
-        color = workspace.paper,
+        color = theme.toolPillBg,
         contentColor = workspace.ink,
-        shadowElevation = 1.dp,
-        border = BorderStroke(1.dp, workspace.hairline),
+        shadowElevation = 0.dp,
+        border = BorderStroke(1.dp, theme.toolPillEdge),
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 9.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+        Row(
+            modifier = Modifier.padding(start = 3.dp, end = 10.dp, top = 3.dp, bottom = 3.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            V3ToolLeadingBadge(
+                status = status,
+                loading = loading,
+            )
+
+            // Inline "label · name" 11.5sp letter 0.2. wrapContentWidth 模式下不再 weight(1f)
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                WorkspaceLeadingIcon(
-                    icon = icon,
-                    size = 28.dp,
-                    iconSize = 15.dp,
-                    tone = tone,
+                Text(
+                    text = title,
+                    fontSize = 11.5.sp,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,
+                    letterSpacing = 0.2.sp,
+                    color = theme.toolLabelInk,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.shimmer(isLoading = loading && status == AgentToolStatus.RUNNING),
                 )
-
-                Column(modifier = Modifier.weight(1f, fill = false)) {
+                if (!subtitle.isNullOrBlank()) {
                     Text(
-                        text = title,
-                        style = MaterialTheme.typography.titleSmall,
-                        color = workspace.ink,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.shimmer(isLoading = loading && status == AgentToolStatus.RUNNING),
-                    )
-                    Text(
-                        text = subtitle ?: "$kindDescription · ${toolName.compactToolPreview(28)}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = workspace.muted,
+                        text = " $subtitle",
+                        fontSize = 11.5.sp,
+                        fontWeight = androidx.compose.ui.text.font.FontWeight.Normal,
+                        letterSpacing = 0.2.sp,
+                        color = theme.inkSoft,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                }
-
-                if (approvalActions != null) {
-                    approvalActions()
-                } else {
-                    ToolStatusPill(status = status)
                 }
             }
-            // Note: dropped the LinearProgressIndicator below the row. Title-level shimmer
-            // (line 409) plus the running status pill on the right already convey "in flight";
-            // the indeterminate bar's segmented sweep (Material3 1.3+ default) read as stuttery
-            // against this tight capsule layout and added visual noise without info gain.
+
+            // V3: 删除右侧 ToolStatusPill ("失败" 文字框). 左侧 badge 已用红 X 表达 FAILED,
+            // 右侧再重复"失败"文字 pill 是冗余. 仅保留 approval actions (待授权时仍需操作按钮).
+            if (approvalActions != null) {
+                approvalActions()
+            }
+        }
+    }
+}
+
+/** V3 spec: 16dp accent 圆 + 10dp 白勾。非成功状态映射其他 tone。 */
+@Composable
+private fun V3ToolLeadingBadge(
+    status: AgentToolStatus,
+    loading: Boolean,
+) {
+    val theme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val workspace = workspaceColors()
+    val (bg, ink) = when (status) {
+        AgentToolStatus.SUCCEEDED -> theme.toolDoneBg to theme.toolDoneBadgeInk
+        AgentToolStatus.RUNNING -> theme.toolDoneBg to theme.toolDoneBadgeInk
+        AgentToolStatus.WAITING_FOR_PERMISSION -> workspace.amber to Color.White
+        AgentToolStatus.FAILED -> workspace.red to Color.White
+        AgentToolStatus.CANCELLED -> workspace.muted to Color.White
+    }
+    Surface(
+        modifier = Modifier
+            .size(16.dp)
+            .shimmer(isLoading = loading && status == AgentToolStatus.RUNNING),
+        shape = androidx.compose.foundation.shape.CircleShape,
+        color = bg,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (status == AgentToolStatus.SUCCEEDED || status == AgentToolStatus.RUNNING) {
+                Icon(
+                    imageVector = me.rerere.hugeicons.HugeIcons.Tick01,
+                    contentDescription = null,
+                    tint = ink,
+                    modifier = Modifier.size(10.dp),
+                )
+            } else if (status == AgentToolStatus.FAILED) {
+                Icon(
+                    imageVector = me.rerere.hugeicons.HugeIcons.Cancel01,
+                    contentDescription = null,
+                    tint = ink,
+                    modifier = Modifier.size(10.dp),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageVirtualItems.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageVirtualItems.kt
@@ -39,6 +39,7 @@ import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.utils.amberTraceMeasure
 import me.rerere.rikkahub.utils.base64Encode
+import me.rerere.rikkahub.utils.copyMessageToClipboard
 import java.util.Locale
 
 internal const val ChatMessageVirtualMarkdownMinChars = 600
@@ -475,8 +476,13 @@ private fun ChatMessageVirtualFooter(
             }
         }
 
-        ProvideTextStyle(textStyle) {
-            ChatMessageNerdLine(message = message)
+        // V3: 隐藏 Nerd Line (跟 ChatMessage.kt 同步). ContextRing popover 有相同数据.
+        @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+        val SHOW_NERD_LINE = false
+        if (SHOW_NERD_LINE) {
+            ProvideTextStyle(textStyle) {
+                ChatMessageNerdLine(message = message)
+            }
         }
     }
 
@@ -491,22 +497,12 @@ private fun ChatMessageVirtualFooter(
             onSelectAndCopy = {
                 showSelectCopySheet = true
             },
+            onCopy = {
+                context.copyMessageToClipboard(message)
+            },
+            onRegenerate = onRegenerate,
             isFavorite = isFavorite,
             onToggleFavorite = onToggleFavorite,
-            onWebViewPreview = {
-                val textContent = message.parts
-                    .filterIsInstance<UIMessagePart.Text>()
-                    .joinToString("\n\n") { it.text }
-                    .trim()
-                if (textContent.isNotBlank()) {
-                    val htmlContent = buildMarkdownPreviewHtml(
-                        context = context,
-                        markdown = textContent,
-                        colorScheme = colorScheme
-                    )
-                    navController.navigate(Screen.WebView(content = htmlContent.base64Encode()))
-                }
-            },
             onDismissRequest = {
                 showActionsSheet = false
             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/GenerativeWidgetCard.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/GenerativeWidgetCard.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -170,14 +171,22 @@ fun GenerativeWidgetCard(
         )
     }
 
+    // V3: 画板风 widget 卡片. 之前用 colorScheme.surface + outlineVariant 1dp 在 Paper/Midnight
+    // 主题下会显示成"硬黑框 + 浅底", 跟设计稿不符. 改为 chatTheme.widgetCanvas (比 bg 略深,
+    // 暗色略浅), 默认无描边; 若主题显式给了 widgetCanvasBorder 才画 1dp 描边.
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val widgetSurfaceColor = chatTheme.widgetCanvas.takeIf { it.isSpecified } ?: MaterialTheme.colorScheme.surface
+    val widgetBorder = chatTheme.widgetCanvasBorder
+        .takeIf { it.alpha > 0f }
+        ?.let { BorderStroke(1.dp, it) }
     Surface(
         modifier = modifier
             .fillMaxWidth()
             .clickable(enabled = canOpenExpanded) { showExpanded = true },
         shape = RoundedCornerShape(10.dp),
-        color = MaterialTheme.colorScheme.surface,
+        color = widgetSurfaceColor,
         contentColor = MaterialTheme.colorScheme.onSurface,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.72f)),
+        border = widgetBorder,
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ToolResultPreview.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ToolResultPreview.kt
@@ -1,0 +1,304 @@
+package me.rerere.rikkahub.ui.components.message
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.ArrowLeft02
+import me.rerere.hugeicons.stroke.ArrowRight02
+import me.rerere.hugeicons.stroke.Tick01
+import me.rerere.rikkahub.ui.pages.chat.LocalChatTheme
+
+/**
+ * V3 ToolResultPreview —— 工具预览卡 (sticky shelf, 常驻 composer 上方)
+ *
+ * 设计规格（claude design 工具预览卡）：
+ *  - 容器: padding(start=14, end=32, top=10, bottom=8) asymmetric, gap=10, align=Bottom
+ *  - 缩略图: 72×96 (3:4) + 8dp radius + 1dp border 8% ink + 单层柔影 0.06
+ *  - 缩略图内: Google 字标 / search input / tab strip / 2 result blocks / divider
+ *  - 结果胶囊: 22dp 高 + 16dp accent 圆 + 白勾 + tool · query + page chevrons
+ *  - 主题色: previewBg / previewEdge / Google 字标 / 状态圆点 / 胶囊底 跟主题
+ */
+@Composable
+fun ToolResultPreview(
+    tool: String,
+    query: String,
+    page: Int,
+    total: Int,
+    modifier: Modifier = Modifier,
+    onPrev: (() -> Unit)? = null,
+    onNext: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 14.dp, end = 32.dp, top = 10.dp, bottom = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Bottom,  // 设计稿：胶囊底沿与缩略图底沿对齐
+    ) {
+        PreviewThumb()
+        Box(modifier = Modifier.weight(1f)) {
+            ResultPill(tool = tool, query = query, page = page, total = total, onPrev = onPrev, onNext = onNext)
+        }
+    }
+}
+
+@Composable
+private fun PreviewThumb() {
+    val theme = LocalChatTheme.current
+    // 设计稿: previewBg 主题 surface (Whisper/Plain 白 / Paper 纸黄 / Midnight 半透白)
+    // border 8% ink (比 composer 5% 略明显) + 单层柔影 0.06 (比 composer 0.08 轻一档)
+    Box(
+        modifier = Modifier
+            .size(width = 72.dp, height = 96.dp)
+            .shadow(
+                elevation = 3.dp,
+                shape = RoundedCornerShape(8.dp),
+                ambientColor = Color(0x0F0F1419),  // rgba(15,20,25,0.06)
+                spotColor = Color(0x0F0F1419),
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .background(theme.surface)
+            .border(
+                BorderStroke(1.dp, Color(0x140F1419)),  // rgba(15,20,25,0.08)
+                RoundedCornerShape(8.dp),
+            ),
+    ) {
+        FakeBrowser()
+    }
+}
+
+/** 假浏览器 mock —— 让眼睛 250ms 内识别"这是网页"，所有文字都用 div 色块替代 */
+@Composable
+private fun FakeBrowser() {
+    val theme = LocalChatTheme.current
+    // 设计稿: previewDim rgba(15,20,25,0.08) / previewDimSoft rgba(15,20,25,0.04)
+    val dim = Color(0x140F1419)
+    val dimSoft = Color(0x0A0F1419)
+    // Google 字标色: 浅色主题 #4285F4, 深色主题改更亮的 #6A9DEB
+    val googleColor = if (theme.isDark) Color(0xFF6A9DEB) else Color(0xFF4285F4)
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // 1) Google 字标 — 8sp / W700 / 顶 6dp 底 3dp
+        Text(
+            text = "Google",
+            fontSize = 8.sp,
+            fontWeight = FontWeight.Bold,
+            color = googleColor,
+            letterSpacing = 0.3.sp,
+            modifier = Modifier.padding(start = 7.dp, end = 7.dp, top = 6.dp, bottom = 3.dp),
+        )
+        // 2) 搜索框 — 高 11dp / 6dp 圆角 / dimSoft 底 / 0.5dp dim 描边
+        Row(
+            modifier = Modifier
+                .padding(horizontal = 7.dp)
+                .height(11.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .background(dimSoft)
+                .border(0.5.dp, dim, RoundedCornerShape(6.dp))
+                .padding(horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            // 3dp 圆形空心描边
+            Box(
+                modifier = Modifier
+                    .size(3.dp)
+                    .clip(CircleShape)
+                    .border(0.5.dp, theme.inkSoft.copy(alpha = 0.6f), CircleShape),
+            )
+            // 2dp 横线模拟输入文字
+            Box(
+                modifier = Modifier
+                    .height(2.dp)
+                    .weight(1f)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(dim),
+            )
+        }
+        // 3) 标签栏 — 5.5sp / 4 标签 / 当前激活"全部"用 accent 蓝 + W700
+        Row(
+            modifier = Modifier.padding(start = 7.dp, end = 7.dp, top = 5.dp, bottom = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text("AI", fontSize = 5.5.sp, color = theme.inkFaint)
+            Text("全部", fontSize = 5.5.sp, color = theme.accent, fontWeight = FontWeight.Bold)
+            Text("图片", fontSize = 5.5.sp, color = theme.inkFaint)
+            Text("购物", fontSize = 5.5.sp, color = theme.inkFaint)
+        }
+        // 4) 结果块 1 — 标题 2dp 宽 45% accent 0.85, 摘要 1.5dp 宽 90%/80% dim
+        Column(
+            modifier = Modifier.padding(start = 7.dp, end = 7.dp, top = 2.dp, bottom = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.45f)
+                    .height(2.dp)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(theme.accent.copy(alpha = 0.85f)),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.90f)
+                    .height(1.5.dp)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(dim),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.80f)
+                    .height(1.5.dp)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(dim),
+            )
+        }
+        // 5) 分隔线 — 0.5dp dimSoft / 左右 margin 7dp
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 7.dp, vertical = 2.dp)
+                .fillMaxWidth()
+                .height(0.5.dp)
+                .background(dimSoft),
+        )
+        // 6) 结果块 2 — 标题宽 38% / opacity 0.7
+        Column(
+            modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.38f)
+                    .height(2.dp)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(theme.accent.copy(alpha = 0.7f)),
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.85f)
+                    .height(1.5.dp)
+                    .clip(RoundedCornerShape(1.dp))
+                    .background(dim),
+            )
+        }
+    }
+}
+
+/** 状态胶囊 —— 22dp 高 / fillMaxWidth / 16dp accent 圆 + 白勾 / inline name·query + 分页 */
+@Composable
+private fun ResultPill(
+    tool: String,
+    query: String,
+    page: Int,
+    total: Int,
+    onPrev: (() -> Unit)?,
+    onNext: (() -> Unit)?,
+) {
+    val theme = LocalChatTheme.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(CircleShape)
+            .background(theme.toolPillBg)
+            .border(BorderStroke(1.dp, Color(0x0D0F1419)), CircleShape)  // 5% ink
+            .padding(start = 3.dp, end = 10.dp, top = 3.dp, bottom = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        // 状态圆点：16dp accent 实心圆 + 白勾 (3 stroke) - 不要描边
+        Box(
+            modifier = Modifier
+                .size(16.dp)
+                .clip(CircleShape)
+                .background(theme.toolDoneBg),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = HugeIcons.Tick01,
+                contentDescription = null,
+                modifier = Modifier.size(10.dp),
+                tint = theme.toolDoneBadgeInk,
+            )
+        }
+        // tool · query inline，工具名 ink + W500，查询词 inkSoft + W400
+        Row(
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = tool,
+                fontSize = 11.5.sp,
+                color = theme.toolLabelInk,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.2.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = " $query",
+                fontSize = 11.5.sp,
+                color = theme.inkSoft,
+                fontWeight = FontWeight.Normal,
+                letterSpacing = 0.2.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        // 翻页器：9dp chevrons + tabular-nums 数字 10.5sp inkSoft
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = HugeIcons.ArrowLeft02,
+                contentDescription = "prev",
+                modifier = Modifier
+                    .size(9.dp)
+                    .then(if (onPrev != null) Modifier.clickable { onPrev() } else Modifier),
+                tint = theme.inkSoft,
+            )
+            Text(
+                text = "$page/$total",
+                fontSize = 10.5.sp,
+                color = theme.inkSoft,
+                letterSpacing = 0.4.sp,
+            )
+            Icon(
+                imageVector = HugeIcons.ArrowRight02,
+                contentDescription = "next",
+                modifier = Modifier
+                    .size(9.dp)
+                    .then(if (onNext != null) Modifier.clickable { onNext() } else Modifier),
+                tint = theme.inkSoft,
+            )
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/CharReveal.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/CharReveal.kt
@@ -55,11 +55,10 @@ enum class StreamRevealPreset(val baseRevealDurationMs: Long) {
     /** Snappy: ~120ms fade. Closest to "no animation but with a soft edge". */
     REALTIME(120L),
 
-    /** Default. ~80ms — ~5 frames @60Hz. "Crisp typing" sweet spot: short
-     *  enough to feel snappy, long enough that the fade is still
-     *  perceivable. Was 200L before the experiment; flip back if streaming
-     *  jank surfaces on slow devices. */
-    BALANCED(80L),
+    /** Default. ~240ms — Codex 同档. 配合 ease-out-expo + baselineShift y-offset
+     *  实现"字符轻飘上浮"质感. 200ms 仍偏短, 240ms 跨 ~2 个 chunk 间隔, 让多字
+     *  fade 窗口稳定重叠, 视觉是连续 cross-fade 而非脉冲. */
+    BALANCED(240L),
 
     /** Slow + cinematic. ~320ms — feels deliberate, good for long replies. */
     SILKY(320L),
@@ -88,10 +87,11 @@ private const val BACKLOG_DEGRADE = 80
  * is this fraction of the preset's base. Below SOFT_BACKPRESSURE_BACKLOG
  * the factor is 1.0; the ramp lerps between them.
  *
- * 0.30 means a 200ms preset compresses to 60ms at queueDepth=80 — fast
- * enough to catch up, slow enough that the fade is still visible.
+ * 之前 0.30 在 200ms 设置下降级到 60ms — 落进 flicker fusion 区(50-100ms),
+ * 视觉成"脉冲". 提到 0.55 让 240ms × 0.55 = 132ms, 跨过阈值, backlog 满时
+ * 仍有 ~8 帧平滑 fade, 不闪.
  */
-private const val BACKPRESSURE_DURATION_FLOOR = 0.30f
+private const val BACKPRESSURE_DURATION_FLOOR = 0.55f
 
 /**
  * EWMA-smoothed FPS below which we drop the fade animation entirely.
@@ -361,7 +361,12 @@ class CharRevealController internal constructor(
                 val age = nowNanos - entry.appearNanos
                 if (age <= 0L) return 0f
                 if (age >= effective) return 1f
-                return age.toFloat() / effective.toFloat()
+                // V3: ease-out-expo `1 - (1-t)^5` 替代 linear. Codex 同款曲线 —
+                // 前 30% 时窗走完 ~83% 进度, 视觉是"快速浮现 + 慢速 settle",
+                // 这才是"轻飘飘"感的核心. Linear 看起来机械.
+                val t = age.toFloat() / effective.toFloat()
+                val inv = 1f - t
+                return 1f - inv * inv * inv * inv * inv
             }
         }
         // Fall-through: shouldn't happen if onContentChanged was called

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -55,6 +56,7 @@ import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -922,12 +924,14 @@ private fun MarkdownNode(
         // 引用块
         MarkdownElementTypes.BLOCK_QUOTE -> {
             ProvideTextStyle(LocalTextStyle.current.copy(fontStyle = FontStyle.Italic)) {
+                // Bug fix: 之前用 drawWithContent + drawRect 把 bg 画在 content 之上 (蒙层覆盖
+                // 文字), 深色下文字几乎看不见. 改 drawBehind 让 bg 画在 content 之后.
+                // 同时降低 bgColor alpha (0.2 → 0.12), 在深色下也清爽.
                 val borderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-                val bgColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f)
+                val bgColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.12f)
                 Column(
                     modifier = Modifier
-                        .drawWithContent {
-                            drawContent()
+                        .drawBehind {
                             drawRect(
                                 color = bgColor, size = size
                             )
@@ -1825,6 +1829,17 @@ internal fun shouldMarkLeafAsFadeEligible(
  * [ranges] is empty — preserves Color.Unspecified parity with the
  * pre-refactor leaf-text fast path.
  */
+/**
+ * V3: 给 fade 中的字符加 baselineShift 模拟"从下方浮上来"(Codex 同款).
+ * alpha=0 → shift = -0.15 (字在 baseline 下方 ~15% font size ≈ 2-3px)
+ * alpha=1 → shift = 0 (归位)
+ * BaselineShift 是 SpanStyle 字段, 不影响 line height (Compose 已 clamp).
+ */
+private fun fadingSpanStyle(baseColor: Color, alpha: Float): SpanStyle = SpanStyle(
+    color = baseColor.copy(alpha = alpha),
+    baselineShift = BaselineShift(-(1f - alpha) * 0.15f),
+)
+
 internal fun applyRevealOverlay(
     static: AnnotatedString,
     ranges: List<AnnotatedString.Range<String>>,
@@ -1865,7 +1880,7 @@ internal fun applyRevealOverlay(
                         runAlpha = alpha
                     } else if (alpha != runAlpha) {
                         addStyle(
-                            style = SpanStyle(color = baseColor.copy(alpha = runAlpha)),
+                            style = fadingSpanStyle(baseColor, runAlpha),
                             start = runStart,
                             end = i,
                         )
@@ -1877,7 +1892,7 @@ internal fun applyRevealOverlay(
                     // accumulated run. The revealed codepoint itself
                     // needs no style.
                     addStyle(
-                        style = SpanStyle(color = baseColor.copy(alpha = runAlpha)),
+                        style = fadingSpanStyle(baseColor, runAlpha),
                         start = runStart,
                         end = i,
                     )
@@ -1887,7 +1902,7 @@ internal fun applyRevealOverlay(
             }
             if (runStart >= 0) {
                 addStyle(
-                    style = SpanStyle(color = baseColor.copy(alpha = runAlpha)),
+                    style = fadingSpanStyle(baseColor, runAlpha),
                     start = runStart,
                     end = rangeEnd,
                 )

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -596,12 +597,13 @@ private fun HtmlCodeBlock(element: Element) {
 @Composable
 private fun HtmlBlockquote(element: Element, onClickCitation: (String) -> Unit) {
     ProvideTextStyle(LocalTextStyle.current.copy(fontStyle = FontStyle.Italic)) {
+        // Bug fix: drawWithContent + drawRect 把 bg 画在 content 之上盖住文字, 深色下看不清.
+        // 改 drawBehind, bgColor alpha 0.2→0.12 减轻蒙层感.
         val borderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-        val bgColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f)
+        val bgColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.12f)
         Column(
             modifier = Modifier
-                .drawWithContent {
-                    drawContent()
+                .drawBehind {
                     drawRect(color = bgColor, size = size)
                     drawRect(color = borderColor, size = Size(10f, size.height))
                 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/SearchImageBlock.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/SearchImageBlock.kt
@@ -245,8 +245,10 @@ private fun ThumbnailImage(
             // <50dp tall. With the LazyRow path replacing that case, it's now
             // only ever hit if the parent bubble is very narrow (<170dp wide)
             // — preferred over a sub-50dp sliver in that edge.
-            .aspectRatio(4f / 3f)
-            .heightIn(min = 72.dp)
+            // V3 设计稿: 网页预览缩略图 3:4 竖向 (不是 4:3 横向)
+            // 因为预览内容是网页 / app / 文档类竖向素材
+            .aspectRatio(3f / 4f)
+            .heightIn(min = 96.dp)
             .clip(RoundedCornerShape(8.dp))
             .clickable { showViewer = true },
         contentScale = ContentScale.Crop,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/CardGroup.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/CardGroup.kt
@@ -32,7 +32,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachIndexed
 import me.rerere.rikkahub.ui.theme.CustomColors
 
-private val CardGroupCorner = 12.dp
+// V3 settings-screen.jsx:79 borderRadius: 18 —— 之前 12dp 偏紧、不像 editorial 卡
+private val CardGroupCorner = 18.dp
 private val CardGroupItemSpacing = 1.dp
 private val CardGroupInnerCorner = 2.dp
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ChainOfThought.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ChainOfThought.kt
@@ -68,29 +68,44 @@ private val LocalCardColor = staticCompositionLocalOf { Color.White }
 @Composable
 fun <T> ChainOfThought(
     modifier: Modifier = Modifier,
+    // V3 设计稿: ChainOfThought wrapper 不要外框 (Card + surfaceColorAtElevation 是
+    //   "灰色背景框")。每个 step 自己负责自己的引用样式 (reasoning 用 thinkRule 左竖线,
+    //   工具用 capsule 等). 透明 + 0 elevation = 视觉无框, 还保留 Card semantics
+    //   (rounded corners 不需要; 留给可能的未来需要).
     cardColors: CardColors = CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(4.dp),
+        containerColor = Color.Transparent,
     ),
     steps: List<T>,
     collapsedVisibleCount: Int = 2,
     collapsedAdaptiveWidth: Boolean = false,
     animateContentChanges: Boolean = true,
+    // V3 设计稿: 单 reasoning step 时不需要 wrapper 竖线 (内层 ReasoningContent 已自带
+    //   引用竖线), 重复两道线观感差. 多 step 链条仍保留 wrapper 竖线作时间线 visual.
+    drawTimeline: Boolean = true,
     content: @Composable ChainOfThoughtScope.(T) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
     val canCollapse = steps.size > collapsedVisibleCount
     val shouldFillCollapseControlWidth = expanded || !collapsedAdaptiveWidth
 
+    // V3: cardColors 透明时, icon 后面用 scheme.background 遮挡, 避免 wrapper timeline
+    // 竖线穿过 icon center. (LocalCardColor 之前是 cardColors.containerColor, 透明时遮挡失效)
+    val maskColor = if (cardColors.containerColor == Color.Transparent) {
+        MaterialTheme.colorScheme.background
+    } else {
+        cardColors.containerColor
+    }
     CompositionLocalProvider(
-        LocalCardColor provides cardColors.containerColor
+        LocalCardColor provides maskColor
     ) {
         Card(
             modifier = modifier,
             colors = cardColors,
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         ) {
             Column(
                 modifier = Modifier
-                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                    // V3: padding 内缩到 0 (外框已透明, 不需要 inner padding)
                     .then(
                         if (animateContentChanges) {
                             Modifier.animateContentSize(
@@ -153,18 +168,25 @@ fun <T> ChainOfThought(
                     }
                 }
 
-                val lineColor = MaterialTheme.colorScheme.outlineVariant
+                // V3: 左竖线用 chatTheme.thinkRule 替代 outlineVariant (faint 灰)
+                // 这样思考链条左线跟主题 accent 走（Whisper 蓝 / Paper 砖红 / Plain 黑 / Midnight 靛蓝）
+                // drawTimeline=false 时跳过竖线（reasoning-only 时由 ReasoningContent 自带引用线，wrapper 不重复画）
+                val lineColor = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.thinkRule
                 val scope = remember { ChainOfThoughtScopeImpl() }
                 Box(
-                    modifier = Modifier.drawBehind {
-                        val x = 12.dp.toPx()
-                        val offsetPx = 18.dp.toPx()
-                        drawLine(
-                            color = lineColor,
-                            start = Offset(x, offsetPx),
-                            end = Offset(x, size.height - offsetPx),
-                            strokeWidth = 1.dp.toPx()
-                        )
+                    modifier = if (drawTimeline) {
+                        Modifier.drawBehind {
+                            val x = 12.dp.toPx()
+                            val offsetPx = 18.dp.toPx()
+                            drawLine(
+                                color = lineColor,
+                                start = Offset(x, offsetPx),
+                                end = Offset(x, size.height - offsetPx),
+                                strokeWidth = 2.dp.toPx()
+                            )
+                        }
+                    } else {
+                        Modifier
                     }
                 ) {
                     Column {
@@ -230,6 +252,9 @@ interface ChainOfThoughtScope {
         onClick: (() -> Unit)? = null,
         collapsedAdaptiveWidth: Boolean = false,
         contentVisible: Boolean = expanded,
+        /** true 时 content 起始 X 跟 step icon center (12dp) 对齐 (而非默认 32dp label 缩进).
+         *  reasoning step 用 true, 让 ReasoningContent 引用竖线 X = wrapper timeline X. */
+        flushContent: Boolean = false,
         content: (@Composable () -> Unit)? = null,
     )
 }
@@ -268,6 +293,7 @@ private class ChainOfThoughtScopeImpl : ChainOfThoughtScope {
         onClick: (() -> Unit)?,
         collapsedAdaptiveWidth: Boolean,
         contentVisible: Boolean,
+        flushContent: Boolean,
         content: @Composable (() -> Unit)?
     ) {
         ChainOfThoughtStepContent(
@@ -279,6 +305,7 @@ private class ChainOfThoughtScopeImpl : ChainOfThoughtScope {
             expanded = expanded,
             onExpandedChange = onExpandedChange,
             contentVisible = contentVisible,
+            flushContent = flushContent,
             content = content,
         )
     }
@@ -293,6 +320,7 @@ private class ChainOfThoughtScopeImpl : ChainOfThoughtScope {
         expanded: Boolean,
         onExpandedChange: (Boolean) -> Unit,
         contentVisible: Boolean,
+        flushContent: Boolean = false,
         content: @Composable (() -> Unit)?
     ) {
         val hasContent = content != null
@@ -399,8 +427,31 @@ private class ChainOfThoughtScopeImpl : ChainOfThoughtScope {
                 }
             }
 
-            // 展开内容（缩进对齐 label）
-            if (contentVisible && hasContent) {
+            // 展开内容：默认缩进对齐 label (32dp). flushContent=true 时缩进对齐 step icon
+            // center (12dp), 让 reasoning content 引用竖线和 wrapper timeline 同 X.
+            // 用 AnimatedVisibility 加 expand+fade 过渡, 替代之前直接 if-render 的硬切.
+            val contentStartPadding = if (flushContent) 12.dp else 32.dp
+            androidx.compose.animation.AnimatedVisibility(
+                visible = contentVisible && hasContent,
+                enter = androidx.compose.animation.expandVertically(
+                    animationSpec = androidx.compose.animation.core.tween(
+                        durationMillis = 220,
+                        easing = androidx.compose.animation.core.FastOutSlowInEasing,
+                    ),
+                    expandFrom = androidx.compose.ui.Alignment.Top,
+                ) + androidx.compose.animation.fadeIn(
+                    animationSpec = androidx.compose.animation.core.tween(180),
+                ),
+                exit = androidx.compose.animation.shrinkVertically(
+                    animationSpec = androidx.compose.animation.core.tween(
+                        durationMillis = 180,
+                        easing = androidx.compose.animation.core.FastOutSlowInEasing,
+                    ),
+                    shrinkTowards = androidx.compose.ui.Alignment.Top,
+                ) + androidx.compose.animation.fadeOut(
+                    animationSpec = androidx.compose.animation.core.tween(140),
+                ),
+            ) {
                 Box(
                     modifier = Modifier
                         .then(
@@ -410,9 +461,9 @@ private class ChainOfThoughtScopeImpl : ChainOfThoughtScope {
                                 Modifier
                             }
                         )
-                        .padding(start = 32.dp, top = 4.dp, bottom = 8.dp)
+                        .padding(start = contentStartPadding, top = 4.dp, bottom = 8.dp)
                 ) {
-                    content()
+                    content?.invoke()
                 }
             }
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Input.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Input.kt
@@ -1,6 +1,18 @@
 package me.rerere.rikkahub.ui.components.ui
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -8,12 +20,22 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.rerere.rikkahub.ui.pages.chat.LocalChatTheme
+import me.rerere.rikkahub.ui.theme.JetbrainsMono
 
 @Composable
 fun <T : Number> OutlinedNumberInput(
@@ -89,3 +111,92 @@ fun <T : Number> NumberInput(
 
 private val NumberRegex = Regex("^[+-]?\\d+(\\.\\d+)?$")
 private fun String.isValidNumberInput() = this.isNotEmpty() && NumberRegex.matches(this)
+
+/**
+ * V3 平卡输入 —— provider-screens.jsx Field 设计稿：
+ *   - label 在上：12sp inkFaint letterSpacing 0.4 + paddingStart 2dp + marginBottom 8dp
+ *   - 输入卡：padding 12/14 + 12dp 圆角 + chatTheme.surface + 1dp hair border + 14.5sp ink
+ *   - error: border 走 error 色
+ *   - mono: 字体切 JetbrainsMono（API key / private key / base url 等）
+ */
+@Composable
+fun FlatTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    isError: Boolean = false,
+    singleLine: Boolean = true,
+    mono: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    supportingText: String? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+) {
+    val theme = LocalChatTheme.current
+    val errorColor = MaterialTheme.colorScheme.error
+    val borderColor = when {
+        isError -> errorColor
+        else -> theme.hair
+    }
+    val textColor = if (enabled) theme.ink else theme.inkSoft
+    val selectionColors = TextSelectionColors(
+        handleColor = theme.accent,
+        backgroundColor = theme.accent.copy(alpha = 0.30f),
+    )
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            color = theme.inkFaint,
+            letterSpacing = 0.4.sp,
+            modifier = Modifier.padding(start = 2.dp, bottom = 8.dp),
+        )
+        // V3 review P3 #5: singleLine 时默认 ImeAction.Done (BasicTextField 不像 M3 TextField 自动配)
+        // V3 review P3 #6: BasicTextField 默认按内容宽度, 加 fillMaxWidth 让整个 surface 都可点击聚焦
+        val effectiveKeyboardOptions = if (singleLine && keyboardOptions == KeyboardOptions.Default) {
+            KeyboardOptions(imeAction = androidx.compose.ui.text.input.ImeAction.Done)
+        } else {
+            keyboardOptions
+        }
+        CompositionLocalProvider(LocalTextSelectionColors provides selectionColors) {
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(theme.surface)
+                    .border(BorderStroke(1.dp, borderColor), RoundedCornerShape(12.dp))
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                enabled = enabled,
+                readOnly = readOnly,
+                singleLine = singleLine,
+                maxLines = maxLines,
+                minLines = minLines,
+                keyboardOptions = effectiveKeyboardOptions,
+                visualTransformation = visualTransformation,
+                cursorBrush = SolidColor(theme.accent),
+                textStyle = TextStyle(
+                    fontSize = 14.5.sp,
+                    color = textColor,
+                    letterSpacing = 0.2.sp,
+                    lineHeight = 21.sp,
+                    fontFamily = if (mono) JetbrainsMono else FontFamily.Default,
+                ),
+            )
+        }
+        if (supportingText != null) {
+            Text(
+                text = supportingText,
+                fontSize = 11.5.sp,
+                color = if (isError) errorColor else theme.inkFaint,
+                letterSpacing = 0.3.sp,
+                modifier = Modifier.padding(start = 2.dp, top = 6.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
@@ -7,8 +7,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -29,6 +30,7 @@ import androidx.compose.ui.util.fastForEach
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.ArrowDown01
 import me.rerere.hugeicons.stroke.ArrowUp01
+import me.rerere.rikkahub.ui.pages.chat.LocalChatTheme
 
 @Composable
 fun <T> Select(
@@ -42,7 +44,9 @@ fun <T> Select(
     trailing: @Composable () -> Unit = {}
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val workspace = workspaceColors()
+    // V3 设计稿：方框 → 胶囊 + 主题色 (不再固定蓝色 workspace.blueContainer)
+    // Paper 是橘棕、Plain 是黑灰、Midnight 是冷靛蓝，跟随 LocalChatTheme.accent
+    val chatTheme = LocalChatTheme.current
 
     ExposedDropdownMenuBox(
         modifier = modifier,
@@ -52,20 +56,21 @@ fun <T> Select(
         Surface(
             tonalElevation = 0.dp,
             shadowElevation = 0.dp,
-            shape = RoundedCornerShape(6.dp),
-            color = workspace.blueContainer.copy(alpha = 0.72f),
-            contentColor = workspace.blue,
-            border = BorderStroke(1.dp, workspace.blue.copy(alpha = 0.12f)),
+            shape = CircleShape,
+            color = chatTheme.accentSoft,
+            contentColor = chatTheme.accent,
+            border = BorderStroke(1.dp, chatTheme.accent.copy(alpha = 0.22f)),
             modifier = Modifier
                 .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                .heightIn(min = 32.dp)
+                .heightIn(min = 34.dp)
         ) {
+            // V3 ValueChip 内容自适应：去掉 fillMaxWidth + Text.weight(1f) 让 Row wrap content
+            // 否则在 ListItem trailing slot 里会撑满剩余宽度把 headline 文字挤到左边
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(6.dp))
+                    .clip(CircleShape)
                     .clickable { expanded = true }
-                    .padding(vertical = 6.dp, horizontal = 10.dp),
+                    .padding(vertical = 7.dp, horizontal = 14.dp),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -73,7 +78,7 @@ fun <T> Select(
                 Text(
                     text = optionToString(selectedOption),
                     style = MaterialTheme.typography.labelMedium,
-                    modifier = Modifier.weight(1f)
+                    maxLines = 1,
                 )
                 trailing()
                 Icon(
@@ -96,11 +101,15 @@ fun <T> Select(
                         expanded = false
                     },
                     text = {
-                        Text(text = optionToString(option), maxLines = 1)
+                        // V3: 去掉 maxLines=1 + 加 softWrap=false, 短 anchor 宽度下长 option 不被截 (不折行只挤一行)
+                        Text(text = optionToString(option), softWrap = false)
                     },
                     leadingIcon = optionLeading?.let {
                         { it(option) }
-                    }
+                    },
+                    // anchor 宽度 (e.g. "浅色" 60dp) < option 文字 ("跟随系统" 80dp) 时 dropdown
+                    // 默认还是 anchor width, 文字被截. 给 item 最小宽度 140dp 留余地.
+                    modifier = Modifier.widthIn(min = 140.dp),
                 )
             }
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UIAvatar.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UIAvatar.kt
@@ -91,7 +91,10 @@ fun UIAvatar(
     editContainerColor: Color = MaterialTheme.colorScheme.tertiaryContainer,
     editContentColor: Color = MaterialTheme.colorScheme.onTertiaryContainer,
     onUpdate: ((Avatar) -> Unit)? = null,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
+    // 显示右下角铅笔徽标。false 时点头像仍可换头像，只是不画铅笔小图标
+    // (V3 drawer footer 用 false —— 设计稿头像是干净圆头像，无铅笔徽标)
+    showEditBadge: Boolean = true,
 ) {
     if (onUpdate == null) {
         UIAvatarFrame(
@@ -135,7 +138,7 @@ fun UIAvatar(
         containerColor = containerColor,
         editContainerColor = editContainerColor,
         editContentColor = editContentColor,
-        showEditIcon = true,
+        showEditIcon = showEditBadge,
         onClick = {
             onClick?.invoke()
             showPickOption = true

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceSearchField.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceSearchField.kt
@@ -34,9 +34,12 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Search
 import com.composables.icons.lucide.X
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.Search01
+import me.rerere.rikkahub.ui.pages.chat.LocalChatTheme
 
 /**
  * Notion-style flat search field. Uses [BasicTextField] under the hood so we
@@ -65,39 +68,35 @@ fun WorkspaceSearchField(
     onSubmit: ((String) -> Unit)? = null,
 ) {
     val workspace = workspaceColors()
+    // V3: 统一 drawer Amber 下方搜索栏样式 — 999 capsule + chatTheme.searchBarBg + hair border
+    // + HugeIcons.Search01 icon + chatTheme.inkSoft tint. (之前是 10dp 圆角 + workspace.row)
+    val chatTheme = LocalChatTheme.current
     val focusRequester = remember { FocusRequester() }
-    // No-ripple interactionSource so tapping the outer search box doesn't
-    // splash on the whole 40dp area — only the BasicTextField shows its
-    // own cursor blink on focus.
     val outerTapSource = remember { MutableInteractionSource() }
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(40.dp)
-            .clip(RoundedCornerShape(10.dp))
-            .background(workspace.row)
-            .border(BorderStroke(1.dp, workspace.hairline), RoundedCornerShape(10.dp))
+            .clip(RoundedCornerShape(999.dp))
+            .background(chatTheme.searchBarBg)
+            .border(BorderStroke(1.dp, chatTheme.hair), RoundedCornerShape(999.dp))
             .clickable(
                 interactionSource = outerTapSource,
                 indication = null,
                 onClick = { focusRequester.requestFocus() },
             )
-            .padding(horizontal = 12.dp),
-        // contentAlignment vertically centers the Row inside the 40dp Box —
-        // without this the Row hugs the top edge and the magnifier icon /
-        // text input visibly float above the vertical midline.
+            .padding(horizontal = 14.dp, vertical = 10.dp),
         contentAlignment = Alignment.CenterStart,
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Icon(
-                imageVector = Lucide.Search,
+                imageVector = HugeIcons.Search01,
                 contentDescription = null,
                 modifier = Modifier.size(16.dp),
-                tint = workspace.muted,
+                tint = chatTheme.inkSoft,
             )
             Box(
                 modifier = Modifier
@@ -112,25 +111,25 @@ fun WorkspaceSearchField(
                         .focusRequester(focusRequester),
                     singleLine = true,
                     textStyle = TextStyle(
-                        color = workspace.ink,
-                        fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                        color = chatTheme.ink,
+                        fontSize = 14.5.sp,
+                        letterSpacing = 0.2.sp,
                     ),
-                    cursorBrush = SolidColor(workspace.ink),
+                    cursorBrush = SolidColor(chatTheme.accent),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                     keyboardActions = KeyboardActions(
                         onSearch = { onSubmit?.invoke(value) },
                     ),
                 )
                 if (value.isEmpty() && placeholder.isNotEmpty()) {
-                    ProvideTextStyle(MaterialTheme.typography.bodyMedium) {
-                        CompositionLocalProvider(LocalContentColor provides workspace.faint) {
-                            Text(
-                                text = placeholder,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                    }
+                    Text(
+                        text = placeholder,
+                        fontSize = 14.5.sp,
+                        color = chatTheme.inkFaint,
+                        letterSpacing = 0.2.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
             }
             if (value.isNotEmpty()) {
@@ -145,7 +144,7 @@ fun WorkspaceSearchField(
                         imageVector = Lucide.X,
                         contentDescription = "Clear",
                         modifier = Modifier.size(14.dp),
-                        tint = workspace.muted,
+                        tint = chatTheme.inkSoft,
                     )
                 }
             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceStyle.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceStyle.kt
@@ -14,10 +14,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
@@ -25,9 +29,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import me.rerere.rikkahub.ui.theme.LocalAmoledDarkMode
 import me.rerere.rikkahub.ui.theme.LocalDarkMode
 
@@ -102,15 +108,20 @@ fun workspaceColors(): WorkspaceColors {
             redContainer = Color(0xFF3A1715),
         )
     } else {
+        // V3 修复：浅色分支镜像深色分支，从 MaterialTheme.colorScheme 读取核心 surface/text。
+        // Theme.kt 已经把 colorScheme 按 chatTheme override (background=chatTheme.bg,
+        // surface=chatTheme.paper, surfaceContainerLowest/Low/Mid/High/Highest 全套)，
+        // 所以二级页面（settings / providers / history）自动跟随 Whisper/Plain/Paper/Midnight。
+        // 之前硬编码白底导致用户切到 Paper 时 settings 页仍是白底+灰，体感不一致。
         WorkspaceColors(
-            canvas = Color(0xFFF7F7F5),
-            paper = Color.White,
-            row = Color(0xFFF7F7F5),
-            note = Color(0xFFFBFBFA),
-            ink = Color(0xFF1F1F1F),
-            muted = Color(0xFF6B6761),
-            faint = Color(0xFF9B9690),
-            hairline = Color.Black.copy(alpha = 0.085f),
+            canvas = scheme.surfaceContainerLowest,
+            paper = scheme.surface,
+            row = scheme.surfaceContainerLow,
+            note = scheme.surfaceContainer,
+            ink = scheme.onSurface,
+            muted = scheme.onSurfaceVariant,
+            faint = Color(0xFF9B9690),                       // 半灰，跨主题保持
+            hairline = scheme.outlineVariant,                // chatTheme.outlineSoft (12% ink)
             blue = Color(0xFF2383E2),
             blueContainer = Color(0xFFEAF4FF),
             green = Color(0xFF168A2D),
@@ -148,9 +159,11 @@ fun WorkspaceStatusPill(
     maxWidth: Dp = Dp.Unspecified,
 ) {
     val colors = workspaceColors()
+    // V3: Accent tone 跟主题 accent（Paper 砖红 / Plain 黑 / Midnight 靛蓝），不再硬蓝
+    val scheme = MaterialTheme.colorScheme
     val (container, content) = when (tone) {
         WorkspaceTone.Neutral -> colors.row to colors.muted
-        WorkspaceTone.Accent -> colors.blueContainer to colors.blue
+        WorkspaceTone.Accent -> scheme.primaryContainer to scheme.primary
         WorkspaceTone.Success -> colors.greenContainer to colors.green
         WorkspaceTone.Warning -> colors.amberContainer to colors.amber
         WorkspaceTone.Danger -> colors.redContainer to colors.red
@@ -181,9 +194,10 @@ fun WorkspaceLeadingIcon(
     tone: WorkspaceTone = WorkspaceTone.Neutral,
 ) {
     val colors = workspaceColors()
+    val scheme = MaterialTheme.colorScheme
     val tint = when (tone) {
         WorkspaceTone.Neutral -> colors.ink
-        WorkspaceTone.Accent -> colors.blue
+        WorkspaceTone.Accent -> scheme.primary
         WorkspaceTone.Success -> colors.green
         WorkspaceTone.Warning -> colors.amber
         WorkspaceTone.Danger -> colors.red
@@ -193,7 +207,7 @@ fun WorkspaceLeadingIcon(
         shape = RoundedCornerShape(6.dp),
         color = when (tone) {
             WorkspaceTone.Neutral -> Color.Transparent
-            WorkspaceTone.Accent -> colors.blueContainer
+            WorkspaceTone.Accent -> scheme.primaryContainer
             WorkspaceTone.Success -> colors.greenContainer
             WorkspaceTone.Warning -> colors.amberContainer
             WorkspaceTone.Danger -> colors.redContainer
@@ -224,9 +238,10 @@ fun WorkspaceIconButton(
     contentDescription: String?,
 ) {
     val colors = workspaceColors()
+    val scheme = MaterialTheme.colorScheme
     val contentColor = when (tone) {
         WorkspaceTone.Neutral -> colors.ink
-        WorkspaceTone.Accent -> colors.blue
+        WorkspaceTone.Accent -> scheme.primary
         WorkspaceTone.Success -> colors.green
         WorkspaceTone.Warning -> colors.amber
         WorkspaceTone.Danger -> colors.red
@@ -237,7 +252,7 @@ fun WorkspaceIconButton(
             .clip(RoundedCornerShape(6.dp))
             .clickable(enabled = enabled, onClick = onClick),
         shape = RoundedCornerShape(6.dp),
-        color = containerColor ?: if (tone == WorkspaceTone.Accent) colors.blueContainer else colors.paper,
+        color = containerColor ?: if (tone == WorkspaceTone.Accent) scheme.primaryContainer else colors.paper,
         contentColor = contentColor,
         border = if (showBorder) workspaceBorder(alpha = if (enabled) 1f else 0.48f) else null,
     ) {
@@ -259,9 +274,10 @@ fun WorkspaceTextButton(
     tone: WorkspaceTone = WorkspaceTone.Neutral,
 ) {
     val colors = workspaceColors()
+    val scheme = MaterialTheme.colorScheme
     val (container, contentColor) = when (tone) {
         WorkspaceTone.Neutral -> colors.row to colors.muted
-        WorkspaceTone.Accent -> colors.blueContainer to colors.blue
+        WorkspaceTone.Accent -> scheme.primaryContainer to scheme.primary
         WorkspaceTone.Success -> colors.greenContainer to colors.green
         WorkspaceTone.Warning -> colors.amberContainer to colors.amber
         WorkspaceTone.Danger -> colors.redContainer to colors.red
@@ -287,4 +303,52 @@ fun WorkspaceTextButton(
             )
         }
     }
+}
+
+/**
+ * V3 settings-shell.jsx SubHeader 设计稿：
+ *   - title 22sp W500 ink letterSpacing 0.3 lineHeight 1
+ *   - 14dp 上下 padding + 18dp 左右 padding (TopAppBar 默认就是 64dp 高，刚好近似)
+ *   - 32dp chevron-back box 内 22dp icon stroke 1.6
+ *   - 无 elevation (M3 TopAppBar 默认就是 0)
+ *
+ * 对外暴露与 [TopAppBar] 一致的 nav/actions/scrollBehavior 接口，
+ * 调用方仅传 title 字符串即可统一字号字重；样式 paddings/elevation 走 M3 默认 (已对齐 spec)。
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkspaceTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable androidx.compose.foundation.layout.RowScope.() -> Unit = {},
+    scrollBehavior: TopAppBarScrollBehavior? = null,
+) {
+    val workspace = workspaceColors()
+    TopAppBar(
+        modifier = modifier,
+        title = {
+            Text(
+                text = title,
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.3.sp,
+                lineHeight = 22.sp,
+                color = workspace.ink,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        navigationIcon = navigationIcon,
+        actions = actions,
+        scrollBehavior = scrollBehavior,
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = workspace.paper,
+            scrolledContainerColor = workspace.paper,
+            titleContentColor = workspace.ink,
+            navigationIconContentColor = workspace.muted,
+            // V3: action icon 跟主题 accent (Paper 砖红 / Whisper 天蓝 等). 之前硬 workspace.blue.
+            actionIconContentColor = MaterialTheme.colorScheme.primary,
+        ),
+    )
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/AmberMark.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/AmberMark.kt
@@ -1,0 +1,133 @@
+package me.rerere.rikkahub.ui.pages.chat
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * AmberMark —— "Refined Chat Screens" 空白态中心宝石。
+ *
+ * 几何编织：三个 vesica（杏仁形）镜片以 0/120/240° 旋转叠加，每个镜片
+ * 由两条镜像贝塞尔弧构成。中心夜光核 + 周围 ambient bloom，复刻设计稿
+ * (/tmp/amber-design/phone-screen.jsx AmberMark)。
+ *
+ * 颜色梯度按 viewBox 64×64 推导：
+ *   弧线 stroke linearGradient：端点 stops[2] @0.25 → 中段 stops[1] @1.0 → 端点 stops[2] @0.25
+ *   中心 core radialGradient：白@0 → stops[0]@0.45 → 透明@1
+ *   bloom 外圈使用 glow 颜色
+ */
+@Composable
+fun AmberMark(
+    modifier: Modifier = Modifier,
+    size: Dp = 72.dp,
+    // stops[0] = bright tint, stops[1] = mid accent, stops[2] = deep
+    stops: Triple<Color, Color, Color> = Triple(
+        Color(0xFFDCEBFF), // bright sky tint
+        Color(0xFF6FA0E8), // mid mid-blue
+        Color(0xFF1E3A8A), // deep navy
+    ),
+    glow: Color = Color(0x666FA0E8), // ~40% alpha bloom
+) {
+    Canvas(
+        modifier = modifier.size(size)
+    ) {
+        val w = this.size.width
+        val h = this.size.height
+        val cx = w / 2f
+        val cy = h / 2f
+        // viewBox 0..64; scale factor:
+        val s = w / 64f
+
+        // ── 1. ambient bloom — radial halo extending well past gem bounds
+        val bloomR = w * (1f + 0.55f * 2f) / 2f  // matches CSS inset:-size*0.55
+        drawCircle(
+            brush = Brush.radialGradient(
+                colorStops = arrayOf(
+                    0.00f to glow,
+                    0.72f to Color.Transparent,
+                ),
+                center = Offset(cx, cy),
+                radius = bloomR,
+            ),
+            radius = bloomR,
+            center = Offset(cx, cy),
+        )
+
+        // ── 2. luminous nucleus — soft white core into tint
+        val coreR = 10f * s
+        drawCircle(
+            brush = Brush.radialGradient(
+                colorStops = arrayOf(
+                    0.00f to Color.White.copy(alpha = 0.85f),
+                    0.55f to stops.first.copy(alpha = 0.45f),
+                    1.00f to Color.Transparent,
+                ),
+                center = Offset(cx, cy),
+                radius = coreR,
+            ),
+            radius = coreR,
+            center = Offset(cx, cy),
+        )
+
+        // ── 3. three vesica lenses
+        // Arc geometry from design: (32,8) → (32,56), one bulges right, one left
+        fun arcRight() = Path().apply {
+            moveTo(cx, cy - 24f * s)                       // 32,8
+            cubicTo(
+                cx + 16f * s, cy - 14f * s,                // 48,18
+                cx + 22f * s, cy,                          // 54,32
+                cx, cy + 24f * s                           // 32,56
+            )
+        }
+        fun arcLeft() = Path().apply {
+            moveTo(cx, cy - 24f * s)
+            cubicTo(
+                cx - 16f * s, cy - 14f * s,                // 16,18
+                cx - 22f * s, cy,                          // 10,32
+                cx, cy + 24f * s
+            )
+        }
+
+        // Linear gradient along the arc axis (top → bottom):
+        // - top:    stops[2] @0.25
+        // - middle: stops[1] @1.00
+        // - bottom: stops[2] @0.25
+        val strokeBrush = Brush.linearGradient(
+            colorStops = arrayOf(
+                0.00f to stops.third.copy(alpha = 0.25f),
+                0.50f to stops.second,
+                1.00f to stops.third.copy(alpha = 0.25f),
+            ),
+            start = Offset(cx, cy - 24f * s),
+            end = Offset(cx, cy + 24f * s),
+        )
+
+        val strokeWidthPx = 2.6f * s
+        val stroke = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
+
+        for (deg in listOf(0f, 120f, 240f)) {
+            rotate(degrees = deg, pivot = Offset(cx, cy)) {
+                drawPath(path = arcRight(), brush = strokeBrush, style = stroke)
+                drawPath(path = arcLeft(), brush = strokeBrush, style = stroke)
+            }
+        }
+
+        // ── 4. focal dot at exact center
+        drawCircle(
+            color = stops.first.copy(alpha = 0.95f),
+            radius = 1.8f * s,
+            center = Offset(cx, cy),
+        )
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -14,7 +14,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.Icon
@@ -25,8 +28,13 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -54,7 +62,9 @@ import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.ChartColumn
 import me.rerere.hugeicons.stroke.DashboardSquare01
 import me.rerere.hugeicons.stroke.Folder01
+import me.rerere.hugeicons.stroke.MessageAdd01
 import me.rerere.hugeicons.stroke.News01
+import me.rerere.hugeicons.stroke.Time02
 import me.rerere.hugeicons.stroke.PencilEdit01
 import me.rerere.hugeicons.stroke.Search01
 import me.rerere.hugeicons.stroke.Settings03
@@ -130,33 +140,218 @@ fun ChatDrawerContent(
     // Menu popup 状态
     val workspace = workspaceColors()
 
+    // drawerShape: 之前 0dp 直角, 覆盖过来很生硬. 右侧 24dp 圆角让滑出时跟主屏边缘有过渡感.
     ModalDrawerSheet(
         modifier = Modifier.width(drawerWidth),
-        drawerShape = RoundedCornerShape(0.dp),
+        drawerShape = RoundedCornerShape(topEnd = 24.dp, bottomEnd = 24.dp),
         drawerContainerColor = workspace.paper,
         drawerContentColor = workspace.ink,
         drawerTonalElevation = 0.dp,
     ) {
+        // V3 convo-history.jsx 全量重构：
+        //   Amber wordmark → SearchBar → Primary nav (新聊天/今日看板/小应用)
+        //   → QuickRow (Workspace 文件/伴随智能/聊天热力图统计 icon-only)
+        //   → divider → 最近 label → ConversationList → Footer (avatar + name + settings gear)
+        val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
         Column(
             modifier = Modifier
                 .background(workspace.paper)
-                .padding(horizontal = 16.dp, vertical = 14.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
+                .windowInsetsPadding(WindowInsets.statusBars),
         ) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 14.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                // (1) Amber wordmark
+                Text(
+                    text = "Amber",
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Medium,
+                    letterSpacing = 0.5.sp,
+                    color = chatTheme.ink,
+                    fontFamily = androidx.compose.ui.text.font.FontFamily.Serif,
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 8.dp),
+                )
+
+                // (2) Search bar capsule
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp)
+                        .clip(RoundedCornerShape(999.dp))
+                        .background(chatTheme.searchBarBg)
+                        .border(
+                            BorderStroke(1.dp, chatTheme.hair),
+                            RoundedCornerShape(999.dp),
+                        )
+                        .clickable { navController.navigate(Screen.MessageSearch) }
+                        .padding(horizontal = 14.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Icon(
+                        imageVector = HugeIcons.Search01,
+                        contentDescription = "Search",
+                        modifier = Modifier.size(16.dp),
+                        tint = chatTheme.inkSoft,
+                    )
+                    Text(
+                        text = "搜索聊天",
+                        fontSize = 14.5.sp,
+                        color = chatTheme.inkFaint,
+                        letterSpacing = 0.2.sp,
+                    )
+                }
+
+                // (3) Primary nav rows: 新聊天 / 今日看板 / 小应用
+                V3NavRow(
+                    icon = HugeIcons.MessageAdd01,
+                    label = "新聊天",
+                    accent = true,
+                    chatTheme = chatTheme,
+                    onClick = {
+                        scope.launch { drawerState.close() }
+                        navigateToChatPage(navController)
+                    },
+                )
+                // V3 设计稿 4 套主题中 "今日看板" 永远显示（不绑 todayBoardEnabled flag），
+                // 点开后用户没启用时由 TodayBoard 页面自己引导启用
+                V3NavRow(
+                    icon = HugeIcons.News01,
+                    label = "今日看板",
+                    accent = false,
+                    chatTheme = chatTheme,
+                    onClick = { navController.navigate(Screen.TodayBoard) },
+                )
+                V3NavRow(
+                    icon = HugeIcons.DashboardSquare01,
+                    label = "小应用",
+                    accent = false,
+                    chatTheme = chatTheme,
+                    onClick = { navController.navigate(Screen.MiniAppList) },
+                )
+
+                // (4) QuickRow: 3 icon-only buttons (Workspace 文件 / 伴随智能 / 聊天热力图统计)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    V3QuickBtn(
+                        icon = HugeIcons.Folder01,
+                        contentDescription = "Workspace 文件",
+                        chatTheme = chatTheme,
+                        onClick = onOpenWorkspace,
+                    )
+                    V3QuickBtn(
+                        icon = HugeIcons.Sparkles,
+                        contentDescription = "伴随智能",
+                        chatTheme = chatTheme,
+                        onClick = onOpenFavoritesLive,
+                    )
+                    V3QuickBtn(
+                        icon = HugeIcons.ChartColumn,
+                        contentDescription = "聊天热力图统计",
+                        chatTheme = chatTheme,
+                        onClick = { navController.navigate(Screen.Stats) },
+                    )
+                }
+
+                // (5) Divider
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 6.dp, vertical = 12.dp)
+                        .height(1.dp)
+                        .background(chatTheme.hair),
+                )
+
+                // (6) 最近 section label: 跟"新聊天"(V3NavRow accent=true) 同款 — accent 色 + Medium
+                Row(
+                    modifier = Modifier
+                        .padding(horizontal = 6.dp, vertical = 11.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    Icon(
+                        imageVector = HugeIcons.Time02,
+                        contentDescription = null,
+                        modifier = Modifier.size(19.dp),
+                        tint = chatTheme.accent,
+                    )
+                    Text(
+                        text = "最近",
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 0.2.sp,
+                        color = chatTheme.accent,
+                    )
+                }
+
+                // (7) ConversationList — 历史会话（active 项已自动 accentSoft pill 高亮）
+                ConversationList(
+                    current = current,
+                    conversations = conversations,
+                    conversationJobs = conversationJobs.keys,
+                    listState = conversationListState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    onClick = {
+                        scope.launch {
+                            if (it.id != current.id) {
+                                withTimeoutOrNull(220L) {
+                                    drawerState.close()
+                                }
+                                navigateToChatPage(navController, it.id)
+                            } else {
+                                drawerState.close()
+                            }
+                        }
+                    },
+                    onRegenerateTitle = {
+                        vm.generateTitle(it, true)
+                    },
+                    onDelete = {
+                        vm.deleteConversation(it)
+                        conversations.refresh()
+                        if (it.id == current.id) {
+                            navigateToChatPage(navController)
+                        }
+                    },
+                    onPin = {
+                        vm.updatePinnedStatus(it)
+                    }
+                )
+            }
+
+            // (8) Footer hair line + avatar + name + settings gear（V3 设计稿原版）
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(chatTheme.hair),
+            )
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 2.dp, vertical = 8.dp),
+                    .padding(horizontal = 22.dp)
+                    .padding(top = 14.dp, bottom = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 UIAvatar(
                     name = settings.displaySetting.userNickname.ifBlank { stringResource(R.string.user_default_name) },
                     value = settings.displaySetting.userAvatar,
-                    size = 48.dp,
-                    containerColor = workspace.blueContainer,
+                    size = 32.dp,
+                    containerColor = chatTheme.userBubble,
                     editContainerColor = workspace.paper,
-                    editContentColor = workspace.blue,
+                    editContentColor = chatTheme.accent,
+                    showEditBadge = false,  // V3 footer 头像无铅笔徽标，仍可点击换头像
                     onUpdate = { newAvatar ->
                         vm.updateSettings(
                             settings.copy(
@@ -167,120 +362,25 @@ fun ChatDrawerContent(
                         )
                     },
                 )
-
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        Text(
-                            text = settings.displaySetting.userNickname.ifBlank { stringResource(R.string.user_default_name) },
-                            style = MaterialTheme.typography.titleMedium,
-                            color = workspace.ink,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.clickable {
-                                nicknameEditState.open(settings.displaySetting.userNickname)
-                            }
-                        )
-
-                        Icon(
-                            imageVector = HugeIcons.PencilEdit01,
-                            contentDescription = "Edit",
-                            modifier = Modifier
-                                .onClick {
-                                    nicknameEditState.open(settings.displaySetting.userNickname)
-                                }
-                                .size(20.dp),
-                            tint = workspace.muted,
-                        )
-                    }
-                    Greeting(
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = workspace.muted,
-                    )
-                }
-            }
-
-            DrawerActions(
-                navController = navController,
-                todayBoardEnabled = settings.agentRuntime.todayBoard.enabled,
-            )
-            WorkspaceDivider(modifier = Modifier.padding(horizontal = 2.dp, vertical = 6.dp))
-
-            ConversationList(
-                current = current,
-                conversations = conversations,
-                conversationJobs = conversationJobs.keys,
-                listState = conversationListState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                onClick = {
-                    scope.launch {
-                        if (it.id != current.id) {
-                            withTimeoutOrNull(220L) {
-                                drawerState.close()
-                            }
-                            navigateToChatPage(navController, it.id)
-                        } else {
-                            drawerState.close()
-                        }
-                    }
-                },
-                onRegenerateTitle = {
-                    vm.generateTitle(it, true)
-                },
-                onDelete = {
-                    vm.deleteConversation(it)
-                    // Refresh the conversation list to immediately remove the deleted item
-                    // This fixes the issue where deleted conversations sometimes remain visible
-                    // until manually clicked (issue #747)
-                    conversations.refresh()
-                    if (it.id == current.id) {
-                        navigateToChatPage(navController)
-                    }
-                },
-                onPin = {
-                    vm.updatePinnedStatus(it)
-                }
-            )
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 2.dp, vertical = 6.dp)
-            ) {
-                DrawerAction(
-                    icon = { Icon(HugeIcons.Folder01, "Workspace") },
-                    label = { Text("文件") },
-                    onClick = onOpenWorkspace,
+                Text(
+                    text = settings.displaySetting.userNickname.ifBlank { stringResource(R.string.user_default_name) },
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = chatTheme.ink,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable {
+                            nicknameEditState.open(settings.displaySetting.userNickname)
+                        },
                 )
-
-                DrawerAction(
-                    icon = { Icon(HugeIcons.Sparkles, "Live") },
-                    label = { Text("Live") },
-                    onClick = onOpenFavoritesLive,
-                )
-
-                DrawerAction(
-                    icon = { Icon(HugeIcons.ChartColumn, "统计数据") },
-                    label = { Text("统计数据") },
-                    onClick = { navController.navigate(Screen.Stats) },
-                )
-
-                Spacer(Modifier.weight(1f))
-
-                DrawerAction(
-                    icon = { Icon(HugeIcons.Settings03, null) },
-                    label = { Text(stringResource(R.string.settings)) },
-                    onClick = { navController.navigate(Screen.Setting) },
-                    tone = WorkspaceTone.Accent,
+                Icon(
+                    imageVector = HugeIcons.Settings03,
+                    contentDescription = stringResource(R.string.settings),
+                    modifier = Modifier
+                        .size(22.dp)
+                        .clickable { navController.navigate(Screen.Setting) },
+                    tint = chatTheme.inkSoft,
                 )
             }
         }
@@ -421,6 +521,66 @@ private fun DrawerAction(
                 Box(modifier = Modifier.size(22.dp)) { icon() }
             }
         }
+    }
+}
+
+/** V3 convo-history.jsx NavRow —— accent=true 时 newchat 用 accent 字色, 否则 ink */
+@Composable
+private fun V3NavRow(
+    icon: ImageVector,
+    label: String,
+    accent: Boolean,
+    chatTheme: me.rerere.rikkahub.ui.pages.chat.ChatTheme,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 6.dp, vertical = 11.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = label,
+            modifier = Modifier.size(19.dp),
+            tint = if (accent) chatTheme.accent else chatTheme.inkSoft,
+        )
+        Text(
+            text = label,
+            fontSize = 15.sp,
+            fontWeight = if (accent) FontWeight.Medium else FontWeight.Normal,
+            letterSpacing = 0.2.sp,
+            color = if (accent) chatTheme.accent else chatTheme.ink,
+        )
+    }
+}
+
+/** V3 convo-history.jsx QuickBtn —— 36×36 icon-only 圆角方块 */
+@Composable
+private fun V3QuickBtn(
+    icon: ImageVector,
+    contentDescription: String,
+    chatTheme: me.rerere.rikkahub.ui.pages.chat.ChatTheme,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(chatTheme.searchBarBg)
+            .border(BorderStroke(1.dp, chatTheme.hair), RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(18.dp),
+            tint = chatTheme.inkSoft,
+        )
     }
 }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListIndicators.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListIndicators.kt
@@ -122,6 +122,8 @@ private fun AgentWaitingDot(
     modifier: Modifier = Modifier,
 ) {
     val workspace = workspaceColors()
+    // V3: 用 chatTheme.accent 替代硬编码 workspace.blue, 跟 4 主题 (Whisper蓝/Plain黑/Paper砖红/Midnight冷靛) 联动.
+    val accent = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current.accent
     val transition = rememberInfiniteTransition(label = "agent_waiting_dot")
     val dotScale by transition.animateFloat(
         initialValue = 0.82f,
@@ -159,14 +161,14 @@ private fun AgentWaitingDot(
                 .size(16.dp)
                 .scale(dotScale)
                 .clip(CircleShape)
-                .background(workspace.blue.copy(alpha = haloAlpha))
+                .background(accent.copy(alpha = haloAlpha))
         )
         Box(
             modifier = Modifier
                 .size(7.dp)
                 .scale(dotScale)
                 .clip(CircleShape)
-                .background(workspace.blue.copy(alpha = dotAlpha))
+                .background(accent.copy(alpha = dotAlpha))
         )
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListNormalSection.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListNormalSection.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -610,10 +612,23 @@ internal fun ChatListNormal(
         )
     }
 
+    // V3 Whisper：空白态让 ChatPage 的 bloom 透上来；有消息则淡入纯白覆盖。
+    // 用 paper(#FFFFFF) 而非 canvas(#F7F7F5)，避免与 TopBar 之间出现灰白分界线。
+    // Paper/Midnight 主题 (showBloomInConvo=true) 对话态需要保留底层 bloom，
+    // 把 canvasAlpha 上限压到 0.85 让 0.25 强度的 convo bloom 透得出来
+    val hasContent = conversation.messageNodes.isNotEmpty()
+    val chatThemeForCanvas = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val maxCanvasAlpha = if (chatThemeForCanvas.showBloomInConvo) 0.85f else 1f
+    val canvasAlpha by animateFloatAsState(
+        targetValue = if (hasContent) maxCanvasAlpha else 0f,
+        animationSpec = tween(durationMillis = 700, easing = FastOutSlowInEasing),
+        label = "canvasFade",
+    )
+    val backgroundColor = workspace.paper.copy(alpha = canvasAlpha)
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(workspace.canvas),
+            .background(backgroundColor),
     ) {
         if (settings.displaySetting.enableAutoScroll) {
             LaunchedEffect(conversation.id, activeGeneration) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListSubViews.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListSubViews.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.ui.draw.shadow
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxScope
@@ -232,11 +233,12 @@ internal fun BoxScope.MessageJumper(
             targetOffsetX = { if (onLeft) -it * 2 else it * 2 },
         )
     ) {
-        // Notion-like 浮动导航：单个 12dp 圆角卡片 + hairline outline + 内部
-        // 用细 divider 分组 4 个 IconButton，配色走 onSurfaceVariant 灰阶，避免
-        // 之前那种 4 个独立圆形蓝色蒙层与整体 surface/outline 体系冲突。
-        val dividerColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
-        val iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+        // V3: 浮动导航卡。之前 border = outlineVariant@60% 在 Paper/Whisper 上看着是粗黑勾边,
+        // 跟整体轻 hairline 体系冲突. 改 chatTheme.hair (8% ink) 极淡描边 + 抬升 shadow 到 8dp
+        // 让它"浮"在 chat 上, 而不是靠 border 厚重感.
+        val chatTheme = LocalChatTheme.current
+        val dividerColor = chatTheme.hair
+        val iconTint = chatTheme.inkSoft
         Surface(
             // width(IntrinsicSize.Min) is load-bearing here. Material3 HorizontalDivider
             // defaults to fillMaxWidth, which would otherwise propagate "fill the parent"
@@ -246,15 +248,22 @@ internal fun BoxScope.MessageJumper(
             // what we actually want the divider to inherit.
             modifier = Modifier
                 .padding(8.dp)
-                .width(IntrinsicSize.Min),
+                .width(IntrinsicSize.Min)
+                .shadow(
+                    elevation = 8.dp,
+                    shape = RoundedCornerShape(12.dp),
+                    clip = false,
+                    ambientColor = chatTheme.composerShadow,
+                    spotColor = chatTheme.composerShadow,
+                ),
             shape = RoundedCornerShape(12.dp),
-            color = MaterialTheme.colorScheme.surface,
+            color = chatTheme.surface,
             border = BorderStroke(
                 width = 1.dp,
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f),
+                color = chatTheme.surfaceEdge,
             ),
-            tonalElevation = 1.dp,
-            shadowElevation = 1.dp,
+            tonalElevation = 0.dp,
+            shadowElevation = 0.dp,
         ) {
             Column {
                 IconButton(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -2,18 +2,31 @@ package me.rerere.rikkahub.ui.pages.chat
 
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
@@ -37,19 +50,24 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -59,12 +77,15 @@ import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelType
 import me.rerere.ai.ui.ToolApprovalState
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.ai.ui.isEmptyInputMessage
@@ -82,6 +103,7 @@ import me.rerere.rikkahub.data.ai.tools.parseDeepReadSlashCommand
 import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.getAssistantById
 import me.rerere.rikkahub.data.datastore.getCurrentAssistant
+import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.datastore.getCurrentChatModel
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.context.ActiveCompactBoundary
@@ -93,6 +115,7 @@ import me.rerere.rikkahub.service.PendingUserMessage
 import me.rerere.rikkahub.service.PendingUserMessageMode
 import me.rerere.rikkahub.service.previewText
 import me.rerere.rikkahub.ui.components.ai.ChatInput
+import me.rerere.rikkahub.ui.components.ai.ModelSelector
 import me.rerere.rikkahub.ui.components.ai.SandboxActivitySheet
 import me.rerere.rikkahub.ui.components.ui.WorkspaceIconButton
 import me.rerere.rikkahub.ui.components.ui.WorkspaceTone
@@ -173,11 +196,13 @@ fun ChatPage(id: Uuid, text: String?, files: List<Uri>, nodeId: Uuid? = null) {
             windowAdaptiveInfo.height >= 600.dp
     val isBigScreen =
         compactTwoPane || windowAdaptiveInfo.width >= 1100.dp
+    // V3 convo-history.jsx 全屏 history (380×832 phone artboard 全宽)，手机端 drawer 拉出来
+    // 覆盖整屏；大屏 (tablet) 保留侧边栏宽度. 用户偏好全屏覆盖, 关闭用系统返回 / 滑动手势.
     val drawerWidth = when {
         compactTwoPane && !comfortableTwoPane -> 240.dp
         comfortableTwoPane && windowAdaptiveInfo.width < 1100.dp -> 252.dp
         isBigScreen -> 304.dp
-        else -> 336.dp
+        else -> windowAdaptiveInfo.width  // 手机端：全屏覆盖
     }
 
     val inputState = vm.inputState
@@ -500,11 +525,51 @@ private fun ChatPageContent(
     TTSAutoPlay(vm = vm, setting = setting, conversation = conversation)
     val pendingQueueCount = pendingUserMessages.size
 
-    Surface(
-        color = MaterialTheme.colorScheme.background,
-        modifier = Modifier.fillMaxSize()
-    ) {
+    // 用 Box 强制 z-order：chatTheme.bg → bloom → Scaffold（透明）
+    // 之前 Surface(color=paper) 包 bloom 时，Material3 Scaffold 内 Surface 可能再画一层
+    // tonal tint 把 bloom 盖住，导致真机看不到光晕。
+    // 必须用 LocalChatTheme.current.bg 而非 workspaceColors().paper —— 后者在浅色模式
+    // 硬编码 Color.White (WorkspaceStyle.kt:107)，会把 Paper #FDFAF3 / Plain #FFFFFF 都
+    // 强行变白，导致用户切到 Paper 看到的还是白底。
+    val chatThemeForBg = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val chatThemeBg = chatThemeForBg.bg
+    Box(modifier = Modifier.fillMaxSize().background(chatThemeBg)) {
         AssistantBackground(setting = setting)
+        // V3 Whisper：空白态满强度 bloom；进入对话按设计稿"蓝光晕去掉 → 干净浅灰白"。
+        // 转场用 700ms tween 缓慢淡出，避免发送瞬间硬切。
+        // Paper/Midnight 设计稿 (themes.jsx haloConvo) 要求对话态保留 faint 底光氛围
+        // → showBloomInConvo=true 时降到 0.25 而非 0；Whisper/Plain 仍然完全淡出
+        //
+        // 切换 conversation 时 init=false 期间 messageNodes 快照可能是空 (异步还没填), bloom
+        // 会误判为"空白态"开始 700ms 渐变到 1f, 内容到了又反向, 用户看到光晕来回闪. 修复:
+        // init=false 时 bloom 锁定在对话态值 (低), 等 initialized=true 真实状态明确再切.
+        // review P3 #4: 之前每次 recomposition 重算 + messageNodes 瞬态空快照会触发 700ms
+        // 反复 fade up/down. 改为只在 (initialized / conversation.id / messageNodes 真实空否
+        // / 主题切换) 四个关键 key 变化时重算, 流式 chunk 引起的 recomp 不再扰动 bloom.
+        val isMessageListEmpty = conversation.messageNodes.isEmpty()
+        val bloomTarget by remember(
+            timelineLoadState.initialized,
+            conversation.id,
+            isMessageListEmpty,
+            chatThemeForBg.showBloomInConvo,
+        ) {
+            derivedStateOf {
+                when {
+                    !timelineLoadState.initialized -> if (chatThemeForBg.showBloomInConvo) 0.25f else 0f
+                    isMessageListEmpty -> 1f
+                    chatThemeForBg.showBloomInConvo -> 0.25f
+                    else -> 0f
+                }
+            }
+        }
+        val bloomIntensity by animateFloatAsState(
+            targetValue = bloomTarget,
+            animationSpec = tween(durationMillis = 700, easing = FastOutSlowInEasing),
+            label = "bloomFade",
+        )
+        if (setting.getCurrentAssistant().background == null && bloomIntensity > 0.001f) {
+            WhisperBottomBloom(intensity = bloomIntensity)
+        }
         Scaffold(
             topBar = {
                 TopBar(
@@ -512,12 +577,25 @@ private fun ChatPageContent(
                     conversation = conversation,
                     bigScreen = bigScreen,
                     drawerState = drawerState,
+                    currentChatModel = currentChatModel,
                     previewMode = previewMode,
                     onNewChat = {
                         navigateToChatPage(navController)
                     },
                     onClickMenu = {
                         previewMode = !previewMode
+                    },
+                    onUpdateChatModel = {
+                        vm.setChatModel(assistant = setting.getCurrentAssistant(), model = it)
+                    },
+                    onUpdateAssistant = { updated ->
+                        vm.updateSettings(
+                            setting.copy(
+                                assistants = setting.assistants.map { a ->
+                                    if (a.id == updated.id) updated else a
+                                }
+                            )
+                        )
                     },
                     onUpdateTitle = {
                         vm.updateTitle(it)
@@ -644,6 +722,27 @@ private fun ChatPageContent(
             },
             containerColor = Color.Transparent,
         ) { innerPadding ->
+            Box(modifier = Modifier.fillMaxSize()) {
+            // V3: timeline 未初始化时 (conversation 刚切换), 用 spinner 完全覆盖整个 chat 区域,
+            //   不渲染 ChatList / hero 这些底层内容. 加载完 (initialized=true) 才显示真实内容,
+            //   避免"空白态闪一下再切到历史对话"的副作用.
+            if (!timelineLoadState.initialized) {
+                val chatTheme = LocalChatTheme.current
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .background(chatTheme.bg),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    androidx.compose.material3.CircularProgressIndicator(
+                        color = chatTheme.accent,
+                        trackColor = chatTheme.accent.copy(alpha = 0.16f),
+                        strokeWidth = 2.4.dp,
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+            } else {
             ChatList(
                 innerPadding = innerPadding,
                 conversation = conversation,
@@ -779,6 +878,63 @@ private fun ChatPageContent(
                 },
                 chatTimelinePlan = chatTimelinePlan,
             )
+            // V3 convo-screen.jsx:27-32 底部 56dp fade scrim ——
+            // 长消息滚动接近 composer pill 时溶解到 bg，不硬切边线
+            // 仅对话态显示（空白态不需要）
+            if (conversation.messageNodes.isNotEmpty()) {
+                val chatBg = LocalChatTheme.current.bg
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .background(
+                            androidx.compose.ui.graphics.Brush.verticalGradient(
+                                0.00f to chatBg.copy(alpha = 0f),
+                                0.75f to chatBg,
+                                1.00f to chatBg,
+                            )
+                        )
+                )
+            }
+
+            // V3 空白态: hero 问候语 (此 else 分支已守护 initialized=true, 不会闪现)
+            // review P2 #3: 之前 (isEmpty && loadingJob==null) 在 "loading && empty" 中间态没 UI,
+            // 401/慢响应时整屏空白看着像卡死. 改成 isEmpty 时 hero 一直保留 (loading 时 hero 上叠
+            // 半透蒙层 spinner 反馈), 直到第一个 chunk 落 (messageNodes 非空) 再切到 ChatList.
+            if (conversation.messageNodes.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    val nick = setting.displaySetting.userNickname.trim()
+                    val heroText = if (nick.isNotEmpty()) "Hi $nick，\n今天想聊点什么？" else "今天想聊点什么？"
+                    val chatTheme = LocalChatTheme.current
+                    Text(
+                        text = heroText,
+                        color = chatTheme.ink.copy(alpha = if (loadingJob != null) 0.45f else 1f),
+                        fontSize = chatTheme.heroSize.sp,
+                        fontWeight = FontWeight(chatTheme.heroWeight),
+                        letterSpacing = chatTheme.heroLetter.sp,
+                        lineHeight = (chatTheme.heroSize * 1.4f).sp,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                    )
+                    if (loadingJob != null) {
+                        // 上叠 spinner 给 "loading && empty" 中间态一个反馈
+                        androidx.compose.material3.CircularProgressIndicator(
+                            color = chatTheme.accent,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier
+                                .size(28.dp)
+                                .padding(top = (chatTheme.heroSize * 2.5f).dp.coerceAtMost(80.dp)),
+                        )
+                    }
+                }
+            }
+            }  // end if (!initialized) else branch (ChatList + hero)
+            }  // end outer Box (fillMaxSize)
         }
 
         if (sandboxOverlayOpen && sandboxActivity != null) {
@@ -1249,123 +1405,141 @@ private fun TopBar(
     conversation: Conversation,
     drawerState: DrawerState,
     bigScreen: Boolean,
+    currentChatModel: Model?,
     previewMode: Boolean,
     onClickMenu: () -> Unit,
     onNewChat: () -> Unit,
+    onUpdateChatModel: (Model) -> Unit,
+    onUpdateAssistant: (Assistant) -> Unit,
     onUpdateTitle: (String) -> Unit,
 ) {
     val scope = rememberCoroutineScope()
-    val toaster = LocalToaster.current
-    val workspace = workspaceColors()
-    val titleState = useEditState<String> {
-        onUpdateTitle(it)
-    }
-
-    TopAppBar(
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = workspace.paper.copy(alpha = 0.94f),
-            scrolledContainerColor = workspace.paper,
-            navigationIconContentColor = workspace.muted,
-            titleContentColor = workspace.ink,
-            actionIconContentColor = workspace.muted,
-        ),
-        navigationIcon = {
-            if (!bigScreen) {
-                WorkspaceIconButton(
-                    onClick = {
-                        scope.launch { drawerState.open() }
-                    },
-                    icon = HugeIcons.Menu03,
-                    size = 42.dp,
-                    iconSize = 24.dp,
-                    showBorder = false,
-                    contentDescription = "Messages",
-                )
-            }
-        },
-        title = {
-            val editTitleWarning = stringResource(R.string.chat_page_edit_title_warning)
-            Text(
-                text = conversation.title.ifBlank { stringResource(R.string.chat_page_new_chat) },
-                modifier = Modifier
-                    .padding(start = 6.dp)
-                    .clickable {
-                        if (conversation.messageNodes.isNotEmpty()) {
-                            titleState.open(conversation.title)
-                        } else {
-                            toaster.show(editTitleWarning, type = ToastType.Warning)
-                        }
-                    },
-                maxLines = 1,
-                style = MaterialTheme.typography.titleLarge,
-                color = workspace.ink,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        actions = {
+    // V3 phone-screen.jsx header 没有 surface —— 直接坐在 bloom 之上
+    // 之前用 workspace.paper@96% (legacy 硬编码白底) 把 halo 顶层盖住，所以 Paper
+    // 主题下用户反馈"顶栏没变暖纸色"——其实是被白 Surface 罩住了
+    Surface(
+        color = Color.Transparent,
+        modifier = Modifier
+            .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.statusBars),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .padding(start = 20.dp, end = 20.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Row(
-                modifier = Modifier.padding(end = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.weight(1f),
                 verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(14.dp),
             ) {
-                WorkspaceIconButton(
-                    onClick = {
-                        onClickMenu()
-                    },
-                    icon = if (previewMode) HugeIcons.Cancel01 else HugeIcons.LeftToRightListBullet,
-                    contentDescription = "Chat Options",
-                    size = 44.dp,
-                    iconSize = 24.dp,
+                if (!bigScreen) {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            // V3: ripple 改圆形 (默认矩形 ripple 跟 36dp 方块大小一致, 看着丑)
+                            .clip(androidx.compose.foundation.shape.CircleShape)
+                            .clickable { scope.launch { drawerState.open() } },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(5.dp),
+                            horizontalAlignment = Alignment.Start,
+                        ) {
+                            AmberHeaderLine(width = 22.dp)
+                            AmberHeaderLine(width = 14.dp)
+                            AmberHeaderLine(width = 19.dp)
+                        }
+                    }
+                }
+                ModelSelector(
+                    modelId = settings.getCurrentAssistant().chatModelId ?: settings.chatModelId,
+                    providers = settings.providers,
+                    type = ModelType.CHAT,
+                    minimalText = true,
+                    modifier = Modifier.weight(1f, fill = false),
+                    currentAssistant = settings.getCurrentAssistant(),
+                    onUpdateAssistant = onUpdateAssistant,
+                    onSelect = onUpdateChatModel,
                 )
+            }
 
-                WorkspaceIconButton(
-                    onClick = {
-                        onNewChat()
-                    },
-                    icon = HugeIcons.MessageAdd01,
-                    contentDescription = "New Message",
-                    tone = WorkspaceTone.Accent,
-                    size = 44.dp,
-                    iconSize = 24.dp,
-                    containerColor = workspace.paper,
-                )
-            }
-        },
-    )
-    titleState.EditStateContent { title, onUpdate ->
-        AlertDialog(
-            onDismissRequest = {
-                titleState.dismiss()
-            },
-            title = {
-                Text(stringResource(R.string.chat_page_edit_title))
-            },
-            text = {
-                OutlinedTextField(
-                    value = title,
-                    onValueChange = onUpdate,
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        titleState.confirm()
-                    }
-                ) {
-                    Text(stringResource(R.string.chat_page_save))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                // V3 Whisper：进入对话后顶栏右侧多出 22dp Context Ring（仅有消息时）。
+                // 真实 used/total —— 取最后一条 assistant 消息的 usage
+                // V3 review P2 #2: 之前用 totalTokens (= 该轮 prompt+completion 加起来), 跟 ring
+                // 的"上下文占用"语义不符 (短问题 totalTokens 小 → ring 缩水, 反而误导). 改用
+                // promptTokens (下一轮 LLM 实际加载的上下文长度), 也是用户最直观的"已占用".
+                if (conversation.messageNodes.isNotEmpty()) {
+                    val lastAssistant = conversation.currentMessages
+                        .lastOrNull { it.role == me.rerere.ai.core.MessageRole.ASSISTANT }
+                    val lastUsage = lastAssistant?.usage
+                    val usedK = ((lastUsage?.promptTokens ?: 0) / 1000).coerceAtLeast(0)
+                    // total: 模型 context window 估值，未取到时按 200K 默认（大多数现代模型）
+                    val totalK = currentChatModel?.let {
+                        // TODO: Model 数据加 contextWindow 字段后用真实值；当前 200K 保守估计
+                        200
+                    } ?: 200
+                    // V3: 接真实 token 数据给 popup. 速度算的是端到端 (含网络/排队), 不是
+                    // 模型纯推理. createdAt 是 message 第一字符落地时刻, finishedAt 是最后字符,
+                    // 所以差值 = 全部 streaming 时长.
+                    val elapsedMs = if (lastAssistant?.finishedAt != null) {
+                        val createdInstant = lastAssistant.createdAt
+                            .toInstant(kotlinx.datetime.TimeZone.currentSystemDefault())
+                        val finishedInstant = lastAssistant.finishedAt!!
+                            .toInstant(kotlinx.datetime.TimeZone.currentSystemDefault())
+                        (finishedInstant.toEpochMilliseconds() - createdInstant.toEpochMilliseconds())
+                            .takeIf { it > 0 }
+                    } else null
+                    ContextRing(
+                        used = usedK,
+                        total = totalK,
+                        lastTurnTotalTokens = lastUsage?.totalTokens,
+                        lastTurnCachedTokens = lastUsage?.cachedTokens,
+                        lastTurnPromptTokens = lastUsage?.promptTokens,
+                        lastTurnElapsedMs = elapsedMs,
+                    )
                 }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = {
-                        titleState.dismiss()
-                    }
+                // V3 Whisper：phone-screen.jsx 注释 "naked compose icon — no
+                // surrounding circle"，仅渲染 26dp ink 描线图标，无背景圆。
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        // V3: ripple 改圆形
+                        .clip(androidx.compose.foundation.shape.CircleShape)
+                        .clickable { onNewChat() },
+                    contentAlignment = Alignment.Center,
                 ) {
-                    Text(stringResource(R.string.chat_page_cancel))
+                    Icon(
+                        imageVector = HugeIcons.MessageAdd01,
+                        contentDescription = "New Message",
+                        tint = LocalChatTheme.current.ink,
+                        modifier = Modifier.size(26.dp),
+                    )
                 }
             }
-        )
+        }
     }
 }
+
+@Composable
+private fun AmberHeaderLine(width: androidx.compose.ui.unit.Dp) {
+    // 主题感知 ink 色 —— legacy workspaceColors().ink 在浅色硬编码 #1F1F1F，
+    // Paper 主题下需要 #2A241B 才能跟 bg/halo 协调
+    Box(
+        modifier = Modifier
+            .width(width)
+            .height(1.6.dp)
+            .background(LocalChatTheme.current.ink, RoundedCornerShape(1.dp))
+    )
+}
+
+// V3 Whisper 空白态本应为纯净留白 + 底部光晕；之前的 EmptyChatHero（宝石 + 问候）
+// 是误读 phone-screen.jsx 未被 Hero 引用的 AmberMark 导致的；移除。
+// AmberMark.kt 文件保留作未来 agent avatar 等场景的备用组件。

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatTheme.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatTheme.kt
@@ -1,0 +1,373 @@
+package me.rerere.rikkahub.ui.pages.chat
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * V3 设计稿 4 套主题 token —— themes.jsx 完整搬运 + 适应 Compose 类型。
+ *
+ * 用法：
+ *   val theme = LocalChatTheme.current
+ *   theme.accent / theme.sendBg / theme.bloomCore / ...
+ *
+ * 4 个实例：[WhisperTheme] (默认浅色) / [PlainTheme] (黑白) /
+ *           [PaperTheme] (暖纸) / [MidnightTheme] (深色)
+ *
+ * 设备深色模式可与用户选择独立 —— Provider 层决定是否在 isDarkMode 时强制
+ * 切到 [MidnightTheme]。
+ */
+@Immutable
+data class ChatTheme(
+    val name: String,
+    // base surface
+    val bg: Color,
+    val paper: Color,
+    val ink: Color,
+    val inkSoft: Color,
+    val inkFaint: Color,
+    val hair: Color,
+    val surface: Color,
+    val surfaceEdge: Color,
+    // accent
+    val accent: Color,
+    val accentDeep: Color,
+    val accentSoft: Color,
+    val accentTint: Color,
+    // send button
+    val sendBg: Color,
+    val sendArrow: Color,
+    val sendHalo: Color,
+    // bottom ambient bloom (multi-layer flowing radial gradient)
+    val bloomCore: Color,        // primary bloom color
+    val bloomSecondary: Color,   // mid-layer accent
+    val bloomHighlight: Color,   // top highlight
+    val bloomMaxAlpha: Float,    // intensity ceiling at peak
+    val showBloomInConvo: Boolean, // some themes keep faint bloom in convo
+    // user bubble
+    val userBubble: Color,
+    val userBubbleEdge: Color,
+    // agent header status dot
+    val modelStatusDot: Color,
+    // tool pill
+    val toolPillBg: Color,
+    val toolPillEdge: Color,
+    val toolLabelInk: Color,
+    val toolIconInk: Color,
+    val toolDoneBg: Color,
+    val toolDoneBadgeInk: Color,
+    // thinking strip
+    val thinkRule: Color,
+    val thinkHeaderInk: Color,
+    val thinkBodyInk: Color,
+    // sheet
+    val sheetBackdrop: Color,
+    val dragHandle: Color,
+    val searchBarBg: Color,
+    // composer pill shadow color (depth indicator; needs theme-aware contrast)
+    val composerShadow: Color,
+    // M3 outline / outline-variant (form边界 visibility)
+    val outlineStrong: Color,
+    val outlineSoft: Color,
+    // 5-level surface container hierarchy (M3 elevation depth)
+    val containerLowest: Color,
+    val containerLow: Color,
+    val containerMid: Color,
+    val containerHigh: Color,
+    val containerHighest: Color,
+    // primary readable text on the accent (FAB / FilledButton)
+    val onAccent: Color,
+    // dark theme flag —— 用于驱动需要"反向"处理的视觉（如 Material shadow 在深色上
+    // 会渲染成白晕，需要改走 border + tonal step 替代）
+    val isDark: Boolean = false,
+    // top ambient halo (themes.jsx halo 第 2 层 radial-gradient at 50% 0%)
+    // Paper/Midnight 设计稿有；Whisper/Plain 没有顶层，默认 Transparent/0 = 不绘制
+    val topHaloCore: Color = Color.Transparent,
+    val topHaloAlpha: Float = 0f,
+    // bottom bloom 垂直覆盖比例 (themes.jsx halo 第 1 层 radial-gradient 高度参数)
+    //   Whisper 38% / Plain 50% / Paper 55% / Midnight 55%
+    // 之前所有主题硬编码 0.32 (基本是 Whisper)，导致 Paper/Midnight 底光晕只占 1/3 高
+    // 中段还是白/黑，跟设计稿不符
+    val bloomHeightFrac: Float = 0.38f,
+    // hero greeting 字体参数 (themes.jsx heroSize/heroWeight/heroLetter)
+    //   Whisper 26/500/0.2 / Plain 25/500/0.6 / Paper 26/600/0.5 / Midnight 26/500/0.2
+    val heroSize: Int = 26,
+    val heroWeight: Int = 500,
+    val heroLetter: Float = 0.2f,
+    // context ring 阈值色 (convo-agent.jsx ContextRing) —— Paper 是棕色阶梯，其他默认蓝/黄/红
+    val contextEmpty: Color = Color(0xFFD6D9DE),
+    val contextLow: Color = Color(0xFF3D8FD4),
+    val contextMid: Color = Color(0xFFE6A23C),
+    val contextHigh: Color = Color(0xFFD9534F),
+    val contextTrack: Color = Color(0x1A0F1419),
+    // popover 浮层底色 (Midnight 专用 #1A1F2A，其他用 surface 即可)
+    val popoverBg: Color = Color.Unspecified,
+    // SVG / HTML / Slides / 生图 widget 卡片底色 (画板风, 比 bg 略深, 暗色略浅).
+    // 取消硬黑边, 用 widgetCanvasBorder 是否非透明决定要不要画 1dp 描边.
+    val widgetCanvas: Color = Color.Unspecified,
+    val widgetCanvasBorder: Color = Color.Transparent,
+)
+
+// ── Whisper · 微光（默认浅色，天蓝点缀）─────────────────────────────
+val WhisperTheme = ChatTheme(
+    name = "微光 · Whisper",
+    bg = Color(0xFFFFFFFF),
+    paper = Color(0xFFFFFFFF),
+    ink = Color(0xFF0F1419),
+    inkSoft = Color(0xFF5B6573),
+    inkFaint = Color(0xFFA8AFBA),
+    hair = Color(0x140F1419),
+    surface = Color(0xFFFFFFFF),
+    surfaceEdge = Color(0x0D0F1419),
+    accent = Color(0xFF0E9CEB),
+    accentDeep = Color(0xFF0282D6),
+    accentSoft = Color(0xFFE0F2FD),
+    accentTint = Color(0xFFCFE6F9),
+    sendBg = Color(0xFF4EA8E8),
+    sendArrow = Color.White,
+    sendHalo = Color(0x8C4EA8E8),
+    bloomCore = Color(0xFF7AC0FF),
+    bloomSecondary = Color(0xFFA5D6FF),
+    bloomHighlight = Color(0xFFBEE3FF),
+    bloomMaxAlpha = 0.85f,
+    showBloomInConvo = false,
+    userBubble = Color(0xFFF2F4F7),
+    userBubbleEdge = Color(0x0F0F1419),
+    modelStatusDot = Color(0xFF5DBE8A),
+    toolPillBg = Color(0xFFF4F4F4),
+    toolPillEdge = Color(0x0D0F1419),
+    toolLabelInk = Color(0xFF5B6573),
+    toolIconInk = Color(0xFF0E9CEB),
+    toolDoneBg = Color(0xFF0E9CEB),
+    toolDoneBadgeInk = Color.White,
+    thinkRule = Color(0x720E9CEB),
+    thinkHeaderInk = Color(0xFF0E9CEB),
+    thinkBodyInk = Color(0xFF5B6573),
+    sheetBackdrop = Color(0x2E0F1419),
+    dragHandle = Color(0x2E0F1419),
+    searchBarBg = Color(0x0A0F1419),
+    composerShadow = Color(0x4D0F1419),
+    outlineStrong = Color(0x330F1419),
+    outlineSoft = Color(0x1F0F1419),
+    containerLowest = Color(0xFFFAFBFC),
+    containerLow = Color(0xFFFFFFFF),
+    containerMid = Color(0xFFF7F9FB),
+    containerHigh = Color(0xFFF1F4F7),
+    containerHighest = Color(0xFFE9EDF1),
+    onAccent = Color.White,
+    // themes.jsx WHISPER halo 第 1 层: radial-gradient(120% 38% at 50% 110%) —— 显式写出默认值
+    bloomHeightFrac = 0.38f,
+    // bg=#FFFFFF, canvas 用淡蓝 #E5ECF4 (比 bg 深一档 + accent 色相)
+    widgetCanvas = Color(0xFFE5ECF4),
+)
+
+// ── Plain · 素白（接近零色彩；纯白底，editorial 风）────────────────
+val PlainTheme = ChatTheme(
+    name = "素白 · Plain",
+    bg = Color(0xFFFFFFFF),
+    paper = Color(0xFFFFFFFF),
+    ink = Color(0xFF0E0E0E),
+    inkSoft = Color(0xFF5A5A5A),
+    inkFaint = Color(0xFFB0B0B0),
+    hair = Color(0x14000000),
+    surface = Color(0xFFFFFFFF),
+    surfaceEdge = Color(0x1A000000),
+    accent = Color(0xFF0E0E0E),
+    accentDeep = Color(0xFF0E0E0E),
+    accentSoft = Color(0xFFF2F2F2),
+    accentTint = Color(0xFFE6E6E6),
+    sendBg = Color(0xFF0E0E0E),
+    sendArrow = Color.White,
+    sendHalo = Color(0x66666666),
+    bloomCore = Color(0xFF888888),
+    bloomSecondary = Color(0xFFCCCCCC),
+    bloomHighlight = Color(0xFFEEEEEE),
+    bloomMaxAlpha = 0.10f,
+    showBloomInConvo = false,
+    userBubble = Color(0xFFF4F4F4),
+    userBubbleEdge = Color(0x0D000000),
+    modelStatusDot = Color(0xFF7A7A7A),
+    toolPillBg = Color(0xFFF4F4F4),
+    toolPillEdge = Color(0x0D000000),
+    toolLabelInk = Color(0xFF0E0E0E),
+    toolIconInk = Color(0xFF5A5A5A),
+    toolDoneBg = Color(0xFF0E0E0E),
+    toolDoneBadgeInk = Color.White,
+    thinkRule = Color(0x2E000000),
+    thinkHeaderInk = Color(0xFF5A5A5A),
+    thinkBodyInk = Color(0xFF5A5A5A),
+    sheetBackdrop = Color(0x33000000),
+    dragHandle = Color(0x2E000000),
+    searchBarBg = Color(0x0A000000),
+    composerShadow = Color(0x4D000000),
+    outlineStrong = Color(0x33000000),
+    outlineSoft = Color(0x1F000000),
+    containerLowest = Color(0xFFFAFAFA),
+    containerLow = Color(0xFFFFFFFF),
+    containerMid = Color(0xFFF8F8F8),
+    containerHigh = Color(0xFFF2F2F2),
+    containerHighest = Color(0xFFEBEBEB),
+    onAccent = Color.White,
+    // themes.jsx PLAIN halo: radial-gradient(110% 50% at 50% 108%)
+    bloomHeightFrac = 0.50f,
+    // themes.jsx PLAIN heroSize 25 / heroWeight 500 / heroLetter 0.6
+    heroSize = 25,
+    heroLetter = 0.6f,
+    // bg=#FFFFFF, canvas 用浅灰 #EDEEF1 (零色彩, 跟主题保持冷静)
+    widgetCanvas = Color(0xFFEDEEF1),
+)
+
+// ── Paper · 暖纸（米黄底 + 砖红 accent + 琥珀光晕）────────────────
+// 用户反馈"太淡了"->推过头->"过暖了，自适应色温会再加一档"——回到设计稿 spec #FDFAF3，
+// 只通过 topHaloAlpha 略加强（0.22→0.30）补 Compose 单 pass 渲染的衰减，不动 bg 本体
+val PaperTheme = ChatTheme(
+    name = "暖纸 · Paper",
+    bg = Color(0xFFFDFAF3),
+    paper = Color(0xFFFBF7EE),
+    ink = Color(0xFF2A241B),
+    inkSoft = Color(0xFF7A6E5C),
+    inkFaint = Color(0xFFB8AC95),
+    hair = Color(0x1A2A241B),
+    surface = Color(0xFFFBF7EE),
+    surfaceEdge = Color(0x142A241B),
+    accent = Color(0xFFB5683A),
+    accentDeep = Color(0xFF7A3F1C),
+    accentSoft = Color(0xFFEADFC8),
+    accentTint = Color(0xFFF0E0BF),
+    sendBg = Color(0xFF3B2418),
+    sendArrow = Color(0xFFFBF7EE),
+    // 砖红 #B5683A + 低 alpha (~50%), 清淡呼吸感
+    sendHalo = Color(0x80B5683A),
+    bloomCore = Color(0xFFE6A564),
+    bloomSecondary = Color(0xFFF0CBA0),
+    bloomHighlight = Color(0xFFF5E5C8),
+    bloomMaxAlpha = 0.55f,
+    showBloomInConvo = true,
+    userBubble = Color(0xFFF7EFDD),
+    userBubbleEdge = Color(0x0D2A241B),
+    modelStatusDot = Color(0xFFA88D5E),
+    toolPillBg = Color(0xFFF7EFDD),
+    toolPillEdge = Color(0x102A241B),
+    toolLabelInk = Color(0xFFB5683A),
+    toolIconInk = Color(0xFFB5683A),
+    toolDoneBg = Color(0xFFB5683A),
+    toolDoneBadgeInk = Color(0xFFFBF7EE),
+    thinkRule = Color(0x4DB5683A),
+    thinkHeaderInk = Color(0xFFB5683A),
+    thinkBodyInk = Color(0xFF7A6E5C),
+    sheetBackdrop = Color(0x382A241B),
+    dragHandle = Color(0x332A241B),
+    searchBarBg = Color(0x0A2A241B),
+    composerShadow = Color(0x4D2A241B),
+    outlineStrong = Color(0x33B5683A),
+    outlineSoft = Color(0x1A2A241B),
+    containerLowest = Color(0xFFFDFAF3),
+    containerLow = Color(0xFFFBF7EE),
+    containerMid = Color(0xFFF7F0E0),
+    containerHigh = Color(0xFFF1E8D2),
+    containerHighest = Color(0xFFE8DFC6),
+    onAccent = Color(0xFFFBF7EE),
+    // themes.jsx Paper halo 第 2 层 spec 0.22，Compose 单 pass 偏弱，提到 0.30
+    // 再高用户反馈过暖（"自适应色温会再加一档"），0.30 是 sweet spot
+    topHaloCore = Color(0xFFF5E5C8),
+    topHaloAlpha = 0.30f,
+    // themes.jsx Paper halo 第 1 层：radial-gradient(120% 55% at 50% 108%, rgba(230,165,100,0.28))
+    bloomHeightFrac = 0.55f,
+    // themes.jsx Paper heroSize 26 / heroWeight 600 / heroLetter 0.5 (W600 比其他更粗，editorial)
+    heroSize = 26,
+    heroWeight = 600,
+    heroLetter = 0.5f,
+    // themes.jsx Paper context ring：棕色阶梯（非默认蓝/黄/红）
+    contextEmpty = Color(0xFFD8CFBE),
+    contextLow = Color(0xFFC9A375),
+    contextMid = Color(0xFFA0703F),
+    contextHigh = Color(0xFF6A3A18),
+    contextTrack = Color(0x1A2A241B),
+    // bg=#FDFAF3, canvas 用深一档暖褐 #E6D8B5 (跟 accent 砖红同色相, 比 bg 明显深)
+    widgetCanvas = Color(0xFFE6D8B5),
+)
+
+// ── Midnight · 夜墨（深色，冷靛蓝点缀）────────────────────────────
+val MidnightTheme = ChatTheme(
+    name = "夜墨 · Midnight",
+    bg = Color(0xFF0B0E14),
+    paper = Color(0xFF0B0E14),
+    ink = Color(0xFFE8EAEF),
+    inkSoft = Color(0xFF8A93A3),
+    inkFaint = Color(0xFF4A5160),
+    hair = Color(0x1AE8EAEF),
+    surface = Color(0xFF15171D),
+    surfaceEdge = Color(0x1AE8EAEF),
+    accent = Color(0xFF8FA9E0),
+    accentDeep = Color(0xFF2A4FA8),
+    accentSoft = Color(0x248FA9E0),
+    accentTint = Color(0xFFD8E6FF),
+    sendBg = Color(0x8C8FA9E0),
+    sendArrow = Color.White,
+    sendHalo = Color(0x8C8FA9E0),
+    bloomCore = Color(0xFF6E8CDC),
+    bloomSecondary = Color(0xFF8FA9E0),
+    bloomHighlight = Color(0xFFB7D5FF),
+    bloomMaxAlpha = 0.40f,
+    showBloomInConvo = true,
+    // Subagent review: 原 5% 白 (0x0DFFFFFF) 落在 #0B0E14 上对比度逼近 WCAG 下限，
+    // 提到 12% 白以保证 user bubble / tool pill 在深色下可读。
+    userBubble = Color(0x1FFFFFFF),
+    userBubbleEdge = Color(0x14E8EAEF),
+    modelStatusDot = Color(0xFF7BD49E),
+    toolPillBg = Color(0x1FFFFFFF),
+    toolPillEdge = Color(0x14E8EAEF),
+    toolLabelInk = Color(0xFF8FA9E0),
+    toolIconInk = Color(0xFF8FA9E0),
+    toolDoneBg = Color(0xFF8FA9E0),
+    toolDoneBadgeInk = Color(0xFF0B0E14),
+    thinkRule = Color(0x4D8FA9E0),
+    thinkHeaderInk = Color(0xFF8FA9E0),
+    thinkBodyInk = Color(0xFF8A93A3),
+    sheetBackdrop = Color(0x8C000000),
+    dragHandle = Color(0x38FFFFFF),
+    searchBarBg = Color(0x0DFFFFFF),
+    // Subagent #10: dark bg 上的墨灰阴影看不见，改半透白 → 让 pill 顶部高光
+    composerShadow = Color(0x40FFFFFF),
+    outlineStrong = Color(0x33E8EAEF),
+    outlineSoft = Color(0x1FE8EAEF),
+    // Subagent #6: 5 级 surface hierarchy 让 NavDrawer / Card / Sheet 有视觉深度
+    containerLowest = Color(0xFF070A0F),
+    containerLow = Color(0xFF0B0E14),
+    containerMid = Color(0xFF11151D),
+    containerHigh = Color(0xFF181D26),
+    containerHighest = Color(0xFF20262F),
+    // Subagent #3: Midnight accent #8FA9E0 (light indigo) 上配纯白文字对比度低，
+    // 改用深底色 #0B0E14 作为 onAccent (FilledButton 上 = 浅蓝底 + 深字)
+    onAccent = Color(0xFF0B0E14),
+    isDark = true,
+    // themes.jsx Midnight halo 第 2 层：radial-gradient(90% 40% at 50% 0%, rgba(60,80,130,0.20))
+    topHaloCore = Color(0xFF3C5082),
+    topHaloAlpha = 0.20f,
+    // themes.jsx Midnight halo 第 1 层：radial-gradient(120% 55% at 50% 108%, rgba(110,140,220,0.40))
+    bloomHeightFrac = 0.55f,
+    // themes.jsx Midnight context ring：保留默认蓝/黄/红，但 track 在深底上需要更亮才能看见
+    contextTrack = Color(0x38E8EAEF), // rgba(232,234,239,0.22)
+    // contextEmpty 默认值 0xFFD6D9DE (浅灰) 在 Midnight 深底上几乎是白色——
+    // 流式生成时 used=0 → empty=true → ring 渲染成"白色"看着像 loading 占位.
+    // Midnight 用浅灰白 22% (跟 contextTrack 同色) 让 empty 时跟 track 同色, 不再"亮白".
+    contextEmpty = Color(0x38E8EAEF),
+    // themes.jsx Midnight popoverBg #1A1F2A —— 浮层在深底上需要 solid surface
+    popoverBg = Color(0xFF1A1F2A),
+    // bg=#0B0E14, dark 反向: canvas 用 #1B1C22 比 bg 略浅, 区分出"画板"
+    widgetCanvas = Color(0xFF1B1C22),
+)
+
+/**
+ * 主题枚举 —— 存到 DataStore 的 stringKey 值。
+ * Midnight 可被 system dark mode override 触发；其他三个由用户在设置里选。
+ */
+enum class ChatThemeChoice(val instance: ChatTheme, val displayName: String) {
+    WHISPER(WhisperTheme, "微光"),
+    PLAIN(PlainTheme, "素白"),
+    PAPER(PaperTheme, "暖纸"),
+    MIDNIGHT(MidnightTheme, "夜墨"),
+}
+
+/** 全局 CompositionLocal —— UI 消费侧读 [LocalChatTheme.current]. */
+val LocalChatTheme = staticCompositionLocalOf { WhisperTheme }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ContextRing.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ContextRing.kt
@@ -1,0 +1,402 @@
+package me.rerere.rikkahub.ui.pages.chat
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * 22dp Context Ring —— 顶栏右侧轻量进度环 + 点开 usage panel popup。
+ *
+ * 设计来源 convo-agent.jsx HeaderContextRing + ContextUsagePanel：
+ *   - 22dp ring + 2.6dp stroke + leading head dot
+ *   - 主题阈值色 (Paper 棕渐变 / 其他蓝-黄-红)
+ *   - 点击展开 290dp 浮层：5h 额度 / 周额度 / Context / meta strip
+ *   - 浮层位置：top right of screen，箭头指向 ring
+ */
+@Composable
+fun ContextRing(
+    used: Int,
+    total: Int,
+    modifier: Modifier = Modifier,
+    // V3: 接真实 token usage. null 时 popup meta strip 显示 "—" 占位.
+    // 来源 = lastAssistantMessage.usage; 计算: 本次=totalTokens,
+    // 缓存命中=cachedTokens/promptTokens, 速度=totalTokens/elapsedSec.
+    lastTurnTotalTokens: Int? = null,
+    lastTurnCachedTokens: Int? = null,
+    lastTurnPromptTokens: Int? = null,
+    lastTurnElapsedMs: Long? = null,
+) {
+    val v = if (total > 0) (used.toFloat() / total.toFloat()).coerceIn(0f, 1f) else 0f
+    val empty = v <= 0.001f
+    val theme = LocalChatTheme.current
+    val color = when {
+        empty -> theme.contextEmpty
+        v < 0.50f -> theme.contextLow
+        v < 0.75f -> theme.contextMid
+        else -> theme.contextHigh
+    }
+    val trackColor = theme.contextTrack
+    val ringSize = 22.dp
+    val strokeDp = 2.6.dp
+
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .size(36.dp)
+            // V3: ripple 改圆形, 跟 ring 视觉一致 (默认矩形 ripple 在圆 ring 周围看着错位)
+            .clip(androidx.compose.foundation.shape.CircleShape)
+            .clickable { expanded = !expanded },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(modifier = Modifier.size(ringSize)) {
+            val s = this.size.width
+            val strokePx = strokeDp.toPx()
+            val r = (s - strokePx) / 2f - 1f
+            val cx = s / 2f
+            val cy = s / 2f
+            drawCircle(
+                color = if (empty) color else trackColor,
+                radius = r,
+                center = Offset(cx, cy),
+                style = Stroke(width = strokePx),
+            )
+            if (!empty) {
+                val sweep = 360f * v
+                drawArc(
+                    color = color,
+                    startAngle = -90f,
+                    sweepAngle = sweep,
+                    useCenter = false,
+                    topLeft = Offset(cx - r, cy - r),
+                    size = Size(r * 2, r * 2),
+                    style = Stroke(width = strokePx, cap = StrokeCap.Round),
+                )
+                if (v < 0.999f) {
+                    val headAngle = (v * 2f - 0.5f) * PI.toFloat()
+                    val headX = cx + r * cos(headAngle)
+                    val headY = cy + r * sin(headAngle)
+                    drawCircle(
+                        color = color,
+                        radius = strokePx / 2f + 0.4f,
+                        center = Offset(headX, headY),
+                    )
+                }
+            }
+        }
+
+        if (expanded) {
+            ContextUsagePopup(
+                used = used,
+                total = total,
+                progressColor = color,
+                lastTurnTotalTokens = lastTurnTotalTokens,
+                lastTurnCachedTokens = lastTurnCachedTokens,
+                lastTurnPromptTokens = lastTurnPromptTokens,
+                lastTurnElapsedMs = lastTurnElapsedMs,
+                onDismiss = { expanded = false },
+            )
+        }
+    }
+}
+
+/**
+ * 用量与上下文 popup —— 290dp 宽，从 ring 下方 10dp 弹出，箭头指向 ring。
+ *
+ * 设计来源 convo-agent.jsx ContextUsagePanel:
+ *   - 5h 额度 / 本周额度 (硬编码 placeholder，app 当前没追踪)
+ *   - Context 用真实 used/total
+ *   - meta strip: 本次 / 缓存命中 / 速度 (placeholder)
+ */
+@Composable
+private fun ContextUsagePopup(
+    used: Int,
+    total: Int,
+    progressColor: Color,
+    lastTurnTotalTokens: Int? = null,
+    lastTurnCachedTokens: Int? = null,
+    lastTurnPromptTokens: Int? = null,
+    lastTurnElapsedMs: Long? = null,
+    onDismiss: () -> Unit,
+) {
+    val theme = LocalChatTheme.current
+    val popoverBg = if (theme.popoverBg.isSpecified()) theme.popoverBg else theme.surface
+    // panel 之前 290dp 顶到屏幕左边. 收到 260dp 留更多 margin.
+    val panelWidth = 260
+    val panelOffsetTop = 46  // 36dp ring 高 + 10dp gap
+    val panelOffsetRight = -8
+    // TODO: 当前 5h/周额度是真实接入前的预留 UI. Codex OAuth/Anthropic 限额查询
+    //   需要 inject 额度 store + 当前 model 的 provider 类型判断. 接口未铺好之前
+    //   默认 false, 只显示 Context 行. 接通 Codex 后传 true + 真数据.
+    val quotaSupported = false
+
+    // V3 review P3: 之前 popupPositionProvider 用硬编码 *2.5f 和 *2 作为"density approx",
+    // 只在 ~xhdpi (2x) / xxhdpi (2.5x ~ 3x) 设备正确. 改用 LocalDensity 在 PopupPositionProvider
+    // 构造前算好 px, 让不同 dpi 设备 (hdpi 1.5x / xxxhdpi 4x / 折叠屏) 都一致.
+    val density = androidx.compose.ui.platform.LocalDensity.current.density
+    val panelOffsetRightPx = (panelOffsetRight * density).toInt()
+    val panelGapPx = ((panelOffsetTop - 36 + 10) * density).toInt()
+    Popup(
+        properties = PopupProperties(focusable = true),
+        onDismissRequest = onDismiss,
+        popupPositionProvider = object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize,
+            ): IntOffset {
+                // 紧贴 ring 下方 10dp，右边界对齐 ring 右 + 8dp 偏移
+                val x = anchorBounds.right + panelOffsetRightPx - popupContentSize.width
+                val y = anchorBounds.bottom + panelGapPx
+                return IntOffset(
+                    x.coerceAtLeast(8),
+                    y.coerceAtLeast(0),
+                )
+            }
+        },
+    ) {
+        // V3: popup 出场动画 — fade + 轻微 scale 从顶右 (ring 位置) 扩开. 避免硬切.
+        val animProgress = remember { androidx.compose.animation.core.Animatable(0f) }
+        LaunchedEffect(Unit) {
+            animProgress.animateTo(
+                1f,
+                animationSpec = androidx.compose.animation.core.tween(
+                    durationMillis = 180,
+                    easing = androidx.compose.animation.core.FastOutSlowInEasing,
+                ),
+            )
+        }
+        Box(
+            modifier = Modifier.graphicsLayer {
+                alpha = animProgress.value
+                val s = 0.94f + 0.06f * animProgress.value
+                scaleX = s
+                scaleY = s
+                transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0.92f, 0f)
+            },
+        ) {
+            // ── 主体卡片 (箭头已删, 不再 padding top)
+            Surface(
+                modifier = Modifier
+                    .width(panelWidth.dp)
+                    .shadow(
+                        elevation = 18.dp,
+                        shape = RoundedCornerShape(18.dp),
+                        clip = false,
+                        ambientColor = Color(0x330F1419),
+                        spotColor = Color(0x330F1419),
+                    ),
+                shape = RoundedCornerShape(18.dp),
+                color = popoverBg,
+                border = BorderStroke(1.dp, theme.surfaceEdge),
+                tonalElevation = 0.dp,
+                shadowElevation = 0.dp,
+            ) {
+                Column(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 14.dp),
+                ) {
+                    Text(
+                        text = "用量与上下文",
+                        fontSize = 13.sp,
+                        color = theme.inkSoft,
+                        letterSpacing = 0.3.sp,
+                        modifier = Modifier.padding(bottom = 10.dp),
+                    )
+
+                    if (quotaSupported) {
+                        UsageRow(
+                            label = "5 小时额度",
+                            value = 0.46f,
+                            caption = "46 / 100 次",
+                            fillColor = theme.accent,
+                            theme = theme,
+                        )
+                        UsageRow(
+                            label = "本周额度",
+                            value = 0.18f,
+                            caption = "450 / 2,500 次",
+                            fillColor = theme.accent,
+                            theme = theme,
+                        )
+
+                        // 分隔线 (仅在显示限额行时画)
+                        Box(
+                            modifier = Modifier
+                                .padding(top = 12.dp, bottom = 10.dp)
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(theme.hair),
+                        )
+                    }
+
+                    UsageRow(
+                        label = "Context",
+                        value = if (total > 0) used.toFloat() / total.toFloat() else 0f,
+                        caption = "${used}K / ${total}K",
+                        fillColor = progressColor,
+                        theme = theme,
+                    )
+
+                    // meta strip — 改 Column 排版 (label 在上, value 在下), 横向 SpaceBetween,
+                    // 避免之前 Row 一行 3 个 label+value 挤换行造成 "速度" 被切到下一行.
+                    Box(
+                        modifier = Modifier
+                            .padding(top = 14.dp)
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(theme.hair),
+                    )
+                    Row(
+                        modifier = Modifier
+                            .padding(top = 12.dp)
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        // V3: 本次 = lastAssistantMessage.usage.totalTokens
+                        val turnVal = lastTurnTotalTokens?.let { formatTokens(it) + " tok" } ?: "—"
+                        MetaStat(label = "本次", value = turnVal, theme = theme)
+                        // 缓存命中率: cached / prompt * 100%, 跳过 prompt==0 (避免除零 / N/A 时显示 —)
+                        val cacheVal = if ((lastTurnPromptTokens ?: 0) > 0 && lastTurnCachedTokens != null) {
+                            val pct = (lastTurnCachedTokens * 100.0 / lastTurnPromptTokens!!).coerceIn(0.0, 100.0)
+                            "${pct.toInt()}%"
+                        } else "—"
+                        MetaStat(label = "缓存命中", value = cacheVal, theme = theme)
+                        // 速度: completion_tokens / elapsed_seconds → tok/s. elapsed=null 时 —
+                        val speedVal = if (lastTurnElapsedMs != null && lastTurnElapsedMs > 0L && lastTurnTotalTokens != null) {
+                            val tps = lastTurnTotalTokens.toDouble() / (lastTurnElapsedMs / 1000.0)
+                            "${tps.toInt()} tok/s"
+                        } else "—"
+                        MetaStat(label = "速度", value = speedVal, theme = theme)
+                    }
+                }
+            }
+
+            // V3: 删除指向 ring 的菱形箭头. 之前 14dp square rotate 45° 想模拟尖角,
+            // 但 panel 没把它下半遮住, 整个菱形完整显示成一个奇怪的对话框勾, 而且 anchor
+            // 错位让它对不准 ring. panel 直接挂在 ring 下方即可, 不需要 anchor 指示.
+        }
+    }
+}
+
+@Composable
+private fun UsageRow(
+    label: String,
+    value: Float,
+    caption: String,
+    fillColor: Color,
+    theme: ChatTheme,
+) {
+    val v = value.coerceIn(0f, 1f)
+    Column(modifier = Modifier.padding(bottom = 10.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            Text(
+                text = label,
+                fontSize = 13.sp,
+                color = theme.ink,
+                fontWeight = FontWeight.Medium,
+                letterSpacing = 0.2.sp,
+            )
+            Text(
+                text = caption,
+                fontSize = 11.5.sp,
+                color = theme.inkFaint,
+                letterSpacing = 0.3.sp,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .padding(top = 6.dp)
+                .fillMaxWidth()
+                .height(5.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .background(Color(0x0F0F1419)),  // 6% ink track
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(v)
+                    .height(5.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(fillColor),
+            )
+        }
+    }
+}
+
+private fun formatTokens(n: Int): String {
+    return if (n >= 1000) {
+        // 2,420 / 12,345 风格
+        "%,d".format(n)
+    } else n.toString()
+}
+
+@Composable
+private fun MetaStat(label: String, value: String, theme: ChatTheme) {
+    // 改 Column: label 上 value 下. 紧凑且避免横排挤换行.
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = label,
+            fontSize = 10.5.sp,
+            color = theme.inkFaint,
+            letterSpacing = 0.3.sp,
+        )
+        Text(
+            text = value,
+            fontSize = 12.sp,
+            color = theme.ink,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = 0.2.sp,
+        )
+    }
+}
+
+/** popoverBg=Color.Unspecified 时回落到 surface */
+private fun Color.isSpecified(): Boolean = this != Color.Unspecified

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
@@ -220,8 +220,11 @@ private fun ConversationItem(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val workspace = workspaceColors()
+    // V3 convo-history.jsx:177 active = accentSoft + accent ink；旧 blueContainer 在 Paper
+    // 主题下不跟主题。改读 LocalChatTheme.accentSoft
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
     val backgroundColor = if (selected) {
-        workspace.blueContainer
+        chatTheme.accentSoft
     } else {
         Color.Transparent
     }
@@ -251,7 +254,8 @@ private fun ConversationItem(
             Text(
                 text = conversation.title.ifBlank { stringResource(id = R.string.chat_page_new_message) },
                 style = MaterialTheme.typography.bodyLarge,
-                color = if (selected) workspace.blue else workspace.ink,
+                // V3 convo-history.jsx:177 active 文字色 = accent (跟主题)
+                color = if (selected) chatTheme.accent else workspace.ink,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -360,8 +364,12 @@ private fun ConversationRunningIndicator(
         ),
         label = "conversation-running-alpha",
     )
-    val workspace = workspaceColors()
-    val runningColor = workspace.blue
+    // V3: 侧边栏 conversation running indicator. 之前 ring=workspace.blue + dot=workspace.green
+    // 双硬编码色, 在 Paper/Midnight 主题下跟整体冲突. 改用 chatTheme.accent (ring 脉冲) +
+    // modelStatusDot (绿点 — 已是主题色 token, Whisper 绿 / Paper 棕灰 / Midnight 暖绿 / Plain 灰).
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val runningColor = chatTheme.accent
+    val dotColor = chatTheme.modelStatusDot
 
     Box(
         modifier = modifier
@@ -384,7 +392,7 @@ private fun ConversationRunningIndicator(
         Box(
             modifier = Modifier
                 .clip(CircleShape)
-                .background(workspace.green)
+                .background(dotColor)
                 .size(6.dp),
         )
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/SendOrb.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/SendOrb.kt
@@ -1,0 +1,199 @@
+package me.rerere.rikkahub.ui.pages.chat
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import me.rerere.hugeicons.HugeIcons
+import me.rerere.hugeicons.stroke.ArrowUp02
+import me.rerere.hugeicons.stroke.Cancel01
+
+/**
+ * SendOrb —— 48dp 圆形发送按钮，外加双层呼吸光晕。
+ *
+ * 设计来源：phone-screen.jsx SendButton
+ *   - outer halo: inset:-14（即半径 = 48/2 + 14 = 38px），3.6s tween，
+ *     scale 0.95↔1.35, opacity 0.30↔0.70
+ *   - inner halo: inset:-4（半径 = 48/2 + 4 = 28px），2.8s tween，
+ *     scale 1.0↔1.18, opacity 0.55↔0.95
+ *   - core orb: 48px 圆 + shadow + sky-blue background + 白色 24px 向上箭头
+ *
+ * 按 reduced motion 偏好关闭呼吸：检测 [breathingEnabled]。
+ *
+ * 三态：
+ *   - active（!isEmpty 或 isQueueSend）：sendBg 满色 + 呼吸光晕
+ *   - loading & empty：amber + 取消图标，光晕变暖
+ *   - idle (state.isEmpty 且非 loading)：sky-blue 软色 + 呼吸光晕但更弱
+ */
+@Composable
+fun SendOrb(
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    isEmpty: Boolean,
+    loading: Boolean,
+    breathingEnabled: Boolean = true,
+    modifier: Modifier = Modifier,
+) {
+    val isStopState = loading && isEmpty
+    val theme = LocalChatTheme.current
+
+    // chat1.md L257 final: "按钮回到干净的纯色圆形"——非 stop 态用 theme.sendBg + theme.sendArrow；
+    // 仅 stop 态(loading & empty) 切到 amber。Empty 状态不再褪色。
+    val targetCore = when {
+        isStopState -> Color(0xFFE5B567)            // amber stop
+        else -> theme.sendBg
+    }
+    val targetHalo = when {
+        isStopState -> Color(0xCCE5B567)
+        else -> theme.sendHalo
+    }
+    val targetIconTint = when {
+        isStopState -> Color(0xFFD37A00)
+        else -> theme.sendArrow
+    }
+    val coreColor by animateColorAsState(targetCore, label = "orbCore")
+    val haloColor by animateColorAsState(targetHalo, label = "orbHalo")
+    val iconTint by animateColorAsState(targetIconTint, label = "orbIcon")
+
+    Box(
+        modifier = modifier.size(76.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (breathingEnabled) {
+            // V3 review P3: 4 个 rememberInfiniteTransition.animateFloat 提到独立 composable,
+            // breathingEnabled=false 时整个不 enter composition → 不产生持续 state changes /
+            // recomposition (跟 WhisperBottomBloom 类似问题).
+            BreathingHalos(haloColor = haloColor)
+        }
+
+        // The orb itself — 48dp, clickable, opaque core
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(CircleShape)
+                .background(coreColor)
+                .combinedClickable(
+                    enabled = loading || !isEmpty,
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            val icon: ImageVector = if (isStopState) HugeIcons.Cancel01 else HugeIcons.ArrowUp02
+            Icon(
+                imageVector = icon,
+                contentDescription = if (isStopState) "stop" else "send",
+                tint = iconTint,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BreathingHalos(haloColor: Color) {
+    val transition = rememberInfiniteTransition(label = "orbBreath")
+    val outerScale by transition.animateFloat(
+        initialValue = 0.85f,
+        targetValue = 1.50f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "outerScale",
+    )
+    val outerAlpha by transition.animateFloat(
+        initialValue = 0.40f,
+        targetValue = 0.90f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "outerAlpha",
+    )
+    val innerScale by transition.animateFloat(
+        initialValue = 0.95f,
+        targetValue = 1.30f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(2800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "innerScale",
+    )
+    val innerAlpha by transition.animateFloat(
+        initialValue = 0.65f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(2800, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "innerAlpha",
+    )
+    Box(contentAlignment = Alignment.Center) {
+        Canvas(
+            modifier = Modifier
+                .size(76.dp)
+                .graphicsLayer {
+                    scaleX = outerScale
+                    scaleY = outerScale
+                    alpha = outerAlpha
+                },
+        ) {
+            drawCircle(
+                brush = Brush.radialGradient(
+                    colorStops = arrayOf(
+                        0.00f to haloColor,
+                        0.70f to Color.Transparent,
+                    ),
+                    center = Offset(size.width / 2f, size.height / 2f),
+                    radius = size.minDimension / 2f,
+                ),
+                radius = size.minDimension / 2f,
+                center = Offset(size.width / 2f, size.height / 2f),
+            )
+        }
+        Canvas(
+            modifier = Modifier
+                .size(56.dp)
+                .graphicsLayer {
+                    scaleX = innerScale
+                    scaleY = innerScale
+                    alpha = innerAlpha
+                },
+        ) {
+            drawCircle(
+                brush = Brush.radialGradient(
+                    colorStops = arrayOf(
+                        0.00f to haloColor,
+                        0.65f to Color.Transparent,
+                    ),
+                    center = Offset(size.width / 2f, size.height / 2f),
+                    radius = size.minDimension / 2f,
+                ),
+                radius = size.minDimension / 2f,
+                center = Offset(size.width / 2f, size.height / 2f),
+            )
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/WhisperHalo.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/WhisperHalo.kt
@@ -1,0 +1,229 @@
+package me.rerere.rikkahub.ui.pages.chat
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Whisper 主题 token —— 取自 Anthropic Design "Refined Chat Screens" 设计稿
+ * (/tmp/amber-design/themes.jsx THEME_WHISPER)。仅供 chat 页使用，不污染全局
+ * WorkspaceColors。
+ */
+@Immutable
+object WhisperTokens {
+    val accent = Color(0xFF0E9CEB)        // sky blue, think header / accent
+    val accentDeep = Color(0xFF0282D6)
+    val accentSoft = Color(0xFFE0F2FD)
+    val accentTint = Color(0xFFCFE6F9)
+    val sendBg = Color(0xFF4EA8E8)        // clear sky blue, friendly
+    val sendArrow = Color.White
+    val sendHalo = Color(0x8C4EA8E8)      // 55% alpha for halo
+    val ink = Color(0xFF0F1419)
+    val inkSoft = Color(0xFF5B6573)
+    val inkFaint = Color(0xFFA8AFBA)
+    val hair = Color(0x140F1419)          // rgba(15,20,25,0.08)
+    val surface = Color(0xFFFFFFFF)
+    val surfaceEdge = Color(0x0D0F1419)   // rgba(15,20,25,0.05)
+    val sheetBackdrop = Color(0x2E0F1419) // rgba(15,20,25,0.18)
+    val searchBarBg = Color(0x0A0F1419)   // rgba(15,20,25,0.04)
+    val dragHandle = Color(0x2E0F1419)    // rgba(15,20,25,0.18)
+    // chat / convo tokens
+    val userBubble = Color(0xFFF2F4F7)
+    val userBubbleEdge = Color(0x0F0F1419) // rgba(15,20,25,0.06)
+    val modelStatusDot = Color(0xFF5DBE8A) // 6px 绿点 status
+    // tool pill (chat1.md L591: 纯灰底 + 浅天蓝描边 + 蓝色文字/图标/完成)
+    val toolPillBg = Color(0xFFF4F4F4)
+    val toolPillEdge = Color(0x0D0F1419)   // rgba(15,20,25,0.05)
+    val toolLabelInk = inkSoft
+    val toolIconInk = accent
+    val toolDoneBg = accent
+    val thinkRule = Color(0x720E9CEB)      // accent @ 45%
+}
+
+/**
+ * Bottom bloom halo —— Gemini 风格的天蓝色辐射光晕，从屏幕底部 110% 处升起。
+ * 放在 Scaffold 容器后面、所有内容下方；空白态显示，对话页可关闭。
+ *
+ * 设计来源：themes.jsx WHISPER.halo
+ *   radial-gradient(120% 38% at 50% 110%,
+ *     rgba(120,170,240,0.55) 0%,
+ *     rgba(120,170,240,0.25) 35%,
+ *     rgba(120,170,240,0.08) 65%,
+ *     rgba(120,170,240,0) 90%)
+ */
+@Composable
+fun WhisperBottomBloom(
+    modifier: Modifier = Modifier,
+    intensity: Float = 1f,
+) {
+    // Theme-aware bloom：从 LocalChatTheme.current 读 bloomCore/Secondary/Highlight，
+    // 自动跟随 Whisper / Plain / Paper / Midnight 切换。
+    val theme = LocalChatTheme.current
+    val core = theme.bloomCore
+    val secondary = theme.bloomSecondary
+    val accent2 = theme.bloomHighlight
+    val themeIntensity = intensity * theme.bloomMaxAlpha
+
+    // 用户反馈："底部 1/6 到 1/3 范围内呼吸 + 像波浪一样左右流动"。
+    // 主光晕中心放在屏幕底边 (cy = h*1.0)，radius ≈ h*0.30；
+    // 使得 0% 色边界恰好落在 y = h*0.70（即从底起 1/3 位置）；
+    // 而 50% 色边界落在 y = h*0.85（从底起 1/6 位置，是呼吸最强处）。
+    // 用户反馈："蓝色应该满底均匀，流动是波纹叠在上面，不是整片蓝左右挪"。
+    // 架构：(1) 基础蓝层完全静态 + 居中对称 + 仅半径/alpha 呼吸；
+    //       (2) 顶部加几个小光斑做波纹流动，绝不让基础蓝缺失。
+    val transition = rememberInfiniteTransition(label = "bloomFlow")
+    // 基础层半径呼吸：0.78 ↔ 1.25 大幅伸缩（原 0.92↔1.05 律动太微弱）
+    val radiusBreath by transition.animateFloat(
+        initialValue = 0.78f, targetValue = 1.25f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3_600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "radiusBreath",
+    )
+    // 基础层 alpha 呼吸：0.55 ↔ 1.30 显著明暗对比（原 0.88↔1.12 看不出脉冲）
+    val alphaBreath by transition.animateFloat(
+        initialValue = 0.55f, targetValue = 1.30f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(3_200, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "alphaBreath",
+    )
+    // 波纹高光层相位（左右流动但不影响 base 满底）
+    val rippleA by transition.animateFloat(
+        initialValue = 0f, targetValue = (2 * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(5_000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "rippleA",
+    )
+    val rippleB by transition.animateFloat(
+        initialValue = (Math.PI).toFloat(), targetValue = (3 * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(6_500, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "rippleB",
+    )
+    val rippleC by transition.animateFloat(
+        initialValue = (Math.PI / 2).toFloat(),
+        targetValue = (2.5 * Math.PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(3_800, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "rippleC",
+    )
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val w = size.width
+        val h = size.height
+        val effective = themeIntensity * alphaBreath
+
+        // ── 层 0：顶部 ambient halo ── (themes.jsx halo 第 2 层 radial-gradient at 50% 0%)
+        // Paper / Midnight 有，给整个 bg 加暖意 / 冷靛蓝氛围；Whisper / Plain topHaloAlpha=0 跳过。
+        // 静态不呼吸 —— 顶层是环境光，不能跟着底部波纹一起脉冲，否则视觉嘈杂。
+        if (theme.topHaloAlpha > 0f) {
+            // CSS 原 radial-gradient(90% 40% at 50% 0%, color X%, transparent 70%)
+            // 90% 宽 × 40% 高 → 椭圆，但 Compose radial 只能圆。
+            // 取较大的轴半径 (h * 0.45) 平衡覆盖范围。
+            drawRect(
+                brush = Brush.radialGradient(
+                    colorStops = arrayOf(
+                        0.00f to theme.topHaloCore.copy(alpha = theme.topHaloAlpha * intensity),
+                        0.70f to Color.Transparent,
+                    ),
+                    center = Offset(w / 2f, 0f),
+                    radius = h * 0.45f,
+                ),
+                topLeft = Offset.Zero,
+                size = Size(w, h),
+            )
+        }
+
+        // ── 层 1：基础底色 ——按主题 bloomHeightFrac 决定垂直覆盖比例 ──
+        // Whisper 0.38 / Plain 0.50 / Paper 0.55 / Midnight 0.55 (themes.jsx halo 1st gradient)
+        // 中心 y = h*1.0（贴底）、x = w/2（不漂移）、radius = h * bloomHeightFrac ± 呼吸
+        val baseRadius = h * theme.bloomHeightFrac * radiusBreath
+        drawRect(
+            brush = Brush.radialGradient(
+                colorStops = arrayOf(
+                    0.00f to core.copy(alpha = 0.80f * effective),
+                    0.40f to core.copy(alpha = 0.48f * effective),
+                    0.70f to core.copy(alpha = 0.18f * effective),
+                    0.90f to core.copy(alpha = 0.05f * effective),
+                    1.00f to Color.Transparent,
+                ),
+                center = Offset(w / 2f, h * 1.00f),
+                radius = baseRadius,
+            ),
+            topLeft = Offset.Zero,
+            size = Size(w, h),
+        )
+
+        // ── 层 2：辅助横向带 —— 与 base 同色对称分布，加强"满底"感 ──
+        // 用一对镜像的偏中心 bloom，永远左右等亮，不会出现"一边白一边蓝"。
+        val sideOffset = w * 0.30f
+        // 副 bloom 半径按主题 fraction 略小，保持与主 bloom 比例
+        val sideRadius = h * (theme.bloomHeightFrac * 0.62f) * radiusBreath
+        listOf(w / 2f - sideOffset, w / 2f + sideOffset).forEach { cx ->
+            drawRect(
+                brush = Brush.radialGradient(
+                    colorStops = arrayOf(
+                        0.00f to secondary.copy(alpha = 0.35f * effective),
+                        0.55f to secondary.copy(alpha = 0.12f * effective),
+                        1.00f to Color.Transparent,
+                    ),
+                    center = Offset(cx, h * 1.02f),
+                    radius = sideRadius,
+                ),
+                topLeft = Offset.Zero,
+                size = Size(w, h),
+            )
+        }
+
+        // ── 层 3：波纹高光斑 —— 3 个小亮点在 base 之上"游动"，
+        // 但每个亮点本身体积小、范围限制在底部，因此 base 的满底不被掏空。
+        val ripples = listOf(
+            Triple(rippleA, 0.18f, 1.05f),  // (相位, 振幅 fraction, cy fraction)
+            Triple(rippleB, 0.24f, 1.02f),
+            Triple(rippleC, 0.15f, 1.08f),
+        )
+        ripples.forEach { (phase, amp, cyFrac) ->
+            val cx = w / 2f + w * amp * sin(phase)
+            val cy = h * cyFrac
+            val r = h * 0.10f
+            drawRect(
+                brush = Brush.radialGradient(
+                    colorStops = arrayOf(
+                        0.00f to accent2.copy(alpha = 0.45f * effective),
+                        0.60f to accent2.copy(alpha = 0.12f * effective),
+                        1.00f to Color.Transparent,
+                    ),
+                    center = Offset(cx, cy),
+                    radius = r,
+                ),
+                topLeft = Offset.Zero,
+                size = Size(w, h),
+            )
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/SkillDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/SkillDetailPage.kt
@@ -266,7 +266,7 @@ private fun SkillFilesPanel(
                     icon = Lucide.Plus,
                     contentDescription = stringResource(R.string.skill_detail_page_new_file),
                     tone = WorkspaceTone.Accent,
-                    containerColor = colors.blueContainer,
+                    // V3: 去掉 colors.blueContainer 硬编码, 让 tone=Accent 自己映射 scheme.primaryContainer (跟主题)
                 )
             }
             if (nodes.isEmpty()) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/SkillsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/SkillsPage.kt
@@ -25,7 +25,12 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.runtime.mutableStateOf
+import me.rerere.hugeicons.stroke.MoreVertical
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -229,7 +234,8 @@ private fun SkillLibraryStatusCard(
     val colors = workspaceColors()
     Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
+        // V3 settings-skills.jsx Skill 库 card 圆角 18dp
+        shape = RoundedCornerShape(18.dp),
         color = colors.paper,
         contentColor = colors.ink,
         border = workspaceBorder(),
@@ -237,19 +243,19 @@ private fun SkillLibraryStatusCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(14.dp),
+                .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Top,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 WorkspaceLeadingIcon(
                     icon = HugeIcons.Puzzle,
                     tone = WorkspaceTone.Neutral,
-                    size = 30.dp,
-                    iconSize = 18.dp,
+                    size = 34.dp,
+                    iconSize = 20.dp,
                 )
                 Column(
                     modifier = Modifier.weight(1f),
@@ -260,8 +266,10 @@ private fun SkillLibraryStatusCard(
                         style = MaterialTheme.typography.titleMedium,
                     )
                     Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        // V3 settings-skills.jsx: 三 pill 中只有"已启用"用 accentSoft + accent，
+                        // 不要绿色。设计稿原注释 "single accent color, no green"
                         WorkspaceStatusPill("已安装 $installedCount")
-                        WorkspaceStatusPill("已启用 $enabledCount", tone = WorkspaceTone.Success)
+                        WorkspaceStatusPill("已启用 $enabledCount", tone = WorkspaceTone.Accent)
                         WorkspaceStatusPill("未启用 $disabledCount")
                     }
                 }
@@ -364,24 +372,27 @@ private fun SkillCard(
     onDelete: () -> Unit,
 ) {
     val colors = workspaceColors()
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3 settings-skills.jsx: 单 Skill 卡 18dp 圆角 + surface 底 + hair 边线
     Surface(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
-        color = Color.Transparent,
-        contentColor = colors.ink,
+        shape = RoundedCornerShape(18.dp),
+        color = chatTheme.surface,
+        contentColor = chatTheme.ink,
+        border = androidx.compose.foundation.BorderStroke(1.dp, chatTheme.hair),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 8.dp),
+                .padding(horizontal = 14.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             WorkspaceLeadingIcon(
                 icon = HugeIcons.Puzzle,
                 tone = WorkspaceTone.Neutral,
-                size = 30.dp,
-                iconSize = 18.dp,
+                size = 34.dp,
+                iconSize = 20.dp,
             )
             Column(
                 modifier = Modifier
@@ -411,39 +422,73 @@ private fun SkillCard(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    WorkspaceStatusPill(
-                        text = if (enabled) "已启用" else "未启用",
-                        tone = if (enabled) WorkspaceTone.Success else WorkspaceTone.Neutral,
-                    )
-                    if (skill.skillDir.resolve("mcp.json").exists()) {
-                        WorkspaceStatusPill(
-                            text = "包含 MCP 配置",
-                            tone = WorkspaceTone.Accent,
-                        )
+                // V3 settings-skills.jsx: 仅 disabled 行显示"未启用"小灰胶囊；MCP skill 显示 accent "MCP" 胶囊
+                if (!enabled || skill.skillDir.resolve("mcp.json").exists()) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        if (!enabled) {
+                            WorkspaceStatusPill(
+                                text = "未启用",
+                                tone = WorkspaceTone.Neutral,
+                            )
+                        }
+                        if (skill.skillDir.resolve("mcp.json").exists()) {
+                            WorkspaceStatusPill(
+                                text = "MCP",
+                                tone = WorkspaceTone.Accent,
+                            )
+                        }
                     }
                 }
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                WorkspaceIconButton(
-                    onClick = onOptimize,
-                    icon = HugeIcons.MagicWand01,
-                    contentDescription = "规整化为移动端",
-                    tone = WorkspaceTone.Accent,
-                    showBorder = false,
-                    containerColor = Color.Transparent,
+            // V3 settings-skills.jsx: 单行右侧仅 chevron-right；操作（规整化/删除）改用 overflow 菜单
+            var showMenu by remember { mutableStateOf(false) }
+            Box {
+                Icon(
+                    imageVector = HugeIcons.MoreVertical,
+                    contentDescription = "更多操作",
+                    tint = chatTheme.inkSoft,
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clickable { showMenu = true },
                 )
-                WorkspaceIconButton(
-                    onClick = onDelete,
-                    icon = HugeIcons.Delete01,
-                    contentDescription = stringResource(R.string.delete),
-                    tone = WorkspaceTone.Danger,
-                    showBorder = false,
-                    containerColor = Color.Transparent,
-                )
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false },
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("规整化为移动端") },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = HugeIcons.MagicWand01,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = chatTheme.accent,
+                            )
+                        },
+                        onClick = {
+                            showMenu = false
+                            onOptimize()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.delete)) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = HugeIcons.Delete01,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                                tint = colors.red,
+                            )
+                        },
+                        onClick = {
+                            showMenu = false
+                            onDelete()
+                        },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAboutPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAboutPage.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -47,6 +46,8 @@ import me.rerere.rikkahub.Screen
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.easteregg.EmojiBurstHost
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.utils.openUrl
@@ -71,19 +72,14 @@ fun SettingAboutPage() {
     var logoCenterPx by remember { mutableStateOf(Offset.Zero) }
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(stringResource(R.string.about_page_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.about_page_title),
+                navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         EmojiBurstHost(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentExecutionPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentExecutionPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -32,6 +31,8 @@ import me.rerere.rikkahub.data.datastore.MAX_AGENT_TOOL_LOOP_STEPS
 import me.rerere.rikkahub.data.datastore.MIN_AGENT_TOOL_LOOP_STEPS
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.components.ui.Select
 import me.rerere.rikkahub.ui.components.ui.Switch
 import me.rerere.rikkahub.ui.theme.CustomColors
@@ -50,15 +51,14 @@ fun SettingAgentExecutionPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_agent_execution_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_agent_execution_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -99,7 +99,7 @@ fun SettingAgentExecutionPage(vm: SettingVM = koinViewModel()) {
                                             stringResource(R.string.setting_page_agent_operation_preview_hidden)
                                     }
                                 },
-                                modifier = Modifier.width(116.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -145,7 +145,7 @@ fun SettingAgentExecutionPage(vm: SettingVM = koinViewModel()) {
                                 optionToString = {
                                     stringResource(R.string.setting_page_agent_tool_loop_steps_value, it)
                                 },
-                                modifier = Modifier.width(120.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -264,7 +264,7 @@ fun SettingAgentExecutionPage(vm: SettingVM = koinViewModel()) {
                                 optionToString = {
                                     stringResource(R.string.setting_page_agent_live_mode_refresh_interval_value, it / 1_000f)
                                 },
-                                modifier = Modifier.width(104.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -291,7 +291,7 @@ fun SettingAgentExecutionPage(vm: SettingVM = koinViewModel()) {
                                 optionToString = {
                                     stringResource(R.string.setting_page_agent_live_mode_max_nodes_value, it)
                                 },
-                                modifier = Modifier.width(104.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -365,7 +365,7 @@ fun SettingAgentExecutionPage(vm: SettingVM = koinViewModel()) {
                                 optionToString = {
                                     stringResource(R.string.setting_page_agent_generation_retry_count_value, it)
                                 },
-                                modifier = Modifier.width(104.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentExtensionsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentExtensionsPage.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -48,6 +47,8 @@ import me.rerere.rikkahub.data.agent.task.AgentTaskScheduler
 import me.rerere.rikkahub.data.agent.task.AgentTaskSnapshot
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.utils.plus
@@ -64,15 +65,14 @@ fun SettingAgentExtensionsPage() {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_agent_extensions_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_agent_extensions_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -137,15 +137,14 @@ fun SettingAgentRuntimeTasksPage(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_agent_runtime_tasks_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_agent_runtime_tasks_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -332,15 +331,14 @@ fun SettingCronTasksPage(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_cron_tasks_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_cron_tasks_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentMemoryPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentMemoryPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,6 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.platform.LocalContext
@@ -619,6 +621,8 @@ private fun AgentSoulCard(
         value
     }
 
+    // V3: 强制跟 chatTheme.surface (即使 dynamicColor 开了 Material You, 这里也跟主题色, 不出现浅蓝底)
+    val agentMemorySoulTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -626,7 +630,7 @@ private fun AgentSoulCard(
                 draft = value
                 showEditor = true
             },
-        colors = CustomColors.cardColorsOnSurfaceContainer,
+        colors = CardDefaults.cardColors(containerColor = agentMemorySoulTheme.surface),
     ) {
         Column(
             modifier = Modifier
@@ -656,7 +660,12 @@ private fun AgentSoulCard(
                     .padding(14.dp),
                 maxLines = 4,
                 overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.typography.bodyMedium,
+                // V3 settings-memory.jsx: agents.md preview 用 monospace
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                    fontSize = 12.5.sp,
+                    lineHeight = 18.sp,
+                ),
                 color = if (value.isBlank()) {
                     MaterialTheme.colorScheme.onSurfaceVariant
                 } else {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentPermissionsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentPermissionsPage.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -31,6 +30,8 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.Screen
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.components.ui.Switch
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.theme.CustomColors
@@ -76,15 +77,14 @@ fun SettingAgentPermissionsPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_agent_permissions_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_agent_permissions_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -55,6 +54,7 @@ import me.rerere.rikkahub.ui.components.ui.Switch
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionManager
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionNotification
 import me.rerere.rikkahub.ui.components.ui.permission.rememberPermissionState
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
 import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.hooks.rememberAmoledDarkMode
 import me.rerere.rikkahub.ui.hooks.rememberSharedPreferenceBoolean
@@ -85,12 +85,14 @@ private fun <T> WorkspaceSegmentedChoice(
     onSelected: (T) -> Unit,
     label: @Composable (T) -> Unit,
 ) {
+    // V3: 改胶囊形状 (CircleShape) — 之前是 6dp 圆角矩形, 视觉太"框框"
     val workspace = workspaceColors()
+    val capsuleShape = androidx.compose.foundation.shape.CircleShape
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(6.dp))
-            .border(1.dp, workspace.hairline, RoundedCornerShape(6.dp))
-            .padding(2.dp),
+            .clip(capsuleShape)
+            .border(1.dp, workspace.hairline, capsuleShape)
+            .padding(3.dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         options.forEach { option ->
@@ -98,7 +100,7 @@ private fun <T> WorkspaceSegmentedChoice(
             Surface(
                 onClick = { onSelected(option) },
                 modifier = Modifier.weight(1f),
-                shape = RoundedCornerShape(4.dp),
+                shape = capsuleShape,
                 color = if (isSelected) workspace.row else Color.Transparent,
                 contentColor = if (isSelected) workspace.ink else workspace.muted,
             ) {
@@ -140,21 +142,10 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(stringResource(R.string.setting_display_page_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_display_page_title),
+                navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = workspace.paper,
-                    scrolledContainerColor = workspace.paper,
-                    titleContentColor = workspace.ink,
-                    navigationIconContentColor = workspace.muted,
-                    actionIconContentColor = workspace.blue,
-                )
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -177,19 +168,53 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                         modifier = Modifier.padding(start = 4.dp, top = 8.dp, bottom = 8.dp)
                     )
                     if (BuildConfig.NOTION_LIKE) {
+                        // V3: 用聊天主题切换器替代旧的 "Notion style" 静态条目
+                        val themeOptions = listOf(
+                            "WHISPER" to "微光",
+                            "PLAIN" to "素白",
+                            "PAPER" to "暖纸",
+                        )
+                        val currentTheme = themeOptions.firstOrNull {
+                            it.first == displaySetting.chatThemeChoice
+                        } ?: themeOptions[0]
                         ListItem(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clip(
                                     RoundedCornerShape(
-                                        topStart = 8.dp,
-                                        topEnd = 8.dp,
+                                        topStart = 16.dp,
+                                        topEnd = 16.dp,
                                         bottomStart = 2.dp,
                                         bottomEnd = 2.dp
                                     )
                                 ),
-                            headlineContent = { Text("Notion style") },
-                            supportingContent = { Text("浅色纸面 / 深色工作区 + 蓝色强调") },
+                            headlineContent = { Text("聊天主题") },
+                            supportingContent = {
+                                Column(
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text("微光 / 素白 / 暖纸 三套浅色主题; 深色模式自动 Midnight")
+                                    WorkspaceSegmentedChoice(
+                                        options = themeOptions,
+                                        selected = currentTheme,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        onSelected = { (key, _) ->
+                                            updateDisplaySetting(
+                                                displaySetting.copy(chatThemeChoice = key)
+                                            )
+                                        },
+                                        label = { (_, name) ->
+                                            Text(
+                                                text = name,
+                                                maxLines = 1,
+                                                textAlign = TextAlign.Center,
+                                                modifier = Modifier.fillMaxWidth(),
+                                            )
+                                        },
+                                    )
+                                }
+                            },
                             colors = CustomColors.listItemColors,
                         )
                     } else {
@@ -198,8 +223,8 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                                 .fillMaxWidth()
                                 .clip(
                                     RoundedCornerShape(
-                                        topStart = 8.dp,
-                                        topEnd = 8.dp,
+                                        topStart = 16.dp,
+                                        topEnd = 16.dp,
                                         bottomStart = 2.dp,
                                         bottomEnd = 2.dp
                                     )
@@ -234,10 +259,10 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                             .fillMaxWidth()
                             .clip(
                                 RoundedCornerShape(
-                                    topStart = 4.dp,
-                                    topEnd = 4.dp,
-                                    bottomStart = 8.dp,
-                                    bottomEnd = 8.dp
+                                    topStart = 2.dp,
+                                    topEnd = 2.dp,
+                                    bottomStart = 16.dp,
+                                    bottomEnd = 16.dp
                                 )
                             ),
                         headlineContent = { Text(stringResource(R.string.setting_display_page_amoled_dark_mode_title)) },
@@ -324,6 +349,7 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                         modifier = Modifier.padding(horizontal = 8.dp),
                         title = { Text(stringResource(R.string.setting_page_message_display_settings)) },
                     ) {
+                        // V3: 聊天主题切换器已移到顶部 (替代旧 "Notion style" 项), 这里去除重复
                         item(
                             headlineContent = { Text(stringResource(R.string.setting_display_page_show_user_avatar_title)) },
                             supportingContent = { Text(stringResource(R.string.setting_display_page_show_user_avatar_desc)) },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalModelCouncilPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalModelCouncilPage.kt
@@ -584,7 +584,7 @@ private fun <T> ModelCouncilSelectRow(
             selectedOption = selected,
             onOptionSelected = onSelected,
             optionToString = optionToString,
-            modifier = Modifier.width(112.dp),
+            // V3 ValueChip 内容自适应,
         )
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalPage.kt
@@ -256,7 +256,8 @@ internal fun ExperimentDivider() {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 46.dp)
+            // V3 settings-experimental.jsx HairDivider indent={60} —— 让 divider 对齐到 leading icon 右边线
+            .padding(start = 60.dp)
             .height(1.dp),
         color = workspace.hairline,
     ) {}
@@ -283,14 +284,17 @@ internal fun ExperimentActionButton(
     onClick: () -> Unit,
 ) {
     val workspace = workspaceColors()
+    val scheme = MaterialTheme.colorScheme
+    // V3: primary 按钮跟主题 (Paper 砖红 / Whisper 天蓝 / Plain 黑 / Midnight 靛蓝),
+    // 不再硬编码 workspace.blue.
     val container = when {
         !enabled -> workspace.row
-        primary -> workspace.blue
+        primary -> scheme.primary
         else -> workspace.paper
     }
     val contentColor = when {
         !enabled -> workspace.faint
-        primary -> MaterialTheme.colorScheme.onPrimary
+        primary -> scheme.onPrimary
         else -> workspace.ink
     }
     Surface(
@@ -344,11 +348,13 @@ internal fun ExperimentBooleanPill(
     ready: Boolean,
 ) {
     val workspace = workspaceColors()
+    val scheme = MaterialTheme.colorScheme
+    // V3: ready 跟主题 (Paper 砖红 / Whisper 天蓝 等), 不硬编码 workspace.blue
     Surface(
         shape = RoundedCornerShape(999.dp),
-        color = if (ready) workspace.blue.copy(alpha = 0.1f) else workspace.row,
-        contentColor = if (ready) workspace.blue else workspace.muted,
-        border = BorderStroke(1.dp, if (ready) workspace.blue.copy(alpha = 0.22f) else workspace.hairline),
+        color = if (ready) scheme.primaryContainer else workspace.row,
+        contentColor = if (ready) scheme.primary else workspace.muted,
+        border = BorderStroke(1.dp, if (ready) scheme.primary.copy(alpha = 0.22f) else workspace.hairline),
     ) {
         Text(
             text = "$label ${if (ready) stringResource(R.string.setting_experimental_ready) else stringResource(R.string.setting_experimental_missing)}",

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalSubAgentPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalSubAgentPage.kt
@@ -352,7 +352,8 @@ private fun <T> SubAgentSelectRow(
             selectedOption = selected,
             onOptionSelected = onSelected,
             optionToString = optionToString,
-            modifier = Modifier.width(112.dp),
+            // V3: 去掉 width(112dp) 硬约束. 之前 Select 内容只占 ~60dp, 在 112dp 容器内左对齐
+            // 导致看着没"顶到右". 改 wrap content + weight(1f) 让 Select 自动靠 row 右端.
         )
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -52,6 +51,8 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.files.FileFolders
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
 import org.koin.compose.koinInject
@@ -108,15 +109,14 @@ fun SettingFilesPage(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_files_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_files_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor
+        containerColor = workspaceColors().canvas
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -87,6 +86,7 @@ import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.FormItem
 import me.rerere.rikkahub.ui.components.ui.Tag
 import me.rerere.rikkahub.ui.components.ui.TagType
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
 import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.hooks.EditState
 import me.rerere.rikkahub.ui.hooks.EditStateContent
@@ -124,13 +124,9 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(stringResource(R.string.setting_mcp_page_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_mcp_page_title),
+                navigationIcon = { BackButton() },
                 actions = {
                     IconButton(
                         onClick = {
@@ -148,13 +144,6 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
                     }
                 },
                 scrollBehavior = scrollBehavior,
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = workspace.paper,
-                    scrolledContainerColor = workspace.paper,
-                    titleContentColor = workspace.ink,
-                    navigationIconContentColor = workspace.muted,
-                    actionIconContentColor = workspace.blue,
-                )
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -40,9 +39,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -83,13 +84,14 @@ import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.findModelById
 import me.rerere.rikkahub.data.datastore.resolveTaskChatModel
 import me.rerere.rikkahub.ui.components.ai.ModelSelector
-import me.rerere.rikkahub.ui.components.ai.hasUsableAuth
+import me.rerere.ai.provider.hasUsableAuth
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.WorkspaceDivider
 import me.rerere.rikkahub.ui.components.ui.WorkspaceLeadingIcon
 import me.rerere.rikkahub.ui.components.ui.WorkspaceStatusPill
 import me.rerere.rikkahub.ui.components.ui.WorkspaceTextButton
 import me.rerere.rikkahub.ui.components.ui.WorkspaceTone
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
 import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
@@ -104,20 +106,10 @@ fun SettingModelPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(stringResource(R.string.setting_model_page_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_model_page_title),
+                navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = workspace.paper,
-                    scrolledContainerColor = workspace.paper,
-                    titleContentColor = workspace.ink,
-                    navigationIconContentColor = workspace.muted,
-                ),
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -187,19 +179,56 @@ private fun DefaultChatModelSetting(
     settings: Settings,
     vm: SettingVM,
 ) {
-    SettingModelRow(
-        title = stringResource(R.string.setting_model_page_chat_model),
-        description = stringResource(R.string.setting_model_page_chat_model_desc),
-        icon = HugeIcons.Message01,
-        tone = WorkspaceTone.Accent,
+    // V3 设计稿 (settings-models.jsx): hero card 36/20 accent leadingIcon + 15sp W500 title
+    // + 12.5sp inkFaint desc + 12dp 间距 + paddingLeft 50 + inline 22dp logo + 14.5sp accent model
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp, vertical = 14.dp),
     ) {
-        ModelPickerRow(
-            description = null,
+        Row(
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            WorkspaceLeadingIcon(
+                icon = HugeIcons.Message01,
+                size = 36.dp,
+                iconSize = 20.dp,
+                tone = WorkspaceTone.Accent,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.setting_model_page_chat_model),
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = 0.2.sp,
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = stringResource(R.string.setting_model_page_chat_model_desc),
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        fontSize = 12.5.sp,
+                        letterSpacing = 0.2.sp,
+                    ),
+                    color = workspaceColors().muted,
+                    modifier = Modifier.padding(top = 3.dp),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        ModelSelector(
             modelId = settings.chatModelId,
+            type = ModelType.CHAT,
             providers = settings.providers,
-            onSelect = {
-                vm.updateSettings(settings.copy(chatModelId = it.id))
-            },
+            inline = true,
+            onSelect = { vm.updateSettings(settings.copy(chatModelId = it.id)) },
+            modifier = Modifier
+                .padding(top = 12.dp, start = 50.dp)
+                .fillMaxWidth(),
         )
     }
 }
@@ -820,13 +849,10 @@ private fun ModelPickerRow(
     onSelect: (Model) -> Unit,
     onClear: (() -> Unit)? = null,
 ) {
-    // Pure picker row — no trailing slot. The "参数" button used to live here
-    // which shifted the ModelSelector's horizontal position based on whether
-    // a button was present; that's now hoisted to SettingModelRow.trailing so
-    // every picker row across the page lines up.
+    // V3 settings-models.jsx 辅助任务 row：inline ModelSelector + paddingLeft 42dp 对齐 leadingIcon 右边
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         if (description != null) {
             Text(
@@ -841,12 +867,15 @@ private fun ModelPickerRow(
             type = modelType,
             onSelect = onSelect,
             providers = providers,
+            inline = true,
             allowClear = allowClear,
             emptyLabel = emptyLabel,
             clearContentDescription = clearContentDescription,
             preferredInputModality = preferredInputModality,
             onClear = onClear,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .padding(start = 42.dp)
+                .fillMaxWidth(),
         )
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -65,6 +64,7 @@ import me.rerere.rikkahub.ui.components.ui.CardGroup
 import me.rerere.rikkahub.ui.components.ui.Select
 import me.rerere.rikkahub.ui.components.ui.WorkspaceLeadingIcon
 import me.rerere.rikkahub.ui.components.ui.WorkspaceTone
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
 import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.context.Navigator
@@ -92,14 +92,9 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(text = stringResource(R.string.settings))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
-                scrollBehavior = scrollBehavior,
+            WorkspaceTopBar(
+                title = stringResource(R.string.settings),
+                navigationIcon = { BackButton() },
                 actions = {
                     if (settings.developerMode) {
                         IconButton(
@@ -111,13 +106,7 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
                         }
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = workspace.paper,
-                    scrolledContainerColor = workspace.paper,
-                    titleContentColor = workspace.ink,
-                    navigationIconContentColor = workspace.muted,
-                    actionIconContentColor = workspace.muted,
-                )
+                scrollBehavior = scrollBehavior,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -167,7 +156,7 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
                                         ColorMode.DARK -> stringResource(R.string.setting_page_color_mode_dark)
                                     }
                                 },
-                                modifier = Modifier.width(150.dp)
+                                // V3 ValueChip 内容自适应（不硬宽 150dp）
                             )
                         },
                         headlineContent = { Text(stringResource(R.string.setting_page_color_mode)) },
@@ -257,12 +246,18 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
                         supportingContent = { Text(stringResource(R.string.setting_page_tts_service_desc)) },
                         headlineContent = { Text(stringResource(R.string.setting_page_tts_service)) },
                     )
-                    item(
-                        onClick = { navController.navigate(Screen.SettingWeb) },
-                        leadingContent = { SettingLeadingIcon(HugeIcons.ServerStack01) },
-                        supportingContent = { Text(stringResource(R.string.setting_page_web_server_desc)) },
-                        headlineContent = { Text(stringResource(R.string.setting_page_web_server)) },
-                    )
+                    // V3: 隐藏 "Web 服务器 / 外部服务器" 入口 (用户暂不需要).
+                    // 改 SHOW_WEB_SERVER = true 即可恢复.
+                    @Suppress("ConstantConditionIf", "KotlinConstantConditions")
+                    val SHOW_WEB_SERVER = false
+                    if (SHOW_WEB_SERVER) {
+                        item(
+                            onClick = { navController.navigate(Screen.SettingWeb) },
+                            leadingContent = { SettingLeadingIcon(HugeIcons.ServerStack01) },
+                            supportingContent = { Text(stringResource(R.string.setting_page_web_server_desc)) },
+                            headlineContent = { Text(stringResource(R.string.setting_page_web_server)) },
+                        )
+                    }
                 }
             }
 
@@ -310,10 +305,11 @@ private fun SettingLeadingIcon(
     icon: ImageVector,
     tone: WorkspaceTone = WorkspaceTone.Neutral,
 ) {
+    // V3 settings-screen.jsx: stroke icon 21dp 无底色容器
     WorkspaceLeadingIcon(
         icon = icon,
-        size = 30.dp,
-        iconSize = 15.dp,
+        size = 32.dp,
+        iconSize = 21.dp,
         tone = tone,
     )
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -5,12 +5,21 @@ import me.rerere.hugeicons.stroke.Package01
 import me.rerere.hugeicons.stroke.Connect
 import me.rerere.hugeicons.stroke.SlidersHorizontal
 import me.rerere.hugeicons.stroke.Share01
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
@@ -110,27 +119,42 @@ fun SettingProviderDetailPage(id: Uuid, vm: SettingVM = koinViewModel()) {
             )
         },
         bottomBar = {
-            NavigationBar {
-                NavigationBarItem(
-                    selected = pager.currentPage == 0,
-                    label = { Text(stringResource(id = R.string.setting_provider_page_configuration)) },
-                    icon = { Icon(HugeIcons.SlidersHorizontal, null) },
-                    onClick = {
-                        scope.launch {
-                            pager.animateScrollToPage(0)
-                        }
-                    }
+            // V3 provider-screens.jsx: 顶 hairline 的 2-flex tab（不是 M3 NavigationBar 重壳）
+            val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+            androidx.compose.foundation.layout.Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(chatTheme.surface)
+                    .windowInsetsPadding(WindowInsets.navigationBars),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(chatTheme.hair),
                 )
-                NavigationBarItem(
-                    selected = pager.currentPage == 1,
-                    label = { Text(stringResource(id = R.string.setting_provider_page_models)) },
-                    icon = { Icon(HugeIcons.Package01, null) },
-                    onClick = {
-                        scope.launch {
-                            pager.animateScrollToPage(1)
-                        }
-                    }
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                ) {
+                    V3DetailTab(
+                        label = stringResource(id = R.string.setting_provider_page_configuration),
+                        icon = HugeIcons.SlidersHorizontal,
+                        selected = pager.currentPage == 0,
+                        chatTheme = chatTheme,
+                        onClick = { scope.launch { pager.animateScrollToPage(0) } },
+                        modifier = Modifier.weight(1f),
+                    )
+                    V3DetailTab(
+                        label = stringResource(id = R.string.setting_provider_page_models),
+                        icon = HugeIcons.Package01,
+                        selected = pager.currentPage == 1,
+                        chatTheme = chatTheme,
+                        onClick = { scope.launch { pager.animateScrollToPage(1) } },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
             }
         }
     ) {
@@ -164,6 +188,43 @@ fun SettingProviderDetailPage(id: Uuid, vm: SettingVM = koinViewModel()) {
                     )
                 }
             }
+        }
+    }
+}
+
+/** V3 provider-screens.jsx detail tab —— hairline 顶 + icon + label，selected 时 accent 色 + accent 底色 indicator */
+@Composable
+private fun V3DetailTab(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    selected: Boolean,
+    chatTheme: me.rerere.rikkahub.ui.pages.chat.ChatTheme,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.foundation.layout.Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .clickable(onClick = onClick),
+        contentAlignment = androidx.compose.ui.Alignment.Center,
+    ) {
+        androidx.compose.foundation.layout.Row(
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
+        ) {
+            androidx.compose.material3.Icon(
+                imageVector = icon,
+                contentDescription = label,
+                modifier = Modifier.size(18.dp),
+                tint = if (selected) chatTheme.accent else chatTheme.inkSoft,
+            )
+            androidx.compose.material3.Text(
+                text = label,
+                fontSize = 14.sp,
+                fontWeight = if (selected) androidx.compose.ui.text.font.FontWeight.Medium else androidx.compose.ui.text.font.FontWeight.Normal,
+                color = if (selected) chatTheme.accent else chatTheme.inkSoft,
+                letterSpacing = 0.2.sp,
+            )
         }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt
@@ -18,8 +18,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import me.rerere.hugeicons.stroke.ArrowRight01
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -27,13 +30,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -52,6 +55,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -67,6 +71,7 @@ import me.rerere.rikkahub.Screen
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.AutoAIIcon
 import me.rerere.rikkahub.ui.components.ui.WorkspaceSearchField
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
 import me.rerere.rikkahub.ui.components.ui.decodeProviderSetting
 import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalNavController
@@ -100,13 +105,9 @@ fun SettingProviderPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(text = stringResource(R.string.setting_provider_page_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_provider_page_title),
+                navigationIcon = { BackButton() },
                 actions = {
                     ImportProviderButton {
                         vm.updateSettings(
@@ -128,11 +129,10 @@ fun SettingProviderPage(vm: SettingVM = koinViewModel()) {
                     }
                 },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         Column(
             modifier = Modifier
@@ -504,93 +504,78 @@ private fun ProviderItem(
     isLast: Boolean,
     modifier: Modifier = Modifier,
     onEdit: () -> Unit,
-    onDelete: () -> Unit,
+    onDelete: () -> Unit,  // 保留参数兼容，但行内已不再显示删除按钮，删除移到 detail 页
 ) {
     val workspace = workspaceColors()
-    // Outer-corner rounding: only the first and last items get the big group
-    // corners; middle items go fully square so the 1dp gap between rows
-    // reads as a clean divider rather than a "stair-step" hairline.
-    val cornerOuter = 12.dp
-    val cornerInner = 0.dp
-    val topCorner = if (isFirst) cornerOuter else cornerInner
-    val bottomCorner = if (isLast) cornerOuter else cornerInner
-
-    // Enabled providers get a very light blue fill + a slightly bluer border;
-    // disabled providers get a very light red fill + slightly redder border.
-    // Picks the existing palette colors (blueContainer #EAF4FF / redContainer
-    // #FFEFED) so the page no longer reads as "all white, all the same".
-    val containerColor = if (provider.enabled) workspace.blueContainer else workspace.redContainer
-    val borderColor = if (provider.enabled) {
-        workspace.blue.copy(alpha = 0.22f)
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    // V3: 整行 background 用主题色区分启用/禁用 —— enabled = accent 18% 半透 (Paper 深褐 /
+    //   Whisper 天蓝 / Plain 深灰 / Midnight 冷靛蓝), disabled = 默认 surface 不变色.
+    //   logo 36dp 区不再单独贴色块, 完全融入整行色调.
+    val rowBg = if (provider.enabled) {
+        chatTheme.accent.copy(alpha = 0.18f).compositeOver(chatTheme.surface)
     } else {
-        workspace.red.copy(alpha = 0.22f)
+        chatTheme.surface
     }
     androidx.compose.material3.Surface(
         onClick = onEdit,
         modifier = modifier,
         shape = androidx.compose.foundation.shape.RoundedCornerShape(
-            topStart = topCorner,
-            topEnd = topCorner,
-            bottomStart = bottomCorner,
-            bottomEnd = bottomCorner,
+            topStart = if (isFirst) 18.dp else 0.dp,
+            topEnd = if (isFirst) 18.dp else 0.dp,
+            bottomStart = if (isLast) 18.dp else 0.dp,
+            bottomEnd = if (isLast) 18.dp else 0.dp,
         ),
-        color = containerColor,
-        contentColor = workspace.ink,
-        border = androidx.compose.foundation.BorderStroke(1.dp, borderColor),
+        color = rowBg,
+        contentColor = chatTheme.ink,
+        border = androidx.compose.foundation.BorderStroke(1.dp, chatTheme.hair),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 14.dp, vertical = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            AutoAIIcon(
-                name = provider.name,
+        Box {
+            Row(
                 modifier = Modifier
-                    .size(32.dp)
-                    .then(
-                        if (!provider.enabled) Modifier.alpha(0.45f) else Modifier
-                    ),
-            )
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 14.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = provider.name,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = if (provider.enabled) workspace.ink else workspace.muted,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    // Status dot — 6dp circle anchored on the same color as
-                    // the card border for visual coherence (blue on enabled
-                    // cards, red on disabled cards). Replaces the heavy
-                    // colored Tag with a small inline indicator.
-                    androidx.compose.foundation.Canvas(
-                        modifier = Modifier.size(6.dp),
-                    ) {
-                        drawCircle(
-                            color = if (provider.enabled) workspace.blue else workspace.red,
-                        )
-                    }
-                    Text(
-                        text = stringResource(
-                            if (provider.enabled) R.string.setting_provider_page_enabled
-                            else R.string.setting_provider_page_disabled
+                // V3: logo 用 40dp 圆形 (CircleShape) bg, 比之前 36dp 圆角矩形更扩.
+                // enabled = accent 30% spot (跟主题, 在 row bg 之上叠加更浓主题色),
+                // disabled = transparent. AutoAIIcon 28dp 占比 ~70% 不显得拥挤.
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(androidx.compose.foundation.shape.CircleShape)
+                        .background(
+                            if (provider.enabled) {
+                                chatTheme.accent.copy(alpha = 0.30f)
+                            } else {
+                                androidx.compose.ui.graphics.Color.Transparent
+                            }
                         ),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = workspace.muted,
+                    contentAlignment = Alignment.Center,
+                ) {
+                    AutoAIIcon(
+                        name = provider.name,
+                        // color=Transparent 让 AIIcon 内置 Surface 圆形 bg 隐形, 避免跟外层 40dp
+                        // CircleShape 形成"双重圆环" (内层 24dp 圆 + 外层 40dp 圆).
+                        color = androidx.compose.ui.graphics.Color.Transparent,
+                        modifier = Modifier
+                            .size(28.dp)
+                            .then(
+                                if (!provider.enabled) Modifier.alpha(0.45f) else Modifier
+                            ),
                     )
+                }
+                // name + 模型计数
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
                     Text(
-                        text = "·",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = workspace.faint,
+                        text = provider.name,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = if (provider.enabled) chatTheme.ink else chatTheme.inkFaint,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                     )
                     Text(
                         text = stringResource(
@@ -598,21 +583,33 @@ private fun ProviderItem(
                             provider.models.size,
                         ),
                         style = MaterialTheme.typography.labelSmall,
-                        color = workspace.muted,
+                        color = chatTheme.inkFaint,
                     )
                 }
-            }
-            // Card tap enters edit, so only the destructive delete stays as
-            // a tappable icon — small, muted, no surrounding box.
-            IconButton(
-                onClick = onDelete,
-                modifier = Modifier.size(32.dp),
-            ) {
+                // 仅 disabled 显示灰胶囊（"已禁用"），enabled 状态不显示
+                if (!provider.enabled) {
+                    me.rerere.rikkahub.ui.components.ui.WorkspaceStatusPill(
+                        text = stringResource(R.string.setting_provider_page_disabled),
+                        tone = me.rerere.rikkahub.ui.components.ui.WorkspaceTone.Neutral,
+                    )
+                }
+                // chevron-right (进入 detail)
                 Icon(
-                    imageVector = HugeIcons.Delete01,
-                    contentDescription = stringResource(R.string.delete),
+                    imageVector = HugeIcons.ArrowRight01,
+                    contentDescription = null,
                     modifier = Modifier.size(16.dp),
-                    tint = workspace.muted,
+                    tint = chatTheme.inkFaint,
+                )
+            }
+            // V3 hairline divider — 仅非 last 行显示，模拟"单卡 + hairline 分隔"
+            if (!isLast) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 14.dp)
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(chatTheme.hair),
                 )
             }
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSandboxPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSandboxPage.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -49,6 +48,8 @@ import me.rerere.rikkahub.data.agent.terminal.TermuxRuntimeStatus
 import me.rerere.rikkahub.data.agent.workspace.WorkspaceManager
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.components.ui.Select
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
@@ -93,15 +94,14 @@ fun SettingSandboxPage(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_sandbox_page_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_sandbox_page_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -223,7 +223,7 @@ fun SettingSandboxPage(
                                             stringResource(R.string.setting_sandbox_terminal_runtime_termux)
                                     }
                                 },
-                                modifier = Modifier.width(120.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -245,7 +245,7 @@ fun SettingSandboxPage(
                                     )
                                 },
                                 optionToString = { stringResource(R.string.setting_sandbox_terminal_jobs_value, it) },
-                                modifier = Modifier.width(120.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -269,7 +269,7 @@ fun SettingSandboxPage(
                                 optionToString = {
                                     stringResource(R.string.setting_sandbox_terminal_output_value, it / 1024)
                                 },
-                                modifier = Modifier.width(120.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )
@@ -293,7 +293,7 @@ fun SettingSandboxPage(
                                 optionToString = {
                                     stringResource(R.string.setting_sandbox_terminal_install_timeout_value, it / 60_000L)
                                 },
-                                modifier = Modifier.width(120.dp),
+                                // V3 ValueChip 内容自适应,
                             )
                         },
                     )

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -36,6 +35,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.utils.plus
 import me.rerere.search.SearchServiceOptions
@@ -53,13 +54,9 @@ fun SettingSearchPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(stringResource(R.string.setting_page_search_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_page_search_title),
+                navigationIcon = { BackButton() },
                 actions = {
                     IconButton(
                         onClick = {
@@ -76,11 +73,10 @@ fun SettingSearchPage(vm: SettingVM = koinViewModel()) {
                     }
                 },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor
+        containerColor = workspaceColors().canvas
     ) {
         val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
             // Three fixed items live before the configurable service rows in this LazyColumn:

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSlidesFontPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSlidesFontPage.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,6 +47,8 @@ import me.rerere.rikkahub.data.font.FontPackState
 import me.rerere.rikkahub.data.font.SlidesFontRepository
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.utils.openUrl
@@ -70,15 +71,14 @@ fun SettingSlidesFontPage(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Slides 字体资源") },
+            WorkspaceTopBar(
+                title = "Slides 字体资源",
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSystemAccessPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSystemAccessPage.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -53,6 +52,8 @@ import me.rerere.rikkahub.data.agent.system.AgentPermissionStatus
 import me.rerere.rikkahub.data.datastore.prefs.SettingsAggregator
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.components.ui.CardGroupScope
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.utils.plus
@@ -111,15 +112,14 @@ fun SettingSystemAccessPage(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_system_access_title)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_system_access_title),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTTSPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTTSPage.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -54,6 +53,8 @@ import me.rerere.rikkahub.data.datastore.DEFAULT_SYSTEM_TTS_ID
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.AutoAIIcon
 import me.rerere.rikkahub.ui.components.ui.NotionListRow
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.context.LocalTTSState
 import me.rerere.rikkahub.ui.pages.setting.components.TTSProviderConfigure
@@ -73,13 +74,9 @@ fun SettingTTSPage(vm: SettingVM = koinViewModel()) {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(text = stringResource(R.string.setting_tts_page_title))
-                },
-                navigationIcon = {
-                    BackButton()
-                },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_tts_page_title),
+                navigationIcon = { BackButton() },
                 actions = {
                     AddTTSProviderButton {
                         vm.updateSettings(
@@ -90,11 +87,10 @@ fun SettingTTSPage(vm: SettingVM = koinViewModel()) {
                     }
                 },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         val lazyListState = rememberLazyListState()
         val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingWebPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingWebPage.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -56,6 +55,8 @@ import me.rerere.rikkahub.data.datastore.prefs.SettingsAggregator
 import me.rerere.rikkahub.service.WebServerService
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
+import me.rerere.rikkahub.ui.components.ui.WorkspaceTopBar
+import me.rerere.rikkahub.ui.components.ui.workspaceColors
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionManager
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionNotification
 import me.rerere.rikkahub.ui.components.ui.permission.rememberPermissionState
@@ -123,11 +124,10 @@ fun SettingWebPage() {
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.setting_page_web_server)) },
+            WorkspaceTopBar(
+                title = stringResource(R.string.setting_page_web_server),
                 navigationIcon = { BackButton() },
                 scrollBehavior = scrollBehavior,
-                colors = CustomColors.topBarColors,
             )
         },
         floatingActionButton = {
@@ -181,7 +181,7 @@ fun SettingWebPage() {
             )
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-        containerColor = CustomColors.topBarColors.containerColor,
+        containerColor = workspaceColors().canvas,
     ) { innerPadding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -212,7 +212,7 @@ fun SettingWebPage() {
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                                 singleLine = true,
                                 isError = portText.toIntOrNull()?.let { it !in 1024..65535 } ?: true,
-                                modifier = Modifier.width(100.dp),
+                                // V3 ValueChip 内容自适应,
                                 enabled = !serverState.isRunning,
                                 shape = CircleShape,
                                 colors = TextFieldDefaults.colors(
@@ -292,7 +292,7 @@ fun SettingWebPage() {
                                 },
                                 singleLine = true,
                                 isError = settings.webServerJwtEnabled && accessPasswordText.isBlank(),
-                                modifier = Modifier.width(180.dp),
+                                // V3 ValueChip 内容自适应,
                                 shape = CircleShape,
                                 colors = TextFieldDefaults.colors(
                                     focusedIndicatorColor = Color.Transparent,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -52,8 +51,8 @@ import me.rerere.ai.provider.providers.openai.OpenAICodexAuthStore
 import me.rerere.ai.provider.providers.openai.OpenAICodexOAuthClient
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.datastore.DEFAULT_PROVIDERS
+import me.rerere.rikkahub.ui.components.ui.FlatTextField
 import me.rerere.rikkahub.ui.context.LocalToaster
-import me.rerere.rikkahub.ui.theme.JetbrainsMono
 import me.rerere.rikkahub.utils.openUrl
 import me.rerere.rikkahub.utils.writeClipboardText
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -106,8 +105,10 @@ fun ProviderConfigure(
     onEdit: (provider: ProviderSetting) -> Unit,
 ) {
     val effectiveCommit = onCommit ?: onEdit
+    // V3 设计稿: fields 之间 16dp gap (provider-screens.jsx Field 容器)。
+    // Toggle/Segmented row 用同 12dp 折中（更紧凑也好看）
     Column(
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = modifier
     ) {
         // Type
@@ -453,14 +454,10 @@ private fun ColumnScope.ProviderConfigureOpenAI(
         )
     }
 
-    OutlinedTextField(
+    FlatTextField(
         value = provider.name,
-        onValueChange = {
-            onEdit(provider.copy(name = it.trim()))
-        },
-        label = {
-            Text(stringResource(id = R.string.setting_provider_page_name))
-        },
+        onValueChange = { onEdit(provider.copy(name = it.trim())) },
+        label = stringResource(id = R.string.setting_provider_page_name),
         modifier = Modifier.fillMaxWidth(),
     )
 
@@ -565,31 +562,36 @@ private fun ColumnScope.ProviderConfigureOpenAI(
         OpenAIAuthMode.MIMO_CODING_PLAN,
     )
     if (provider.authMode == OpenAIAuthMode.API_KEY || isCodingPlan) {
-        OutlinedTextField(
+        FlatTextField(
             value = provider.apiKey,
-            onValueChange = {
-                onEdit(provider.copy(apiKey = it.trim()))
-            },
-            label = {
-                Text(stringResource(id = R.string.setting_provider_page_api_key))
-            },
+            onValueChange = { onEdit(provider.copy(apiKey = it.trim())) },
+            label = stringResource(id = R.string.setting_provider_page_api_key),
             modifier = Modifier.fillMaxWidth(),
+            singleLine = false,
+            mono = true,
             maxLines = 3,
+            // V3 review P3 #11: 多 key 时 BasicTextField maxLines=3 内部不滚动, 用户看不到后面的 key.
+            // 用 supportingText 报告"共 N 个 key", 帮用户确认完整粘贴生效.
+            supportingText = provider.apiKey
+                .split(Regex("[\\s,]+"))
+                .filter { it.isNotBlank() }
+                .size
+                .takeIf { it > 1 }
+                ?.let { "已配置 $it 个 key (空格/逗号/换行分隔)" },
         )
 
         // baseUrl: editable for plain API_KEY, read-only when pinned by a Coding Plan mode.
         // Without the read-only state the user could clobber the brand-specific URL and the
         // request would silently 404 with no obvious cause.
-        OutlinedTextField(
+        FlatTextField(
             value = provider.baseUrl,
             onValueChange = {
                 if (!isCodingPlan) onEdit(provider.copy(baseUrl = it.trim()))
             },
-            label = {
-                Text(stringResource(id = R.string.setting_provider_page_api_base_url))
-            },
+            label = stringResource(id = R.string.setting_provider_page_api_base_url),
             modifier = Modifier.fillMaxWidth(),
             enabled = !isCodingPlan,
+            mono = true,
             isError = !isCodingPlan && provider.baseUrl.isNotBlank() && !provider.baseUrl.isValidBaseUrl()
         )
 
@@ -597,16 +599,13 @@ private fun ColumnScope.ProviderConfigureOpenAI(
         // Plans hit a fixed endpoint, no need to expose the protocol knobs.
         if (!isCodingPlan) {
             if (!provider.useResponseApi) {
-                OutlinedTextField(
+                FlatTextField(
                     value = provider.chatCompletionsPath,
-                    onValueChange = {
-                        onEdit(provider.copy(chatCompletionsPath = it.trim()))
-                    },
-                    label = {
-                        Text(stringResource(id = R.string.setting_provider_page_api_path))
-                    },
+                    onValueChange = { onEdit(provider.copy(chatCompletionsPath = it.trim())) },
+                    label = stringResource(id = R.string.setting_provider_page_api_path),
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !provider.builtIn
+                    mono = true,
+                    enabled = !provider.builtIn,
                 )
             }
 
@@ -636,14 +635,14 @@ private fun ColumnScope.ProviderConfigureOpenAI(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        OutlinedTextField(
+        FlatTextField(
             value = OPENAI_CODEX_BACKEND_BASE_URL,
             onValueChange = {},
-            label = {
-                Text(stringResource(id = R.string.setting_provider_page_api_base_url))
-            },
+            label = stringResource(id = R.string.setting_provider_page_api_base_url),
             modifier = Modifier.fillMaxWidth(),
             enabled = false,
+            readOnly = true,
+            mono = true,
         )
         Text(
             text = oauthTokens?.let { tokens ->
@@ -662,14 +661,14 @@ private fun ColumnScope.ProviderConfigureOpenAI(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            OutlinedTextField(
+            FlatTextField(
                 value = oauthDeviceCode.orEmpty(),
                 onValueChange = {},
-                label = {
-                    Text(stringResource(R.string.setting_provider_page_codex_oauth_device_code))
-                },
+                label = stringResource(R.string.setting_provider_page_codex_oauth_device_code),
                 modifier = Modifier.fillMaxWidth(),
                 enabled = false,
+                readOnly = true,
+                mono = true,
             )
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -841,39 +840,29 @@ private fun ColumnScope.ProviderConfigureClaude(
         )
     }
 
-    OutlinedTextField(
+    FlatTextField(
         value = provider.name,
-        onValueChange = {
-            onEdit(provider.copy(name = it.trim()))
-        },
-        label = {
-            Text(stringResource(id = R.string.setting_provider_page_name))
-        },
+        onValueChange = { onEdit(provider.copy(name = it.trim())) },
+        label = stringResource(id = R.string.setting_provider_page_name),
         modifier = Modifier.fillMaxWidth(),
-        maxLines = 3,
     )
 
-    OutlinedTextField(
+    FlatTextField(
         value = provider.apiKey,
-        onValueChange = {
-            onEdit(provider.copy(apiKey = it.trim()))
-        },
-        label = {
-            Text(stringResource(id = R.string.setting_provider_page_api_key))
-        },
+        onValueChange = { onEdit(provider.copy(apiKey = it.trim())) },
+        label = stringResource(id = R.string.setting_provider_page_api_key),
         modifier = Modifier.fillMaxWidth(),
+        singleLine = false,
+        mono = true,
         maxLines = 3,
     )
 
-    OutlinedTextField(
+    FlatTextField(
         value = provider.baseUrl,
-        onValueChange = {
-            onEdit(provider.copy(baseUrl = it.trim()))
-        },
-        label = {
-            Text(stringResource(id = R.string.setting_provider_page_api_base_url))
-        },
+        onValueChange = { onEdit(provider.copy(baseUrl = it.trim())) },
+        label = stringResource(id = R.string.setting_provider_page_api_base_url),
         modifier = Modifier.fillMaxWidth(),
+        mono = true,
         isError = provider.baseUrl.isNotBlank() && !provider.baseUrl.isValidBaseUrl()
     )
 
@@ -953,15 +942,11 @@ private fun ColumnScope.ProviderConfigureGoogle(
         )
     }
 
-    OutlinedTextField(
+    FlatTextField(
         value = provider.name,
-        onValueChange = {
-            onEdit(provider.copy(name = it.trim()))
-        },
-        label = {
-            Text(stringResource(id = R.string.setting_provider_page_name))
-        },
-        modifier = Modifier.fillMaxWidth()
+        onValueChange = { onEdit(provider.copy(name = it.trim())) },
+        label = stringResource(id = R.string.setting_provider_page_name),
+        modifier = Modifier.fillMaxWidth(),
     )
 
     // Auth mode segmented row — mirrors the OpenAI side. API_KEY keeps the existing
@@ -1051,37 +1036,30 @@ private fun ColumnScope.ProviderConfigureGoogle(
         }
 
         if (!(provider.vertexAI && provider.useServiceAccount)) {
-            OutlinedTextField(
+            FlatTextField(
                 value = provider.apiKey,
-                onValueChange = {
-                    onEdit(provider.copy(apiKey = it.trim()))
-                },
-                label = {
-                    Text(stringResource(id = R.string.setting_provider_page_api_key))
-                },
+                onValueChange = { onEdit(provider.copy(apiKey = it.trim())) },
+                label = stringResource(id = R.string.setting_provider_page_api_key),
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = false,
+                mono = true,
                 maxLines = 3,
             )
         }
 
         if (!provider.vertexAI) {
-            OutlinedTextField(
+            FlatTextField(
                 value = provider.baseUrl,
-                onValueChange = {
-                    onEdit(provider.copy(baseUrl = it.trim()))
-                },
-                label = {
-                    Text(stringResource(id = R.string.setting_provider_page_api_base_url))
-                },
+                onValueChange = { onEdit(provider.copy(baseUrl = it.trim())) },
+                label = stringResource(id = R.string.setting_provider_page_api_base_url),
                 modifier = Modifier.fillMaxWidth(),
+                mono = true,
                 isError = provider.baseUrl.isNotBlank() && (
                     !provider.baseUrl.isValidBaseUrl() || !provider.baseUrl.endsWith("/v1beta")
                 ),
                 supportingText = if (!provider.baseUrl.endsWith("/v1beta")) {
-                    {
-                        Text("The base URL usually ends with `/v1beta`")
-                    }
-                } else null
+                    "The base URL usually ends with `/v1beta`"
+                } else null,
             )
         } else {
             Row(
@@ -1106,49 +1084,34 @@ private fun ColumnScope.ProviderConfigureGoogle(
                 ) {
                     Text(stringResource(R.string.setting_provider_page_import_service_account_json))
                 }
-                OutlinedTextField(
+                FlatTextField(
                     value = provider.serviceAccountEmail,
-                    onValueChange = {
-                        onEdit(provider.copy(serviceAccountEmail = it.trim()))
-                    },
-                    label = {
-                        Text(stringResource(id = R.string.setting_provider_page_service_account_email))
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                OutlinedTextField(
-                    value = provider.privateKey,
-                    onValueChange = {
-                        onEdit(provider.copy(privateKey = it.trim()))
-                    },
-                    label = {
-                        Text(stringResource(id = R.string.setting_provider_page_private_key))
-                    },
+                    onValueChange = { onEdit(provider.copy(serviceAccountEmail = it.trim())) },
+                    label = stringResource(id = R.string.setting_provider_page_service_account_email),
                     modifier = Modifier.fillMaxWidth(),
+                    mono = true,
+                )
+                FlatTextField(
+                    value = provider.privateKey,
+                    onValueChange = { onEdit(provider.copy(privateKey = it.trim())) },
+                    label = stringResource(id = R.string.setting_provider_page_private_key),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = false,
+                    mono = true,
                     maxLines = 6,
                     minLines = 3,
-                    textStyle = MaterialTheme.typography.bodySmall.copy(fontFamily = JetbrainsMono),
                 )
-                OutlinedTextField(
+                FlatTextField(
                     value = provider.location,
-                    onValueChange = {
-                        onEdit(provider.copy(location = it.trim()))
-                    },
-                    label = {
-                        // https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#available-regions
-                        Text(stringResource(id = R.string.setting_provider_page_location))
-                    },
-                    modifier = Modifier.fillMaxWidth()
+                    onValueChange = { onEdit(provider.copy(location = it.trim())) },
+                    label = stringResource(id = R.string.setting_provider_page_location),
+                    modifier = Modifier.fillMaxWidth(),
                 )
-                OutlinedTextField(
+                FlatTextField(
                     value = provider.projectId,
-                    onValueChange = {
-                        onEdit(provider.copy(projectId = it.trim()))
-                    },
-                    label = {
-                        Text(stringResource(id = R.string.setting_provider_page_project_id))
-                    },
-                    modifier = Modifier.fillMaxWidth()
+                    onValueChange = { onEdit(provider.copy(projectId = it.trim())) },
+                    label = stringResource(id = R.string.setting_provider_page_project_id),
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }
@@ -1162,14 +1125,14 @@ private fun ColumnScope.ProviderConfigureGoogle(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        OutlinedTextField(
+        FlatTextField(
             value = checkNotNull(GoogleAuthMode.GEMINI_CODE_ASSIST_OAUTH.fixedBaseUrl()),
             onValueChange = {},
-            label = {
-                Text(stringResource(id = R.string.setting_provider_page_api_base_url))
-            },
+            label = stringResource(id = R.string.setting_provider_page_api_base_url),
             modifier = Modifier.fillMaxWidth(),
             enabled = false,
+            readOnly = true,
+            mono = true,
         )
         Text(
             text = geminiTokens?.let { tokens ->

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsPage.kt
@@ -277,9 +277,11 @@ private fun HeatmapGridCanvas(
     cellSize: androidx.compose.ui.unit.Dp,
     cellSpacing: androidx.compose.ui.unit.Dp,
 ) {
-    val futureColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-    val emptyColor = MaterialTheme.colorScheme.surfaceVariant
-    val baseColor = MaterialTheme.colorScheme.primary
+    // V3: heatmap 强制跟 chatTheme (即使 dynamicColor 开了 Material You, heatmap 也跟主题).
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
+    val futureColor = chatTheme.toolPillBg.copy(alpha = 0.3f)
+    val emptyColor = chatTheme.toolPillBg
+    val baseColor = chatTheme.accent
     val density = LocalDensity.current
     val cellPx = with(density) { cellSize.toPx() }
     val spacingPx = with(density) { cellSpacing.toPx() }
@@ -320,10 +322,11 @@ private fun HeatmapGridCanvas(
 
 @Composable
 private fun HeatmapCell(alpha: Float, sizeDp: Int) {
+    val chatTheme = me.rerere.rikkahub.ui.pages.chat.LocalChatTheme.current
     val color = when {
-        alpha < 0f -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f) // future
-        alpha == 0f -> MaterialTheme.colorScheme.surfaceVariant
-        else -> MaterialTheme.colorScheme.primary.copy(alpha = alpha)
+        alpha < 0f -> chatTheme.toolPillBg.copy(alpha = 0.3f) // future
+        alpha == 0f -> chatTheme.toolPillBg
+        else -> chatTheme.accent.copy(alpha = alpha)
     }
     Box(
         modifier = Modifier

--- a/app/src/main/java/me/rerere/rikkahub/ui/theme/Theme.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
@@ -199,22 +200,95 @@ fun RikkahubTheme(
         }
     }
 
+    // V3 chat theme（Phase 4.5）：深色模式强制 Midnight；浅色读 displaySetting.chatThemeChoice
+    // ("WHISPER" / "PLAIN" / "PAPER")。未知值 fallback 到 Whisper。
+    val chatTheme = if (darkTheme) {
+        me.rerere.rikkahub.ui.pages.chat.MidnightTheme
+    } else {
+        when (settings.displaySetting.chatThemeChoice) {
+            "PLAIN" -> me.rerere.rikkahub.ui.pages.chat.PlainTheme
+            "PAPER" -> me.rerere.rikkahub.ui.pages.chat.PaperTheme
+            else -> me.rerere.rikkahub.ui.pages.chat.WhisperTheme
+        }
+    }
+
+    // V3 Phase 4 二级页面适配：把 LocalChatTheme 映射到 MaterialTheme.colorScheme 的核心字段。
+    // 例外：
+    //   - dynamicColor 模式：用户明确选 Material You，跳过 chatTheme override
+    //   - AmoledDark：终审 #2 fix——AmoledDark 时仍应用 chatTheme accent/outline 体系，
+    //     但保留 bg/surface 为 #000 以省电。下方 cherry-pick override 处理。
+    val shouldApplyChatTheme = !(settings.dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+    val themedColorScheme = remember(colorSchemeConverted, chatTheme, shouldApplyChatTheme) {
+        if (!shouldApplyChatTheme) {
+            colorSchemeConverted
+        } else {
+            // AmoledDark 时保留纯黑 bg/surface（省电），其他主题 token 仍跟 chatTheme
+            val useAmoledBlack = amoledDarkMode && darkTheme
+            colorSchemeConverted.copy(
+                background = if (useAmoledBlack) colorSchemeConverted.background else chatTheme.bg,
+                onBackground = chatTheme.ink,
+                surface = if (useAmoledBlack) colorSchemeConverted.surface else chatTheme.paper,
+                onSurface = chatTheme.ink,
+                surfaceVariant = if (useAmoledBlack) colorSchemeConverted.surfaceVariant else chatTheme.toolPillBg,
+                onSurfaceVariant = chatTheme.inkSoft,
+                // Subagent #6: 5 级 hierarchy 让 NavDrawer / Card / BottomSheet 有深度
+                surfaceContainerLowest = chatTheme.containerLowest,
+                surfaceContainerLow = chatTheme.containerLow,
+                surfaceContainer = chatTheme.containerMid,
+                surfaceContainerHigh = chatTheme.containerHigh,
+                surfaceContainerHighest = chatTheme.containerHighest,
+                // surfaceBright / surfaceDim 之前没 override, dynamicLight 默认给浅蓝 tinted,
+                // 导致 cardColorsOnSurfaceContainer (= surfaceBright) 出现浅蓝底. 跟 chatTheme.
+                surfaceBright = chatTheme.containerHighest,
+                surfaceDim = chatTheme.containerLowest,
+                surfaceTint = chatTheme.accent,
+                primary = chatTheme.accent,
+                // Subagent #3: Midnight 用深字反白 (chatTheme.onAccent)；其他主题仍是白字
+                onPrimary = chatTheme.onAccent,
+                primaryContainer = chatTheme.accentSoft,
+                onPrimaryContainer = chatTheme.accentDeep,
+                secondary = chatTheme.accent,
+                secondaryContainer = chatTheme.accentSoft,
+                onSecondaryContainer = chatTheme.accentDeep,
+                // Subagent #8 补齐 tertiary 用同主题 accent 体系
+                tertiary = chatTheme.accentDeep,
+                onTertiary = chatTheme.onAccent,
+                tertiaryContainer = chatTheme.accentTint,
+                onTertiaryContainer = chatTheme.accentDeep,
+                // Subagent #9 / 终审 #1：Snackbar 用 inverseSurface 应为"反相"色——
+                // 深色主题给亮底 + 深字; 浅色主题给深底 + 亮字。当前 chatTheme.ink/paper
+                // 在浅色 = 深字/白底 (正确)；在深色 = 浅字/深底 (反了)。所以深色下交换。
+                inverseSurface = if (darkTheme) chatTheme.paper else chatTheme.ink,
+                inverseOnSurface = if (darkTheme) chatTheme.ink else chatTheme.paper,
+                inversePrimary = chatTheme.accentTint,
+                // Subagent #4
+                outline = chatTheme.outlineStrong,
+                outlineVariant = chatTheme.outlineSoft,
+            )
+        }
+    }
+
     CompositionLocalProvider(
         LocalDarkMode provides darkTheme,
         LocalAmoledDarkMode provides (darkTheme && amoledDarkMode),
         LocalExtendColors provides extendColors,
-        LocalOverscrollFactory provides null
+        LocalOverscrollFactory provides null,
+        me.rerere.rikkahub.ui.pages.chat.LocalChatTheme provides chatTheme,
+        // Bug fix: M3 LocalContentColor 默认 Color.Black. 没有 Surface 显式 provide 时
+        // (如 ChatPage 直接放 MarkdownBlock 的无 bubble 渲染路径), 深色模式下文字仍渲染成黑色.
+        // 这里显式 provide onSurface (= chatTheme.ink) 作为全局默认前景色.
+        LocalContentColor provides themedColorScheme.onSurface,
     ) {
         if (BuildConfig.NOTION_LIKE) {
             MaterialTheme(
-                colorScheme = colorSchemeConverted,
+                colorScheme = themedColorScheme,
                 typography = NotionTypography,
                 shapes = NotionShapes,
                 content = content,
             )
         } else {
             MaterialExpressiveTheme(
-                colorScheme = colorSchemeConverted,
+                colorScheme = themedColorScheme,
                 typography = Typography,
                 content = content,
                 motionScheme = MotionScheme.expressive()

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -603,8 +603,8 @@
   <string name="setting_display_page_show_line_numbers_title">顯示行號</string>
   <string name="setting_display_page_show_message_jumper_desc">在捲動聊天列表時，在右側顯示快速跳轉按鈕</string>
   <string name="setting_display_page_show_message_jumper_title">消息導航按鈕</string>
-  <string name="setting_display_page_show_model_name_desc">是否在聊天消息中顯示模型名稱</string>
-  <string name="setting_display_page_show_model_name_title">顯示模型名稱</string>
+  <string name="setting_display_page_show_model_name_desc">是否在聊天訊息中顯示 Agent 名稱</string>
+  <string name="setting_display_page_show_model_name_title">顯示 Agent 名稱</string>
   <string name="setting_display_page_show_thinking_content_desc">是否在生成時預設展開並顯示思考過程</string>
   <string name="setting_display_page_show_thinking_content_title">顯示思考內容</string>
   <string name="setting_display_page_show_token_usage_desc">顯示token用量和消息數量</string>
@@ -703,8 +703,8 @@
   <string name="setting_page_chat_storage_desc">%1$d 個檔案，%2$.2f MB</string>
   <string name="setting_page_code_display_settings">程式碼顯示</string>
   <string name="setting_page_color_mode">顏色模式</string>
-  <string name="setting_page_color_mode_dark">深色</string>
-  <string name="setting_page_color_mode_light">淺色</string>
+  <string name="setting_page_color_mode_dark">深色模式</string>
+  <string name="setting_page_color_mode_light">淺色模式</string>
   <string name="setting_page_color_mode_system">跟隨系統</string>
   <string name="setting_page_config">配置</string>
   <string name="setting_page_config_api_desc">你還沒有配置API和模型，請先配置</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -667,8 +667,8 @@
   <string name="setting_display_page_show_line_numbers_title">显示行号</string>
   <string name="setting_display_page_show_message_jumper_desc">在滚动聊天列表时，在右侧显示快速跳转按钮</string>
   <string name="setting_display_page_show_message_jumper_title">消息导航按钮</string>
-  <string name="setting_display_page_show_model_name_desc">是否在聊天消息中显示模型名称</string>
-  <string name="setting_display_page_show_model_name_title">显示模型名称</string>
+  <string name="setting_display_page_show_model_name_desc">是否在聊天消息中显示 Agent 名字</string>
+  <string name="setting_display_page_show_model_name_title">显示 Agent 名字</string>
   <string name="setting_display_page_show_thinking_content_desc">是否在生成过程中默认展开并显示思考过程</string>
   <string name="setting_display_page_show_thinking_content_title">显示思考内容</string>
   <string name="setting_display_page_show_token_usage_desc">显示token用量和消息数量</string>
@@ -1191,8 +1191,8 @@
   <string name="setting_page_chat_storage_desc">%1$d 个文件，%2$.2f MB</string>
   <string name="setting_page_code_display_settings">代码显示</string>
   <string name="setting_page_color_mode">颜色模式</string>
-  <string name="setting_page_color_mode_dark">深色</string>
-  <string name="setting_page_color_mode_light">浅色</string>
+  <string name="setting_page_color_mode_dark">深色模式</string>
+  <string name="setting_page_color_mode_light">浅色模式</string>
   <string name="setting_page_color_mode_system">跟随系统</string>
   <string name="setting_page_config">配置</string>
   <string name="setting_page_config_api_desc">你还没有配置API和模型，请先配置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -667,8 +667,8 @@
   <string name="setting_display_page_show_line_numbers_title">Show Line Numbers</string>
   <string name="setting_display_page_show_message_jumper_desc">Display quick jump buttons on the right when scrolling the chat list</string>
   <string name="setting_display_page_show_message_jumper_title">Show Message Jumper</string>
-  <string name="setting_display_page_show_model_name_desc">Whether to display model names in chat messages</string>
-  <string name="setting_display_page_show_model_name_title">Show Model Name</string>
+  <string name="setting_display_page_show_model_name_desc">Whether to display the Agent name in chat messages</string>
+  <string name="setting_display_page_show_model_name_title">Show Agent Name</string>
   <string name="setting_display_page_show_thinking_content_desc">Whether to expand and show the thinking process by default during generation</string>
   <string name="setting_display_page_show_thinking_content_title">Show Thinking Content</string>
   <string name="setting_display_page_show_token_usage_desc">Display token usage and message count</string>

--- a/app/src/refactortest/res/values/strings.xml
+++ b/app/src/refactortest/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="app_name">Amber Refresh</string>
+</resources>

--- a/docs/CHAT_UI_REFRESH_2026-05-23.html
+++ b/docs/CHAT_UI_REFRESH_2026-05-23.html
@@ -1,0 +1,1906 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Amber Agent · 主聊天页 UI 重构稿 · 2026-05-23</title>
+<style>
+  /* ============================================================
+     DESIGN TOKENS
+     ============================================================ */
+  :root {
+    /* Light */
+    --canvas: #F7F7F5;
+    --paper: #FFFFFF;
+    --row: #FAFAF8;
+    --ink: #1F1F1F;
+    --muted: #6B6761;
+    --faint: #9B9690;
+    --hairline: rgba(0, 0, 0, 0.085);
+    --hairline-soft: rgba(0, 0, 0, 0.045);
+
+    /* Brand blue — light scope */
+    --blue: #6BA8FF;
+    --blue-deep: #4A8FE8;
+    --blue-container: color-mix(in srgb, var(--blue) 16%, white);
+    --blue-glow: color-mix(in srgb, var(--blue) 28%, transparent);
+  }
+
+  .phone.dark {
+    --canvas: #0B0B0D;
+    --paper: #141417;
+    --row: #18181C;
+    --ink: #F1F3F5;
+    --muted: #A7ABB2;
+    --faint: #666C74;
+    --hairline: #22252B;
+    --hairline-soft: #1A1D22;
+
+    --blue: #82B7FF;
+    --blue-deep: #6BA8FF;
+    --blue-container: color-mix(in srgb, var(--blue) 22%, #0D1620);
+    --blue-glow: color-mix(in srgb, var(--blue) 30%, transparent);
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html, body { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Segoe UI", "Microsoft Yahei", sans-serif; }
+
+  body {
+    background: #ECECEE;
+    color: #1F1F1F;
+    padding: 64px 24px 160px;
+    -webkit-font-smoothing: antialiased;
+    text-wrap: pretty;
+  }
+
+  /* ============================================================
+     DOC HEADER
+     ============================================================ */
+  .doc-header {
+    max-width: 1280px;
+    margin: 0 auto 64px;
+    padding: 0 8px;
+  }
+  .doc-eyebrow {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: #6B6761;
+    font-weight: 600;
+    margin-bottom: 10px;
+  }
+  .doc-title {
+    font-size: 34px;
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    margin-bottom: 14px;
+    color: #1A1A1C;
+  }
+  .doc-lede {
+    font-size: 15.5px;
+    color: #5C5853;
+    max-width: 760px;
+    line-height: 1.65;
+  }
+  .doc-lede strong { color: #1F1F1F; font-weight: 600; }
+
+  .token-strip {
+    margin-top: 32px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 14px;
+    max-width: 1080px;
+  }
+  .token-card {
+    background: white;
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: 14px;
+    padding: 14px 16px;
+  }
+  .token-card h4 {
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #6B6761;
+    margin-bottom: 11px;
+    font-weight: 600;
+  }
+  .token-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    margin-bottom: 7px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: #3D3A36;
+  }
+  .token-row:last-child { margin-bottom: 0; }
+  .token-row .lbl { color: #6B6761; min-width: 64px; }
+  .token-swatch {
+    width: 14px; height: 14px;
+    border-radius: 4px;
+    border: 1px solid rgba(0,0,0,0.08);
+    flex-shrink: 0;
+  }
+
+  /* ============================================================
+     FRAME GRID
+     ============================================================ */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+    gap: 64px 36px;
+    justify-items: center;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  .frame {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    max-width: 420px;
+  }
+
+  .caption {
+    text-align: center;
+    max-width: 380px;
+  }
+  .caption .title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #1F1F1F;
+    margin-bottom: 5px;
+    letter-spacing: -0.005em;
+  }
+  .caption .note {
+    font-size: 12.5px;
+    color: #6B6761;
+    line-height: 1.6;
+  }
+  .caption .note code {
+    background: rgba(0,0,0,0.05);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11.5px;
+  }
+
+  /* ============================================================
+     PHONE BEZEL
+     ============================================================ */
+  .phone {
+    width: 390px;
+    height: 844px;
+    background: var(--canvas);
+    border-radius: 52px;
+    box-shadow:
+      0 0 0 1.5px #2A2A2E,
+      0 0 0 11px #16161B,
+      0 0 0 12px #2E2E33,
+      0 38px 80px -28px rgba(20, 20, 40, 0.22),
+      0 12px 28px -10px rgba(20, 20, 40, 0.14);
+    overflow: hidden;
+    position: relative;
+    color: var(--ink);
+    isolation: isolate;
+  }
+
+  /* Inner screen */
+  .screen {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--canvas);
+  }
+
+  /* ============================================================
+     STATUS BAR
+     ============================================================ */
+  .status-bar {
+    height: 46px;
+    padding: 14px 28px 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    flex-shrink: 0;
+    color: var(--ink);
+    position: relative;
+    z-index: 5;
+  }
+  .status-bar .right {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 600;
+  }
+  .status-bar .right svg { color: var(--ink); }
+  .battery {
+    border: 1.2px solid var(--ink);
+    border-radius: 4px;
+    padding: 1.5px 4px 1.5px 3px;
+    font-size: 9px;
+    font-weight: 700;
+    position: relative;
+    line-height: 1;
+  }
+  .battery::after {
+    content: "";
+    position: absolute;
+    right: -3px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1.5px; height: 5px;
+    background: var(--ink);
+    border-radius: 0 1px 1px 0;
+  }
+
+  /* ============================================================
+     TOP BAR
+     ============================================================ */
+  .top-bar {
+    height: 52px;
+    padding: 0 12px 0 14px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-shrink: 0;
+    position: relative;
+    z-index: 4;
+    background: var(--canvas);
+  }
+  .top-bar .left {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+  }
+  .icon-btn {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background 120ms ease;
+  }
+  .icon-btn:hover { background: var(--hairline-soft); }
+  .icon-btn.muted { color: var(--muted); }
+  .icon-btn.accent { color: var(--blue-deep); }
+
+  .model-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 6px 4px 8px;
+    border-radius: 12px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 17px;
+    color: var(--ink);
+    letter-spacing: -0.012em;
+    min-width: 0;
+    transition: background 120ms ease;
+  }
+  .model-pill:hover { background: var(--hairline-soft); }
+  .model-pill .chev {
+    display: inline-flex; align-items: center; justify-content: center;
+    color: var(--muted);
+    margin-top: 1px;
+  }
+
+  /* ============================================================
+     CONTENT AREA
+     ============================================================ */
+  .content {
+    flex: 1;
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* Sky-blue ambient — Gemini-style atmospheric rise from bottom half of the
+     screen, not a tiny glow. Linear lift + a slightly off-center radial
+     for natural-looking light. */
+  .sky-glow {
+    position: absolute;
+    left: 0; right: 0; bottom: -80px;
+    height: 520px;
+    pointer-events: none;
+    background:
+      linear-gradient(to top,
+        var(--blue-glow) 0%,
+        color-mix(in srgb, var(--blue) 12%, transparent) 36%,
+        color-mix(in srgb, var(--blue) 4%, transparent) 62%,
+        transparent 84%),
+      radial-gradient(150% 80% at 50% 120%,
+        color-mix(in srgb, var(--blue) 22%, transparent) 0%,
+        transparent 58%);
+    z-index: 0;
+  }
+
+  /* ============================================================
+     INPUT REGION (capsule composer)
+     ============================================================ */
+  .input-region {
+    padding: 4px 12px 28px;
+    position: relative;
+    z-index: 3;
+  }
+  .composer {
+    height: 62px;
+    background: var(--paper);
+    border: 1px solid var(--hairline);
+    border-radius: 31px;
+    display: flex;
+    align-items: center;
+    padding: 0 7px 0 6px;
+    gap: 4px;
+    box-shadow:
+      0 1px 0 rgba(0,0,0,0.02),
+      0 12px 28px -16px rgba(0,0,0,0.08);
+  }
+  .composer .add-btn {
+    width: 44px; height: 44px;
+    border-radius: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink);
+    flex-shrink: 0;
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease;
+  }
+  .composer .add-btn:hover { background: var(--hairline-soft); }
+  .composer .add-btn.expanded {
+    color: var(--blue-deep);
+    background: var(--blue-container);
+  }
+  .composer .divider {
+    width: 1px; height: 22px;
+    background: var(--hairline);
+    flex-shrink: 0;
+    margin: 0 2px;
+  }
+  .composer .field {
+    flex: 1;
+    font-size: 15px;
+    color: var(--faint);
+    padding: 0 4px;
+    letter-spacing: -0.005em;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .composer .field.typed {
+    color: var(--ink);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 14.5px;
+  }
+  .composer .field.typed .caret {
+    display: inline-block;
+    width: 1.5px; height: 16px;
+    background: var(--blue);
+    vertical-align: -3px;
+    margin-left: 1px;
+    animation: blink 1.05s steps(1) infinite;
+  }
+  .composer .slash-chip {
+    height: 30px;
+    min-width: 30px;
+    padding: 0 9px;
+    border-radius: 9px;
+    border: 1px solid color-mix(in srgb, var(--blue) 45%, transparent);
+    background: var(--blue-container);
+    color: var(--blue-deep);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 14.5px;
+    font-weight: 700;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    flex-shrink: 0;
+    margin-right: 4px;
+    cursor: pointer;
+  }
+  .composer .slash-chip.active {
+    background: var(--blue);
+    color: white;
+    border-color: var(--blue);
+  }
+  .composer .send {
+    width: 44px; height: 44px;
+    border-radius: 22px;
+    background: var(--blue);
+    color: white;
+    display: inline-flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    cursor: pointer;
+    box-shadow: 0 4px 12px -4px color-mix(in srgb, var(--blue) 55%, transparent);
+    transition: background 120ms ease;
+  }
+  .composer .send:hover { background: var(--blue-deep); }
+  .composer .send.muted {
+    background: var(--blue-container);
+    color: color-mix(in srgb, var(--blue) 60%, white);
+    box-shadow: none;
+  }
+  .phone.dark .composer .send.muted {
+    color: color-mix(in srgb, var(--blue) 70%, transparent);
+  }
+
+  @keyframes blink {
+    50% { opacity: 0; }
+  }
+
+  /* ============================================================
+     OPTIONAL GREETING (toggled via Tweaks → 问候)
+     ============================================================ */
+  .greeting {
+    position: absolute;
+    left: 0; right: 0;
+    top: 40%;
+    transform: translateY(-50%);
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    z-index: 1;
+    padding: 0 32px;
+    pointer-events: none;
+  }
+  body.show-greeting .greeting { display: flex; }
+  .sparkle {
+    width: 28px; height: 28px;
+    background:
+      conic-gradient(from 90deg at 50% 50%,
+        #5390ff 0%, #b385f0 28%, #ff80a6 52%, #ffb068 76%, #5390ff 100%);
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 1.6 13.7 8.6 22 12 13.7 15.4 12 22.4 10.3 15.4 2 12 10.3 8.6z'/></svg>") center / contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 1.6 13.7 8.6 22 12 13.7 15.4 12 22.4 10.3 15.4 2 12 10.3 8.6z'/></svg>") center / contain no-repeat;
+  }
+  .greet-text {
+    font-size: 28px;
+    font-weight: 400;
+    color: var(--ink);
+    letter-spacing: -0.022em;
+    text-align: center;
+    line-height: 1.3;
+    text-wrap: balance;
+  }
+
+  /* ============================================================
+     CHAT MESSAGES
+     ============================================================ */
+  .messages {
+    padding: 10px 16px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    overflow: hidden;
+    position: relative;
+    z-index: 1;
+  }
+  .msg-user {
+    align-self: flex-end;
+    max-width: 86%;
+    background: var(--blue-container);
+    color: var(--ink);
+    padding: 10px 14px;
+    border-radius: 20px 20px 6px 20px;
+    font-size: 14.5px;
+    line-height: 1.5;
+  }
+  .msg-ai {
+    align-self: flex-start;
+    max-width: 96%;
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+  }
+  .msg-ai .avatar {
+    width: 26px; height: 26px;
+    border-radius: 8px;
+    background: linear-gradient(140deg, var(--blue), var(--blue-deep));
+    color: white;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 10.5px;
+    font-weight: 700;
+    flex-shrink: 0;
+    margin-top: 1px;
+    letter-spacing: -0.02em;
+  }
+  .msg-ai .body {
+    flex: 1;
+    font-size: 14.5px;
+    line-height: 1.6;
+    color: var(--ink);
+  }
+  .msg-ai .body p { margin-bottom: 6px; }
+  .msg-ai .body p:last-child { margin-bottom: 0; }
+  .ai-cursor {
+    display: inline-block;
+    width: 6px; height: 14px;
+    background: var(--blue);
+    vertical-align: text-bottom;
+    margin-left: 2px;
+    border-radius: 1px;
+    animation: blink 1.05s steps(1) infinite;
+  }
+
+  /* ============================================================
+     MODEL PICKER SHEET
+     ============================================================ */
+  .scrim {
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.34);
+    z-index: 2;
+    backdrop-filter: blur(2px);
+  }
+  .sheet {
+    position: absolute;
+    left: 0; right: 0; bottom: 0;
+    height: 78%;
+    background: var(--paper);
+    border-radius: 24px 24px 0 0;
+    display: flex;
+    flex-direction: column;
+    z-index: 3;
+    box-shadow: 0 -8px 32px rgba(0,0,0,0.10);
+  }
+  .sheet-handle {
+    width: 36px; height: 4px;
+    background: var(--hairline);
+    border-radius: 2px;
+    margin: 8px auto 4px;
+    flex-shrink: 0;
+  }
+  .sheet-head {
+    padding: 6px 14px 6px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+  }
+  .sheet-head .title {
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+  }
+  .search-input {
+    margin: 4px 14px 8px;
+    height: 40px;
+    border-radius: 12px;
+    background: var(--row);
+    border: 1px solid var(--hairline);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 12px;
+    font-size: 14px;
+    color: var(--faint);
+    flex-shrink: 0;
+  }
+  .search-input svg { color: var(--muted); }
+
+  .model-list {
+    flex: 1;
+    overflow: hidden;
+    padding: 4px 12px 16px;
+    display: flex;
+    flex-direction: column;
+  }
+  .provider-head {
+    padding: 12px 8px 6px;
+    font-size: 10.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+  }
+  .model-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px 10px 16px;
+    border-radius: 12px;
+    position: relative;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+  .model-row:hover { background: var(--row); }
+  .model-row.selected {
+    background: var(--blue-container);
+  }
+  .model-row.selected::before {
+    content: "";
+    position: absolute;
+    left: 6px;
+    top: 16px; bottom: 16px;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--blue);
+  }
+  .model-row .ic {
+    width: 30px; height: 30px;
+    border-radius: 9px;
+    background: var(--row);
+    border: 1px solid var(--hairline);
+    display: inline-flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    color: var(--ink);
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+  .model-row.selected .ic {
+    background: var(--paper);
+    border-color: color-mix(in srgb, var(--blue) 35%, transparent);
+  }
+  .model-row .meta { flex: 1; min-width: 0; }
+  .model-row .name {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 3px;
+    letter-spacing: -0.008em;
+  }
+  .model-row .sub {
+    font-size: 11.5px;
+    color: var(--muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .cap-chip {
+    display: inline-flex; align-items: center; gap: 3px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--row);
+    border: 1px solid var(--hairline);
+    font-size: 10.5px;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  .model-row.selected .cap-chip {
+    background: var(--paper);
+    border-color: color-mix(in srgb, var(--blue) 22%, transparent);
+  }
+  .cap-chip svg { width: 11px; height: 11px; }
+  .model-row .check {
+    width: 22px; height: 22px;
+    border-radius: 11px;
+    background: var(--blue);
+    color: white;
+    display: inline-flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .model-row:not(.selected) .check { display: none; }
+
+  /* ============================================================
+     DRAWER
+     ============================================================ */
+  .drawer {
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 304px;
+    background: var(--paper);
+    display: flex;
+    flex-direction: column;
+    box-shadow: 8px 0 24px rgba(0,0,0,0.06);
+    z-index: 2;
+    padding-top: 46px; /* leave room for status bar */
+  }
+  .drawer-head {
+    padding: 12px 12px 6px;
+  }
+  .new-chat-btn {
+    height: 40px;
+    border-radius: 14px;
+    border: 1px solid var(--hairline);
+    background: var(--paper);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 14px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--ink);
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+  .new-chat-btn:hover { background: var(--row); }
+  .new-chat-btn .ic-plus { color: var(--blue); display: inline-flex; }
+  .drawer-search {
+    margin: 8px 12px 4px;
+    height: 36px;
+    border-radius: 10px;
+    background: var(--row);
+    border: 1px solid var(--hairline);
+    display: flex; align-items: center; gap: 8px;
+    padding: 0 10px;
+    font-size: 13px;
+    color: var(--faint);
+  }
+  .drawer-search svg { color: var(--muted); }
+  .drawer-list {
+    flex: 1;
+    overflow: hidden;
+    padding: 4px 8px 12px;
+  }
+  .drawer-group-head {
+    padding: 14px 10px 6px;
+    font-size: 10.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .drawer-group-head svg { width: 11px; height: 11px; }
+  .conv-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+  .conv-row:hover { background: var(--row); }
+  .conv-row.active { background: var(--blue-container); }
+  .conv-row .ic {
+    width: 24px; height: 24px;
+    border-radius: 7px;
+    background: var(--row);
+    border: 1px solid var(--hairline);
+    display: inline-flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    font-size: 9.5px;
+    font-weight: 700;
+    color: var(--muted);
+    margin-top: 2px;
+    letter-spacing: -0.02em;
+  }
+  .conv-row.active .ic { background: var(--paper); color: var(--blue-deep); border-color: color-mix(in srgb, var(--blue) 30%, transparent); }
+  .conv-row .text { flex: 1; min-width: 0; }
+  .conv-row .title-line {
+    font-size: 13.5px;
+    font-weight: 500;
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 2px;
+    letter-spacing: -0.005em;
+  }
+  .conv-row .preview {
+    font-size: 11.5px;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .drawer-foot {
+    padding: 10px 14px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    border-top: 1px solid var(--hairline);
+  }
+  .user-mini {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+  }
+  .user-mini .av {
+    width: 30px; height: 30px;
+    border-radius: 15px;
+    background: linear-gradient(140deg, #FFD27C, #FF9447);
+    color: white;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 11.5px;
+    font-weight: 700;
+  }
+  .user-mini .label {
+    font-size: 13.5px;
+    color: var(--ink);
+    font-weight: 500;
+  }
+
+  .drawer-scrim {
+    position: absolute;
+    left: 304px; right: 0; top: 0; bottom: 0;
+    background: rgba(0,0,0,0.30);
+    z-index: 2;
+    backdrop-filter: blur(0.5px);
+  }
+
+  /* ============================================================
+     ATTACHMENT TRAY (floating above input)
+     ============================================================ */
+  .attach-tray {
+    position: absolute;
+    left: 12px; right: 12px;
+    bottom: 14px;
+    background: var(--paper);
+    border: 1px solid var(--hairline);
+    border-radius: 22px;
+    padding: 14px 6px;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    box-shadow:
+      0 1px 0 rgba(0,0,0,0.02),
+      0 16px 36px -14px rgba(0,0,0,0.14);
+    z-index: 2;
+  }
+  .attach-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: 12px;
+    cursor: pointer;
+    color: var(--ink);
+  }
+  .attach-tile:hover { background: var(--row); }
+  .attach-tile .ic-wrap {
+    width: 46px; height: 46px;
+    border-radius: 14px;
+    background: var(--blue-container);
+    color: var(--blue-deep);
+    display: inline-flex; align-items: center; justify-content: center;
+  }
+  .attach-tile .lbl {
+    font-size: 11.5px;
+    color: var(--muted);
+    font-weight: 500;
+    letter-spacing: -0.005em;
+  }
+
+  /* ============================================================
+     SLASH COMMAND PALETTE
+     ============================================================ */
+  .slash-card {
+    position: absolute;
+    left: 16px; right: 16px;
+    bottom: 14px;
+    background: var(--paper);
+    border: 1px solid var(--hairline);
+    border-radius: 18px;
+    padding: 6px;
+    box-shadow:
+      0 1px 0 rgba(0,0,0,0.02),
+      0 18px 44px -16px rgba(0,0,0,0.16);
+    z-index: 2;
+  }
+  .slash-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    cursor: pointer;
+  }
+  .slash-row.focus { background: var(--row); }
+  .slash-row:hover { background: var(--row); }
+  .slash-row .ic {
+    width: 34px; height: 34px;
+    border-radius: 10px;
+    background: var(--blue-container);
+    color: var(--blue-deep);
+    display: inline-flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .slash-row .meta { flex: 1; min-width: 0; }
+  .slash-row .cmd {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--ink);
+    margin-bottom: 2px;
+    letter-spacing: -0.005em;
+  }
+  .slash-row .desc {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.4;
+  }
+  .slash-row .hint {
+    font-size: 10.5px;
+    color: var(--faint);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    flex-shrink: 0;
+  }
+
+  /* ============================================================
+     SECTION SEPARATOR
+     ============================================================ */
+  .section-mark {
+    grid-column: 1 / -1;
+    text-align: center;
+    margin: 8px 0 -16px;
+  }
+  .section-mark .label {
+    display: inline-block;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: #6B6761;
+    font-weight: 700;
+    background: #ECECEE;
+    padding: 0 14px;
+    position: relative;
+  }
+  .section-mark::before {
+    content: "";
+    display: block;
+    height: 1px;
+    background: rgba(0,0,0,0.08);
+    position: relative;
+    top: 12px;
+    margin: 0 auto;
+    max-width: 720px;
+  }
+
+  /* ============================================================
+     TWEAKS PANEL
+     ============================================================ */
+  .tweaks {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: 14px;
+    padding: 14px 16px;
+    box-shadow: 0 12px 32px -8px rgba(0,0,0,0.16);
+    font-size: 12px;
+    color: #1F1F1F;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    z-index: 99;
+  }
+  .tweaks-label {
+    font-weight: 600;
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #6B6761;
+  }
+  .tweaks-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .tweaks input[type="color"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 28px; height: 28px;
+    border: 1px solid rgba(0,0,0,0.12);
+    border-radius: 8px;
+    cursor: pointer;
+    padding: 0;
+    background: transparent;
+  }
+  .tweaks input[type="color"]::-webkit-color-swatch-wrapper { padding: 0; }
+  .tweaks input[type="color"]::-webkit-color-swatch { border: none; border-radius: 6px; }
+  .tweaks .hex {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11.5px;
+    color: #3D3A36;
+    min-width: 64px;
+  }
+  .tweaks button {
+    appearance: none;
+    border: 1px solid rgba(0,0,0,0.12);
+    background: white;
+    border-radius: 8px;
+    padding: 4px 10px;
+    font-size: 11.5px;
+    color: #3D3A36;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .tweaks button:hover { background: #F7F7F5; }
+</style>
+</head>
+<body>
+
+<!-- ============================================================
+     ICON LIBRARY (defined once, used via <use>)
+     ============================================================ -->
+<svg style="position:absolute; width:0; height:0;" aria-hidden="true">
+  <defs>
+    <symbol id="i-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round">
+      <path d="M4 7h16M4 12h16M4 17h16"/>
+    </symbol>
+    <symbol id="i-chev-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 9.5l6 6 6-6"/>
+    </symbol>
+    <symbol id="i-compose" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="10" stroke-dasharray="1.6 2.4"/>
+      <path d="m14.7 7.4 2.4 2.4-6.6 6.6-2.9.5.5-2.9z"/>
+      <path d="m13.6 8.6 2.4 2.4"/>
+    </symbol>
+    <symbol id="i-plus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <path d="M12 5.5v13M5.5 12h13"/>
+    </symbol>
+    <symbol id="i-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <path d="M18 6L6 18M6 6l12 12"/>
+    </symbol>
+    <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M20 6L9 17l-5-5"/>
+    </symbol>
+    <symbol id="i-arrow-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 19V5M5 12l7-7 7 7"/>
+    </symbol>
+    <symbol id="i-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <circle cx="11" cy="11" r="7"/>
+      <path d="m20 20-3.6-3.6"/>
+    </symbol>
+    <symbol id="i-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1A1.7 1.7 0 0 0 9 19.4a1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1A1.7 1.7 0 0 0 4.6 9a1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>
+    </symbol>
+    <symbol id="i-pin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 17v5"/>
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16h14v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V5a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/>
+    </symbol>
+    <symbol id="i-camera" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 8.5h2.6l1.7-2h9.4l1.7 2H21a1 1 0 0 1 1 1V18a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V9.5a1 1 0 0 1 1-1z"/>
+      <circle cx="12" cy="13.5" r="3.6"/>
+    </symbol>
+    <symbol id="i-image" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="4.5" width="18" height="15" rx="2.4"/>
+      <circle cx="8.6" cy="9.6" r="1.5"/>
+      <path d="m3.5 17 5-5 4 4 2.5-2.5 5.5 5.5"/>
+    </symbol>
+    <symbol id="i-video" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="6" width="13.5" height="12" rx="2"/>
+      <path d="m21 8-4.5 3v2L21 16z"/>
+    </symbol>
+    <symbol id="i-music" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 18V6l11-2v12"/>
+      <circle cx="6" cy="18" r="2.6"/>
+      <circle cx="17" cy="16" r="2.6"/>
+    </symbol>
+    <symbol id="i-file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/>
+      <path d="M14 3v5h5"/>
+    </symbol>
+    <symbol id="i-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 5.5A2 2 0 0 1 5 3.5h6.5v17H5a2 2 0 0 1-2-2z"/>
+      <path d="M21 5.5a2 2 0 0 0-2-2h-6.5v17H19a2 2 0 0 0 2-2z"/>
+    </symbol>
+    <symbol id="i-translate" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 5.5h10"/>
+      <path d="M7.5 3.5v2"/>
+      <path d="M11 5.5c-.6 4-3.5 7.5-7.5 9"/>
+      <path d="M5 9.5c1.7 2.7 4 4.6 7 5.6"/>
+      <path d="m13 20 4-9 4 9"/>
+      <path d="M14.5 17h5"/>
+    </symbol>
+    <symbol id="i-summary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 6h16M4 12h12M4 18h8"/>
+    </symbol>
+    <symbol id="i-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9"/>
+      <path d="M3.5 12h17"/>
+      <path d="M12 3.2c2.5 2.4 3.8 5.6 3.8 8.8s-1.3 6.4-3.8 8.8c-2.5-2.4-3.8-5.6-3.8-8.8s1.3-6.4 3.8-8.8z"/>
+    </symbol>
+    <symbol id="i-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
+      <circle cx="12" cy="12" r="2.8"/>
+    </symbol>
+    <symbol id="i-tool" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14.7 5.3a4.6 4.6 0 0 1 6.3 4.3 4.6 4.6 0 0 1-6.1 4.3l-7.5 7.5a2 2 0 0 1-2.8-2.8l7.5-7.5a4.6 4.6 0 0 1 2.6-5.8z"/>
+    </symbol>
+    <symbol id="i-brain" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 4a2.5 2.5 0 0 0-2.5 2.5v.7A3 3 0 0 0 4 10v.5a3 3 0 0 0 0 5V16a3 3 0 0 0 3 3 2.5 2.5 0 0 0 2 1 2.5 2.5 0 0 0 2.5-2.5V4.5A2.5 2.5 0 0 0 9 4z"/>
+      <path d="M15 4a2.5 2.5 0 0 1 2.5 2.5v.7A3 3 0 0 1 20 10v.5a3 3 0 0 1 0 5V16a3 3 0 0 1-3 3 2.5 2.5 0 0 1-2 1 2.5 2.5 0 0 1-2.5-2.5V4.5A2.5 2.5 0 0 1 15 4z"/>
+    </symbol>
+    <symbol id="i-wifi" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M2 9a16 16 0 0 1 20 0"/>
+      <path d="M5 13a11 11 0 0 1 14 0"/>
+      <path d="M8.5 16.5a6 6 0 0 1 7 0"/>
+      <circle cx="12" cy="20" r="1" fill="currentColor"/>
+    </symbol>
+    <symbol id="i-signal" viewBox="0 0 24 24" fill="currentColor">
+      <rect x="2" y="14" width="3" height="6" rx="0.5"/>
+      <rect x="7" y="10" width="3" height="10" rx="0.5"/>
+      <rect x="12" y="6" width="3" height="14" rx="0.5"/>
+      <rect x="17" y="2" width="3" height="18" rx="0.5"/>
+    </symbol>
+  </defs>
+</svg>
+
+<!-- ============================================================
+     DOC HEADER
+     ============================================================ -->
+<div class="doc-header">
+  <div class="doc-eyebrow">DESIGN COMPS · 2026-05-23</div>
+  <h1 class="doc-title">Amber Agent · 主聊天页 UI 重构</h1>
+  <p class="doc-lede">
+    一套 Gemini 级别的克制感主聊天页设计稿。<strong>顶栏只露当前模型 + 下拉</strong>，
+    新建聊天图标变成无填充的轻量线条；<strong>中间彻底留白</strong>，没有大 logo、问候、prompt chips；
+    <strong>底部输入框是真正的高级大胶囊</strong>，[+] 附件、[/] 斜杠命令、淡蓝圆形发送各司其职。
+    主色锁定淡蓝 <code>#6BA8FF</code>，可在右下 Tweaks 实时换 hue 看效果。
+  </p>
+
+  <div class="token-strip">
+    <div class="token-card">
+      <h4>Brand Blue（淡蓝）</h4>
+      <div class="token-row"><span class="token-swatch" style="background:#6BA8FF"></span><span class="lbl">blue</span><span>#6BA8FF</span></div>
+      <div class="token-row"><span class="token-swatch" style="background:#4A8FE8"></span><span class="lbl">deep</span><span>#4A8FE8</span></div>
+      <div class="token-row"><span class="token-swatch" style="background:#EAF2FF"></span><span class="lbl">container</span><span>#EAF2FF</span></div>
+    </div>
+    <div class="token-card">
+      <h4>Neutral（浅色）</h4>
+      <div class="token-row"><span class="token-swatch" style="background:#FFFFFF;border-color:#DDD"></span><span class="lbl">paper</span><span>#FFFFFF</span></div>
+      <div class="token-row"><span class="token-swatch" style="background:#F7F7F5"></span><span class="lbl">canvas</span><span>#F7F7F5</span></div>
+      <div class="token-row"><span class="token-swatch" style="background:#1F1F1F"></span><span class="lbl">ink</span><span>#1F1F1F</span></div>
+      <div class="token-row"><span class="token-swatch" style="background:#6B6761"></span><span class="lbl">muted</span><span>#6B6761</span></div>
+    </div>
+    <div class="token-card">
+      <h4>Typography</h4>
+      <div class="token-row"><span class="lbl">title</span><span>17px / 600</span></div>
+      <div class="token-row"><span class="lbl">body</span><span>14.5–15px / 400</span></div>
+      <div class="token-row"><span class="lbl">sub</span><span>11.5–12.5px / 500</span></div>
+      <div class="token-row"><span class="lbl">eyebrow</span><span>10.5px UPPER · ls 0.1em</span></div>
+    </div>
+    <div class="token-card">
+      <h4>Shape</h4>
+      <div class="token-row"><span class="lbl">capsule</span><span>radius 31px</span></div>
+      <div class="token-row"><span class="lbl">round-btn</span><span>22px (圆)</span></div>
+      <div class="token-row"><span class="lbl">card</span><span>radius 12–18px</span></div>
+      <div class="token-row"><span class="lbl">stroke</span><span>1px hairline 8.5%</span></div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     FRAMES
+     ============================================================ -->
+<div class="grid">
+
+  <!-- =========================================================
+       FRAME 1 — EMPTY CHAT (LIGHT)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content">
+          <div class="sky-glow"></div>
+          <div class="greeting">
+            <div class="sparkle"></div>
+            <div class="greet-text">想问什么？</div>
+          </div>
+        </div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn"><svg width="20" height="20"><use href="#i-plus"/></svg></div>
+            <div class="divider"></div>
+            <div class="field">输入消息</div>
+            <div class="slash-chip">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">01 · 空白态主聊天页</div>
+      <div class="note">顶栏只展示当前模型名 + 下拉；中央彻底留白；底部胶囊由淡蓝晕光向上托起，呼应用户参考目标。空状态发送键灰化，避免误触。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 2 — ACTIVE CONVERSATION (LIGHT, STREAMING)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:36</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content">
+          <div class="sky-glow"></div>
+          <div class="messages">
+            <div class="msg-user">请把这段日语合同的第 4 条翻译成中文，注意法律语气。</div>
+            <div class="msg-ai">
+              <div class="avatar">DS</div>
+              <div class="body">
+                <p>好的。第 4 条原文为「乙は本契約に基づき、甲から提供された資料につき秘密保持義務を負う」。</p>
+                <p>直译："乙方依据本合同，对甲方提供的资料承担保密义务，未经书面同意不得披露给第三方。"</p>
+              </div>
+            </div>
+            <div class="msg-user">再帮我润色得更正式一些。</div>
+            <div class="msg-ai">
+              <div class="avatar">DS</div>
+              <div class="body">当然。润色后的版本：<br>"乙方依据本合同之约定，对甲方所提供之全部资料承担严格保密义务，<span class="ai-cursor"></span></div>
+            </div>
+          </div>
+        </div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn"><svg width="20" height="20"><use href="#i-plus"/></svg></div>
+            <div class="divider"></div>
+            <div class="field">输入消息</div>
+            <div class="slash-chip">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">02 · 活跃对话态（流式输出中）</div>
+      <div class="note">用户气泡淡蓝底贴右；助手消息无气泡，模型小头像 + 纯正文，便于阅读；流式末尾用细单条淡蓝光标，不抢戏。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 3 — MODEL PICKER BOTTOM SHEET (LIGHT)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content"><div class="sky-glow"></div></div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn"><svg width="20" height="20"><use href="#i-plus"/></svg></div>
+            <div class="divider"></div>
+            <div class="field">输入消息</div>
+            <div class="slash-chip">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+
+        <!-- Overlay: scrim + sheet -->
+        <div class="scrim"></div>
+        <div class="sheet">
+          <div class="sheet-handle"></div>
+          <div class="sheet-head">
+            <span class="title">选择模型</span>
+            <div class="icon-btn muted"><svg width="18" height="18"><use href="#i-close"/></svg></div>
+          </div>
+          <div class="search-input">
+            <svg width="16" height="16"><use href="#i-search"/></svg>
+            <span>搜索模型</span>
+          </div>
+          <div class="model-list">
+            <div class="provider-head">DeepSeek</div>
+            <div class="model-row selected">
+              <div class="ic">DS</div>
+              <div class="meta">
+                <div class="name">DeepSeek V4 Pro</div>
+                <div class="sub">
+                  <span>128K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+              <div class="check"><svg width="13" height="13"><use href="#i-check"/></svg></div>
+            </div>
+            <div class="model-row">
+              <div class="ic">DS</div>
+              <div class="meta">
+                <div class="name">DeepSeek V3.5</div>
+                <div class="sub">
+                  <span>64K</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                </div>
+              </div>
+            </div>
+            <div class="provider-head">OpenAI</div>
+            <div class="model-row">
+              <div class="ic">GPT</div>
+              <div class="meta">
+                <div class="name">GPT-5 Pro</div>
+                <div class="sub">
+                  <span>200K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+            <div class="model-row">
+              <div class="ic">GPT</div>
+              <div class="meta">
+                <div class="name">GPT-5</div>
+                <div class="sub">
+                  <span>200K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                </div>
+              </div>
+            </div>
+            <div class="provider-head">Anthropic</div>
+            <div class="model-row">
+              <div class="ic">CL</div>
+              <div class="meta">
+                <div class="name">Claude Opus 4.7</div>
+                <div class="sub">
+                  <span>1M</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+            <div class="provider-head">Google</div>
+            <div class="model-row">
+              <div class="ic">GM</div>
+              <div class="meta">
+                <div class="name">Gemini 3 Pro</div>
+                <div class="sub">
+                  <span>1M</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">03 · 模型选择面板（复用现有 ModalBottomSheet）</div>
+      <div class="note">按 Provider 分组；选中行淡蓝底 + 内嵌 3px 竖条 + 右侧实心淡蓝勾；上下文窗大小与能力 chip（视觉 / 工具 / 推理）同行简述，可一眼对比。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 4 — DRAWER (LIGHT)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="drawer">
+          <div class="drawer-head">
+            <div class="new-chat-btn">
+              <span class="ic-plus"><svg width="16" height="16"><use href="#i-plus"/></svg></span>
+              新对话
+            </div>
+          </div>
+          <div class="drawer-search">
+            <svg width="14" height="14"><use href="#i-search"/></svg>
+            <span>搜索会话</span>
+          </div>
+          <div class="drawer-list">
+            <div class="drawer-group-head"><svg><use href="#i-pin"/></svg>置顶</div>
+            <div class="conv-row active">
+              <div class="ic">DS</div>
+              <div class="text">
+                <div class="title-line">Amber Agent 主聊天 UI 重构</div>
+                <div class="preview">好的，我先整理整套设计稿…</div>
+              </div>
+            </div>
+            <div class="conv-row">
+              <div class="ic">CL</div>
+              <div class="text">
+                <div class="title-line">KMP 多平台架构梳理</div>
+                <div class="preview">commonMain 里这层 use case…</div>
+              </div>
+            </div>
+            <div class="drawer-group-head">今天</div>
+            <div class="conv-row">
+              <div class="ic">DS</div>
+              <div class="text">
+                <div class="title-line">翻译日语合同第 4–7 条</div>
+                <div class="preview">乙方依据本合同之约定…</div>
+              </div>
+            </div>
+            <div class="conv-row">
+              <div class="ic">GPT</div>
+              <div class="text">
+                <div class="title-line">Compose 性能优化 checklist</div>
+                <div class="preview">推荐顺序：1) defer 状态…</div>
+              </div>
+            </div>
+            <div class="drawer-group-head">昨天</div>
+            <div class="conv-row">
+              <div class="ic">GM</div>
+              <div class="text">
+                <div class="title-line">Gemini 3 体验记录</div>
+                <div class="preview">1M 上下文确实是质变…</div>
+              </div>
+            </div>
+            <div class="drawer-group-head">7 天内</div>
+            <div class="conv-row">
+              <div class="ic">CL</div>
+              <div class="text">
+                <div class="title-line">读 Designing Data-Intensive Applications 第 5 章</div>
+                <div class="preview">单 leader 复制的核心问题…</div>
+              </div>
+            </div>
+            <div class="conv-row">
+              <div class="ic">DS</div>
+              <div class="text">
+                <div class="title-line">Android Room 迁移调研</div>
+                <div class="preview">先把 @Insert 改成挂起函数…</div>
+              </div>
+            </div>
+          </div>
+          <div class="drawer-foot">
+            <div class="user-mini">
+              <div class="av">A</div>
+              <div class="label">Arquiel</div>
+            </div>
+            <div class="icon-btn muted"><svg width="18" height="18"><use href="#i-settings"/></svg></div>
+          </div>
+        </div>
+        <div class="drawer-scrim"></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">04 · 侧边抽屉（会话列表）</div>
+      <div class="note">顶部轻量"新对话"按钮 + 搜索；按 <code>置顶 / 今天 / 昨天 / 7 天内</code> 分组；每行模型小图标 + 标题 + 最后一句预览；底部用户头像与设置入口。当前会话用淡蓝底高亮。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 5 — ATTACHMENT TRAY (LIGHT)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content">
+          <div class="sky-glow"></div>
+          <div class="attach-tray">
+            <div class="attach-tile">
+              <div class="ic-wrap"><svg width="22" height="22"><use href="#i-camera"/></svg></div>
+              <span class="lbl">拍照</span>
+            </div>
+            <div class="attach-tile">
+              <div class="ic-wrap"><svg width="22" height="22"><use href="#i-image"/></svg></div>
+              <span class="lbl">图片</span>
+            </div>
+            <div class="attach-tile">
+              <div class="ic-wrap"><svg width="22" height="22"><use href="#i-video"/></svg></div>
+              <span class="lbl">视频</span>
+            </div>
+            <div class="attach-tile">
+              <div class="ic-wrap"><svg width="22" height="22"><use href="#i-music"/></svg></div>
+              <span class="lbl">音频</span>
+            </div>
+            <div class="attach-tile">
+              <div class="ic-wrap"><svg width="22" height="22"><use href="#i-file"/></svg></div>
+              <span class="lbl">文件</span>
+            </div>
+          </div>
+        </div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn expanded"><svg width="18" height="18"><use href="#i-close"/></svg></div>
+            <div class="divider"></div>
+            <div class="field">输入消息</div>
+            <div class="slash-chip">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">05 · 附件菜单（轻量浮层）</div>
+      <div class="note">点击左侧加号后，输入框上方浮出一排淡蓝容器的图标按钮；不是全屏 sheet，不打断输入焦点；加号变为关闭叉，状态变化清晰。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 6 — SLASH COMMAND PALETTE (LIGHT)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content">
+          <div class="sky-glow"></div>
+          <div class="slash-card">
+            <div class="slash-row focus">
+              <div class="ic"><svg width="18" height="18"><use href="#i-book"/></svg></div>
+              <div class="meta">
+                <div class="cmd">/deepread</div>
+                <div class="desc">把链接送入深度阅读，生成杂志风长文</div>
+              </div>
+              <span class="hint">↵</span>
+            </div>
+            <div class="slash-row">
+              <div class="ic"><svg width="18" height="18"><use href="#i-translate"/></svg></div>
+              <div class="meta">
+                <div class="cmd">/translate</div>
+                <div class="desc">把选中或下一条消息翻译成中文</div>
+              </div>
+            </div>
+            <div class="slash-row">
+              <div class="ic"><svg width="18" height="18"><use href="#i-summary"/></svg></div>
+              <div class="meta">
+                <div class="cmd">/summarize</div>
+                <div class="desc">把当前对话总结成 5 条要点</div>
+              </div>
+            </div>
+            <div class="slash-row">
+              <div class="ic"><svg width="18" height="18"><use href="#i-globe"/></svg></div>
+              <div class="meta">
+                <div class="cmd">/search</div>
+                <div class="desc">联网搜索后再让模型回答</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn"><svg width="20" height="20"><use href="#i-plus"/></svg></div>
+            <div class="divider"></div>
+            <div class="field typed">/<span class="caret"></span></div>
+            <div class="slash-chip active">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">06 · 斜杠命令面板</div>
+      <div class="note">键入 <code>/</code> 或点击 [/] chip 触发；浮卡列出已挂载命令，每行 icon + 命令名 + 一行说明；首项 focus 态高亮，<code>↵</code> 提示直接执行。</div>
+    </div>
+  </div>
+
+  <!-- Section separator -->
+  <div class="section-mark"><span class="label">Dark Mode</span></div>
+
+  <!-- =========================================================
+       FRAME 7 — EMPTY CHAT (DARK)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone dark">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content">
+          <div class="sky-glow"></div>
+          <div class="greeting">
+            <div class="sparkle"></div>
+            <div class="greet-text">想问什么？</div>
+          </div>
+        </div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn"><svg width="20" height="20"><use href="#i-plus"/></svg></div>
+            <div class="divider"></div>
+            <div class="field">输入消息</div>
+            <div class="slash-chip">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">07 · 空白态 · 深色</div>
+      <div class="note">深底用 <code>#0B0B0D</code> canvas + <code>#141417</code> paper；淡蓝在深底转为 <code>#82B7FF</code>，对比度足够；底部蓝晕仍能浮起胶囊。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 8 — MODEL PICKER SHEET (DARK)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone dark">
+      <div class="screen">
+        <div class="status-bar">
+          <span>00:35</span>
+          <span class="right">
+            <svg width="15" height="13"><use href="#i-signal"/></svg>
+            <span>5G</span>
+            <svg width="15" height="13"><use href="#i-wifi"/></svg>
+            <span class="battery">100</span>
+          </span>
+        </div>
+        <div class="top-bar">
+          <div class="left">
+            <div class="icon-btn"><svg width="20" height="20"><use href="#i-menu"/></svg></div>
+            <div class="model-pill">
+              DeepSeek V4 Pro
+              <span class="chev"><svg width="14" height="14"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="icon-btn"><svg width="22" height="22"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="content"><div class="sky-glow"></div></div>
+        <div class="input-region">
+          <div class="composer">
+            <div class="add-btn"><svg width="20" height="20"><use href="#i-plus"/></svg></div>
+            <div class="divider"></div>
+            <div class="field">输入消息</div>
+            <div class="slash-chip">/</div>
+            <div class="send muted"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div>
+          </div>
+        </div>
+
+        <div class="scrim"></div>
+        <div class="sheet">
+          <div class="sheet-handle"></div>
+          <div class="sheet-head">
+            <span class="title">选择模型</span>
+            <div class="icon-btn muted"><svg width="18" height="18"><use href="#i-close"/></svg></div>
+          </div>
+          <div class="search-input">
+            <svg width="16" height="16"><use href="#i-search"/></svg>
+            <span>搜索模型</span>
+          </div>
+          <div class="model-list">
+            <div class="provider-head">DeepSeek</div>
+            <div class="model-row selected">
+              <div class="ic">DS</div>
+              <div class="meta">
+                <div class="name">DeepSeek V4 Pro</div>
+                <div class="sub">
+                  <span>128K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+              <div class="check"><svg width="13" height="13"><use href="#i-check"/></svg></div>
+            </div>
+            <div class="model-row">
+              <div class="ic">DS</div>
+              <div class="meta">
+                <div class="name">DeepSeek V3.5</div>
+                <div class="sub">
+                  <span>64K</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                </div>
+              </div>
+            </div>
+            <div class="provider-head">Anthropic</div>
+            <div class="model-row">
+              <div class="ic">CL</div>
+              <div class="meta">
+                <div class="name">Claude Opus 4.7</div>
+                <div class="sub">
+                  <span>1M</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+            <div class="model-row">
+              <div class="ic">CL</div>
+              <div class="meta">
+                <div class="name">Claude Sonnet 4.6</div>
+                <div class="sub">
+                  <span>200K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                </div>
+              </div>
+            </div>
+            <div class="provider-head">Google</div>
+            <div class="model-row">
+              <div class="ic">GM</div>
+              <div class="meta">
+                <div class="name">Gemini 3 Pro</div>
+                <div class="sub">
+                  <span>1M</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">08 · 模型选择面板 · 深色</div>
+      <div class="note">选中行 <code>#10263A</code> 深蓝容器 + 淡蓝竖条与勾，识别度足够而不刺眼；scrim 32% 黑 + 微模糊维持层级。</div>
+    </div>
+  </div>
+
+</div>
+
+<!-- ============================================================
+     TWEAKS (实时调主蓝色调)
+     ============================================================ -->
+<div class="tweaks">
+  <span class="tweaks-label">Tweaks</span>
+  <div class="tweaks-row">
+    <span style="font-size:11.5px;color:#6B6761;">主蓝</span>
+    <input type="color" id="tw-color" value="#6BA8FF">
+    <span class="hex" id="tw-hex">#6BA8FF</span>
+  </div>
+  <div class="tweaks-row">
+    <label for="tw-greeting" style="display:flex; align-items:center; gap:6px; cursor:pointer; font-size:11.5px; color:#6B6761;">
+      <input type="checkbox" id="tw-greeting" style="width:14px; height:14px; accent-color:#6BA8FF; cursor:pointer;">
+      显示问候
+    </label>
+  </div>
+  <button id="tw-reset">重置</button>
+</div>
+
+<script>
+  // Live recolor — updates --blue, all derived tokens (container, glow, deep)
+  // recompute automatically via color-mix.
+  const colorInput = document.getElementById('tw-color');
+  const hexLabel   = document.getElementById('tw-hex');
+  const resetBtn   = document.getElementById('tw-reset');
+
+  // Derive a slightly darker hex for --blue-deep (for hover/active and avatar gradient)
+  function darken(hex, amount) {
+    const h = hex.replace('#', '');
+    const r = Math.max(0, parseInt(h.slice(0, 2), 16) - amount);
+    const g = Math.max(0, parseInt(h.slice(2, 4), 16) - amount);
+    const b = Math.max(0, parseInt(h.slice(4, 6), 16) - amount);
+    return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+  }
+
+  function apply(hex) {
+    document.documentElement.style.setProperty('--blue', hex);
+    document.documentElement.style.setProperty('--blue-deep', darken(hex, 36));
+    // dark phones override --blue/--blue-deep inside .phone.dark; mirror the bump there.
+    document.querySelectorAll('.phone.dark').forEach(p => {
+      p.style.setProperty('--blue', hex);
+      p.style.setProperty('--blue-deep', darken(hex, 24));
+    });
+    hexLabel.textContent = hex.toUpperCase();
+  }
+
+  colorInput.addEventListener('input', e => apply(e.target.value));
+
+  // Greeting toggle
+  const greetingInput = document.getElementById('tw-greeting');
+  greetingInput.addEventListener('change', e => {
+    document.body.classList.toggle('show-greeting', e.target.checked);
+  });
+
+  resetBtn.addEventListener('click', () => {
+    colorInput.value = '#6BA8FF';
+    apply('#6BA8FF');
+    greetingInput.checked = false;
+    document.body.classList.remove('show-greeting');
+    // also clear per-phone overrides
+    document.querySelectorAll('.phone.dark').forEach(p => {
+      p.style.removeProperty('--blue');
+      p.style.removeProperty('--blue-deep');
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/docs/CHAT_UI_REFRESH_2026-05-23_v2.html
+++ b/docs/CHAT_UI_REFRESH_2026-05-23_v2.html
@@ -1,0 +1,2241 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Amber Agent · 主聊天页 UI v2（雾蓝 / 简约 / 琥珀 / 深色）· 2026-05-23</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;600;700&family=Noto+Serif+SC:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* ============================================================
+   TOKEN PALETTE — 4 THEMES
+   (per Anthropic Design 设计包 v2: refined-accent-as-spice)
+   ============================================================ */
+
+/* ── 雾蓝 Misty ── (浅色默认；天蓝 #3D8FD4 而非靛蓝) */
+.theme-misty {
+  --bg:           #FAFBFC;
+  --halo:
+    radial-gradient(120% 55% at 50% 108%, rgba(120,170,240,0.55) 0%, rgba(120,170,240,0.28) 28%, rgba(120,170,240,0.10) 55%, rgba(120,170,240,0) 75%),
+    radial-gradient(80% 35% at 50% 0%, rgba(200,215,240,0.22) 0%, rgba(200,215,240,0) 70%);
+  --ink:          #0F1419;
+  --ink-soft:     #5B6573;
+  --ink-faint:    #A8AFBA;
+  --hair:         rgba(15,20,25,0.08);
+  --surface:      #FFFFFF;
+  --surface-edge: rgba(15,20,25,0.05);
+  --surface-shadow: 0 1px 2px rgba(15,20,25,0.04), 0 10px 32px rgba(15,20,25,0.08);
+  --sheet-bg:     #FFFFFF;
+
+  --title-font: -apple-system, BlinkMacSystemFont, "PingFang SC", "Noto Sans SC", "Microsoft Yahei", system-ui, sans-serif;
+  --body-font:  -apple-system, BlinkMacSystemFont, "PingFang SC", "Noto Sans SC", "Microsoft Yahei", system-ui, sans-serif;
+  --hero-font:  -apple-system, BlinkMacSystemFont, "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --title-weight: 500;
+  --title-letter: 0.2px;
+  --hero-weight: 500;
+  --hero-letter: 0.2px;
+
+  --accent:       #3D8FD4;
+  --accent-soft:  #E6F2FB;
+  --accent-deep:  #1F76C8;
+  --accent-tint:  #CFE3FF;
+
+  --send-bg:    #4EA8E8;
+  --send-arrow: #FFFFFF;
+  --send-halo:  rgba(78,168,232,0.55);
+  --send-shadow: 0 4px 14px rgba(78,168,232,0.40);
+
+  --battery-bg:  #0F1419;
+  --battery-ink: #FAFBFC;
+  --home-bar:    rgba(15,20,25,0.32);
+
+  --user-bubble:      #F2F4F7;
+  --user-bubble-edge: rgba(15,20,25,0.06);
+
+  --tool-pill-bg:    #F4F4F4;
+  --tool-pill-edge:  rgba(15,20,25,0.08);
+  --tool-label-ink:  #5B6573;
+  --tool-icon-ink:   #5B6573;
+  --tool-done-ink:   #1F76C8;  /* only "完成" is themed blue */
+
+  --think-rule:  rgba(61,143,212,0.40);
+  --think-ink:   #5B6573;
+}
+
+/* ── 简约 Plain ── (黑白，对比降一档) */
+.theme-plain {
+  --bg:           #FFFFFF;
+  --halo:
+    radial-gradient(110% 50% at 50% 108%, rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.02) 35%, rgba(0,0,0,0) 70%);
+  --ink:          #1A1A1A;
+  --ink-soft:     #5A5A5A;
+  --ink-faint:    #B0B0B0;
+  --hair:         rgba(0,0,0,0.08);
+  --surface:      #FFFFFF;
+  --surface-edge: rgba(0,0,0,0.08);
+  --surface-shadow: 0 1px 2px rgba(0,0,0,0.03), 0 8px 24px rgba(0,0,0,0.06);
+  --sheet-bg:     #FFFFFF;
+
+  --title-font: "Noto Serif SC", "Source Han Serif SC", "Songti SC", "STSong", serif;
+  --body-font:  -apple-system, "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --hero-font:  "Noto Serif SC", "Source Han Serif SC", "Songti SC", serif;
+  --title-weight: 500;
+  --title-letter: 0.4px;
+  --hero-weight: 500;
+  --hero-letter: 0.6px;
+
+  --accent:       #2D2D2D;
+  --accent-soft:  #F4F4F4;
+  --accent-deep:  #1A1A1A;
+  --accent-tint:  #E0E0E0;
+
+  --send-bg:    #1A1A1A;
+  --send-arrow: #FFFFFF;
+  --send-halo:  rgba(40,40,40,0.35);
+  --send-shadow: 0 4px 14px rgba(0,0,0,0.18);
+
+  --battery-bg:  #1A1A1A;
+  --battery-ink: #FFFFFF;
+  --home-bar:    rgba(0,0,0,0.28);
+
+  --user-bubble:      #F4F4F4;
+  --user-bubble-edge: rgba(0,0,0,0.06);
+
+  --tool-pill-bg:    #F4F4F4;
+  --tool-pill-edge:  rgba(0,0,0,0.06);
+  --tool-label-ink:  #5A5A5A;
+  --tool-icon-ink:   #5A5A5A;
+  --tool-done-ink:   #1A1A1A;  /* mono — no chromatic accent */
+
+  --think-rule:  rgba(0,0,0,0.18);
+  --think-ink:   #5A5A5A;
+}
+
+/* ── 琥珀 Amber ── (米黄 + 砖红，宋体；保留底部淡光晕) */
+.theme-amber {
+  --bg:           #F3ECDD;
+  --halo:
+    radial-gradient(120% 55% at 50% 108%, rgba(230,165,100,0.55) 0%, rgba(225,160,95,0.25) 32%, rgba(225,160,95,0.08) 60%, rgba(225,160,95,0) 80%),
+    radial-gradient(90% 40% at 50% 0%, rgba(245,229,200,0.40) 0%, rgba(245,229,200,0) 70%);
+  --ink:          #2A241B;
+  --ink-soft:     #7A6E5C;
+  --ink-faint:    #B8AC95;
+  --hair:         rgba(42,36,27,0.10);
+  --surface:      #FBF7EE;
+  --surface-edge: rgba(42,36,27,0.08);
+  --surface-shadow: 0 1px 2px rgba(42,36,27,0.04), 0 10px 28px rgba(42,36,27,0.10);
+  --sheet-bg:     #FBF7EE;
+
+  --title-font: "Noto Serif SC", "Source Han Serif SC", "Songti SC", "STSong", serif;
+  --body-font:  -apple-system, "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --hero-font:  "Noto Serif SC", "Source Han Serif SC", "Songti SC", serif;
+  --title-weight: 600;
+  --title-letter: 0.3px;
+  --hero-weight: 600;
+  --hero-letter: 0.5px;
+
+  --accent:       #B5683A;
+  --accent-soft:  #EADFC8;
+  --accent-deep:  #8A4520;
+  --accent-tint:  #F4D6B0;
+
+  --send-bg:    #3B2418;
+  --send-arrow: #FBF7EE;
+  --send-halo:  rgba(181,104,58,0.45);
+  --send-shadow: 0 4px 14px rgba(59,36,24,0.25);
+
+  --battery-bg:  #2A241B;
+  --battery-ink: #F3ECDD;
+  --home-bar:    rgba(42,36,27,0.30);
+
+  --user-bubble:      #EDE4D2;  /* cooler than #EADFC8 per chat iter */
+  --user-bubble-edge: rgba(42,36,27,0.10);
+
+  --tool-pill-bg:    #EDE4D2;
+  --tool-pill-edge:  rgba(42,36,27,0.10);
+  --tool-label-ink:  #7A6E5C;
+  --tool-icon-ink:   #7A6E5C;
+  --tool-done-ink:   #B5683A;  /* brick red — paper-native accent */
+
+  --think-rule:  rgba(181,104,58,0.30);
+  --think-ink:   #7A6E5C;
+}
+
+/* ── 深色 Dark ── (深墨蓝；蓝光晕降到原 1/3；气泡几乎透明白雾) */
+.theme-dark {
+  --bg:           #0B0E14;
+  --halo:
+    radial-gradient(120% 55% at 50% 108%, rgba(110,140,220,0.18) 0%, rgba(110,140,220,0.08) 30%, rgba(110,140,220,0.03) 60%, rgba(110,140,220,0) 80%),
+    radial-gradient(90% 40% at 50% 0%, rgba(60,80,130,0.10) 0%, rgba(60,80,130,0) 70%);
+  --ink:          #E8EAEF;
+  --ink-soft:     #8A93A3;
+  --ink-faint:    #4A5160;
+  --hair:         rgba(232,234,239,0.10);
+  --surface:      rgba(255,255,255,0.06);
+  --surface-edge: rgba(232,234,239,0.10);
+  --surface-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 10px 30px rgba(0,0,0,0.40);
+  --sheet-bg:     #15171D;
+
+  --title-font: -apple-system, "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --body-font:  -apple-system, "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --hero-font:  -apple-system, "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --title-weight: 500;
+  --title-letter: 0.2px;
+  --hero-weight: 500;
+  --hero-letter: 0.2px;
+
+  --accent:       #8FA9E0;
+  --accent-soft:  rgba(143,169,224,0.14);
+  --accent-deep:  #B7D5FF;
+  --accent-tint:  #B7D5FF;
+
+  --send-bg:    rgba(143,169,224,0.55);
+  --send-arrow: #FFFFFF;
+  --send-halo:  rgba(143,169,224,0.40);
+  --send-shadow: 0 4px 14px rgba(143,169,224,0.25);
+
+  --battery-bg:  #E8EAEF;
+  --battery-ink: #0B0E14;
+  --home-bar:    rgba(232,234,239,0.30);
+
+  --user-bubble:      rgba(255,255,255,0.05);
+  --user-bubble-edge: rgba(255,255,255,0.08);
+
+  --tool-pill-bg:    rgba(255,255,255,0.05);
+  --tool-pill-edge:  rgba(255,255,255,0.08);
+  --tool-label-ink:  #8A93A3;
+  --tool-icon-ink:   #8A93A3;
+  --tool-done-ink:   #8FA9E0;
+
+  --think-rule:  rgba(143,169,224,0.30);
+  --think-ink:   #8A93A3;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { font-family: "Noto Sans SC", -apple-system, BlinkMacSystemFont, "PingFang SC", system-ui, sans-serif; }
+
+body {
+  background: #ECECEE;
+  color: #1F1F1F;
+  padding: 64px 24px 160px;
+  -webkit-font-smoothing: antialiased;
+  text-wrap: pretty;
+}
+
+/* ============================================================
+   DOC HEADER
+   ============================================================ */
+.doc-header {
+  max-width: 1280px;
+  margin: 0 auto 56px;
+  padding: 0 8px;
+}
+.doc-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #6B6761;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.doc-title {
+  font-size: 34px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin-bottom: 14px;
+  color: #1A1A1C;
+}
+.doc-lede {
+  font-size: 15.5px;
+  color: #5C5853;
+  max-width: 760px;
+  line-height: 1.65;
+}
+.doc-lede strong { color: #1F1F1F; font-weight: 600; }
+.doc-lede code {
+  background: rgba(0,0,0,0.05);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+}
+
+.theme-strip {
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
+  max-width: 1280px;
+}
+.theme-card {
+  background: white;
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.theme-card h4 {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6B6761;
+  margin-bottom: 10px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.theme-card h4 .badge {
+  font-weight: 700;
+  font-size: 9.5px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  background: rgba(0,0,0,0.06);
+  color: #3D3A36;
+}
+.theme-card .meta {
+  font-size: 12px;
+  color: #6B6761;
+  line-height: 1.55;
+  margin-bottom: 10px;
+}
+.theme-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  margin-bottom: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #3D3A36;
+}
+.theme-row:last-child { margin-bottom: 0; }
+.theme-row .lbl { color: #6B6761; min-width: 60px; }
+.swatch {
+  width: 14px; height: 14px;
+  border-radius: 4px;
+  border: 1px solid rgba(0,0,0,0.08);
+  flex-shrink: 0;
+}
+
+/* ============================================================
+   SECTION HEADERS
+   ============================================================ */
+.section-mark {
+  grid-column: 1 / -1;
+  text-align: center;
+  margin: 16px 0 -16px;
+  position: relative;
+}
+.section-mark .label {
+  display: inline-block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #6B6761;
+  font-weight: 700;
+  background: #ECECEE;
+  padding: 0 14px;
+  position: relative;
+  z-index: 1;
+}
+.section-mark::before {
+  content: "";
+  display: block;
+  height: 1px;
+  background: rgba(0,0,0,0.08);
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 8px);
+  width: 100%;
+  max-width: 720px;
+}
+.section-mark .sub {
+  display: block;
+  font-size: 12.5px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: #6B6761;
+  margin-top: 14px;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.55;
+}
+
+/* ============================================================
+   GRID
+   ============================================================ */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+  gap: 64px 36px;
+  justify-items: center;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.frame {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  max-width: 420px;
+}
+
+.caption { text-align: center; max-width: 380px; }
+.caption .title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1F1F1F;
+  margin-bottom: 5px;
+  letter-spacing: -0.005em;
+}
+.caption .note {
+  font-size: 12.5px;
+  color: #6B6761;
+  line-height: 1.6;
+}
+.caption .note code {
+  background: rgba(0,0,0,0.05);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11.5px;
+}
+
+/* ============================================================
+   PHONE BEZEL
+   ============================================================ */
+.phone {
+  width: 390px;
+  height: 844px;
+  background: var(--bg);
+  border-radius: 52px;
+  box-shadow:
+    0 0 0 1.5px #2A2A2E,
+    0 0 0 11px #16161B,
+    0 0 0 12px #2E2E33,
+    0 38px 80px -28px rgba(20, 20, 40, 0.22),
+    0 12px 28px -10px rgba(20, 20, 40, 0.14);
+  overflow: hidden;
+  position: relative;
+  color: var(--ink);
+  font-family: var(--body-font);
+  isolation: isolate;
+}
+
+.screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+/* Halo bloom (empty state only; convo screens drop this) */
+.halo {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: var(--halo);
+  z-index: 0;
+}
+.screen > *:not(.halo) { position: relative; z-index: 1; }
+
+/* ============================================================
+   STATUS BAR
+   ============================================================ */
+.status-bar {
+  height: 40px;
+  padding: 14px 22px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  flex-shrink: 0;
+}
+.status-bar .left {
+  display: flex; align-items: center; gap: 8px;
+}
+.status-bar .app-dots {
+  display: flex; align-items: center; gap: 4px; margin-left: 4px;
+}
+.app-dot {
+  width: 14px; height: 14px;
+  border-radius: 4px;
+}
+.status-bar .right {
+  display: flex; align-items: center; gap: 6px;
+}
+.kbs {
+  display: flex; flex-direction: column;
+  align-items: flex-end; line-height: 1; gap: 1px;
+}
+.kbs .num { font-size: 10px; font-weight: 600; }
+.kbs .unit { font-size: 9px; opacity: 0.7; letter-spacing: 0.3px; }
+.signal {
+  display: flex; align-items: flex-end; gap: 1px;
+}
+.signal .label {
+  font-size: 8px; font-weight: 700;
+  margin-bottom: 3px; margin-right: 1px; line-height: 1;
+}
+.signal .bar {
+  width: 2px; background: var(--ink); border-radius: 0.5px;
+}
+.battery {
+  padding: 2px 4px;
+  border-radius: 4px;
+  background: var(--battery-bg);
+  color: var(--battery-ink);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  line-height: 1;
+}
+
+/* ============================================================
+   HEADER — EMPTY STATE
+   ============================================================ */
+.header {
+  padding: 18px 22px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+.header .left {
+  display: flex; align-items: center; gap: 16px;
+}
+.hamburger {
+  display: flex; flex-direction: column; gap: 5px;
+  align-items: flex-start;
+  cursor: pointer;
+}
+.hamburger .line { height: 1.6px; background: var(--ink); border-radius: 1px; }
+.hamburger .line.l1 { width: 22px; }
+.hamburger .line.l2 { width: 14px; }
+.hamburger .line.l3 { width: 19px; }
+
+.title-pill {
+  display: flex; align-items: baseline; gap: 6px;
+  cursor: pointer;
+}
+.title-pill .name {
+  font-family: var(--title-font);
+  font-size: 19px;
+  font-weight: var(--title-weight);
+  letter-spacing: var(--title-letter);
+  color: var(--ink);
+  line-height: 1.1;
+}
+.title-pill .chev {
+  color: var(--ink-soft);
+  transform: translateY(-1px);
+}
+.compose-btn {
+  width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: var(--ink);
+}
+
+/* ============================================================
+   CONVO HEADER (different from empty — no model selector chevron)
+   ============================================================ */
+.convo-header {
+  padding: 18px 20px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.convo-header .left {
+  display: flex; align-items: center; gap: 14px;
+  min-width: 0; flex: 1;
+}
+.convo-header .agent-name {
+  color: var(--ink);
+  font-family: var(--body-font);
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+}
+
+/* ============================================================
+   HERO (centered greeting, empty state)
+   ============================================================ */
+.hero {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 36px 60px;
+}
+.greet {
+  text-align: center;
+  font-family: var(--hero-font);
+  font-size: 26px;
+  font-weight: var(--hero-weight);
+  letter-spacing: var(--hero-letter);
+  line-height: 1.35;
+  color: var(--ink);
+}
+body.no-greeting .hero .greet { display: none; }
+
+/* ============================================================
+   INPUT BAR (shared — empty + convo identical)
+   ============================================================ */
+.input-region {
+  padding: 0 14px 10px;
+  flex-shrink: 0;
+}
+.composer {
+  height: 68px;
+  background: var(--surface);
+  border: 1px solid var(--surface-edge);
+  box-shadow: var(--surface-shadow);
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  padding: 0 10px 0 20px;
+  gap: 8px;
+}
+.composer .plus {
+  color: var(--ink);
+  display: inline-flex;
+  cursor: pointer;
+}
+.composer .divider {
+  width: 1px; height: 20px;
+  background: var(--hair);
+  margin-left: 8px; margin-right: 6px;
+}
+.composer .field {
+  flex: 1;
+  color: var(--ink-faint);
+  font-size: 15px;
+  font-family: var(--body-font);
+  letter-spacing: 0.2px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.composer .field.typed { color: var(--ink); }
+.composer .field.typed .caret {
+  display: inline-block;
+  width: 1.5px; height: 16px;
+  background: var(--send-bg);
+  vertical-align: -3px;
+  margin-left: 1px;
+  animation: caret-blink 1.05s steps(1) infinite;
+}
+@keyframes caret-blink { 50% { opacity: 0; } }
+
+.composer .slash {
+  width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+.composer .slash.active { color: var(--accent); }
+.composer .plus.expanded { color: var(--accent); }
+
+/* Send — 48px circle + double-layer breathing halo */
+.send-wrap {
+  position: relative;
+  width: 48px; height: 48px;
+  margin-left: 4px;
+  display: flex; align-items: center; justify-content: center;
+}
+.send-halo-outer {
+  position: absolute; inset: -14px;
+  border-radius: 50%;
+  background: radial-gradient(50% 50% at 50% 50%, var(--send-halo) 0%, transparent 70%);
+  animation: send-breathe-soft 3.6s ease-in-out infinite;
+  pointer-events: none;
+}
+.send-halo-inner {
+  position: absolute; inset: -4px;
+  border-radius: 50%;
+  background: radial-gradient(50% 50% at 50% 50%, var(--send-halo) 0%, transparent 65%);
+  animation: send-breathe 2.8s ease-in-out infinite;
+  pointer-events: none;
+}
+.send-orb {
+  position: relative;
+  width: 48px; height: 48px;
+  border-radius: 50%;
+  background: var(--send-bg);
+  color: var(--send-arrow);
+  box-shadow: var(--send-shadow);
+  display: flex; align-items: center; justify-content: center;
+}
+@keyframes send-breathe-soft {
+  0%, 100% { transform: scale(0.95); opacity: 0.30; }
+  50%      { transform: scale(1.35); opacity: 0.70; }
+}
+@keyframes send-breathe {
+  0%, 100% { transform: scale(1);    opacity: 0.55; }
+  50%      { transform: scale(1.18); opacity: 0.95; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .send-halo-outer, .send-halo-inner { animation: none; opacity: 0.5; }
+}
+
+/* ============================================================
+   HOME INDICATOR
+   ============================================================ */
+.home-bar {
+  height: 22px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.home-bar .pill {
+  width: 120px; height: 4px;
+  border-radius: 2px;
+  background: var(--home-bar);
+}
+
+/* ============================================================
+   CONVO BODY pieces (per design bundle convo-*.jsx)
+   ============================================================ */
+.convo-body {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+.convo-body .scroll {
+  position: absolute; inset: 0;
+  overflow: hidden;
+  padding-top: 6px;
+}
+.convo-body .fade {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  height: 56px;
+  background: linear-gradient(180deg, transparent 0%, var(--bg) 75%);
+  pointer-events: none;
+}
+
+/* USER TURN: identity row + capsule bubble (right-aligned) */
+.user-turn { padding: 4px 20px 14px; }
+.user-identity {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-size: 13px;
+  color: var(--ink-soft);
+  letter-spacing: 0.2px;
+}
+.user-avatar {
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: var(--user-bubble);
+  border: 1px solid var(--user-bubble-edge);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--accent);
+}
+.user-bubble-wrap {
+  display: flex; justify-content: flex-end;
+  padding-left: 60px;
+}
+.user-bubble {
+  background: var(--user-bubble);
+  border: 1px solid var(--user-bubble-edge);
+  border-radius: 999px;     /* true capsule per design bundle */
+  padding: 10px 18px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink);
+  letter-spacing: 0.2px;
+  max-width: 100%;
+}
+
+/* AGENT HEADER: small dot with halo + model name */
+.agent-header {
+  display: flex; align-items: center; gap: 10px;
+  padding: 4px 20px 12px;
+}
+.agent-mark {
+  position: relative;
+  width: 22px; height: 22px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.agent-mark .halo {
+  position: absolute; inset: -6px;
+  border-radius: 50%;
+  background: radial-gradient(50% 50% at 50% 50%, var(--accent-soft) 0%, transparent 70%);
+}
+.agent-mark .dot {
+  position: relative;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, var(--accent-tint) 0%, var(--accent) 70%, var(--accent-deep) 100%);
+}
+.agent-model {
+  font-family: var(--body-font);
+  font-size: 13.5px;
+  color: var(--ink-soft);
+  letter-spacing: 0.3px;
+}
+
+/* THINKING STRIP: vertical accent rule + dim text + chevron */
+.thinking {
+  margin: 0 20px 14px;
+  padding-left: 14px;
+  position: relative;
+}
+.thinking-rule {
+  position: absolute;
+  top: 4px; bottom: 4px; left: 0;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--think-rule);
+}
+.thinking-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--think-ink);
+  font-size: 13px;
+  letter-spacing: 0.2px;
+  line-height: 1.4;
+}
+.thinking-label { display: flex; align-items: center; gap: 8px; }
+.thinking-label .sep { opacity: 0.5; }
+.thinking-label .mode { opacity: 0.7; }
+.thinking-chev { color: var(--ink-soft); transition: transform .2s; }
+.thinking.expanded .thinking-chev { transform: rotate(180deg); }
+.thinking-body {
+  margin-top: 10px;
+  color: var(--think-ink);
+  font-size: 13.5px;
+  line-height: 1.7;
+  letter-spacing: 0.2px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.thinking:not(.expanded) .thinking-body { display: none; }
+
+/* TOOL CALL: slim single-line pill */
+.tool-call { margin: 4px 20px 14px; }
+.tool-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px 7px 10px;
+  border-radius: 999px;
+  background: var(--tool-pill-bg);
+  border: 1px solid var(--tool-pill-edge);
+  max-width: 100%;
+}
+.tool-pill .icon {
+  color: var(--tool-icon-ink);
+  flex-shrink: 0;
+}
+.tool-pill .label {
+  font-size: 13px;
+  color: var(--tool-label-ink);
+  letter-spacing: 0.3px;
+  font-weight: 500;
+}
+.tool-pill .name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  font-weight: 400;
+  opacity: 0.85;
+}
+.tool-pill .done {
+  font-size: 12px;
+  color: var(--tool-done-ink);
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  margin-left: 4px;
+}
+
+/* Para text */
+.para {
+  padding: 0 20px 14px;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--ink);
+  letter-spacing: 0.2px;
+}
+.para.dim { color: var(--ink-soft); }
+.para .cursor {
+  display: inline-block;
+  width: 6px; height: 14px;
+  background: var(--accent);
+  vertical-align: text-bottom;
+  margin-left: 2px;
+  border-radius: 1px;
+  animation: caret-blink 1.05s steps(1) infinite;
+}
+
+/* ============================================================
+   MODEL PICKER SHEET
+   ============================================================ */
+.scrim {
+  position: absolute; inset: 0;
+  background: rgba(0,0,0,0.36);
+  backdrop-filter: blur(2px);
+  z-index: 2;
+}
+.theme-dark .scrim { background: rgba(0,0,0,0.50); }
+.sheet {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 78%;
+  background: var(--sheet-bg);
+  border-radius: 24px 24px 0 0;
+  display: flex;
+  flex-direction: column;
+  z-index: 3;
+  box-shadow: 0 -8px 32px rgba(0,0,0,0.10);
+}
+.sheet-handle {
+  width: 36px; height: 4px;
+  background: var(--hair);
+  border-radius: 2px;
+  margin: 8px auto 4px;
+}
+.sheet-head {
+  padding: 6px 14px 6px 20px;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.sheet-head .title {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  font-family: var(--title-font);
+}
+.sheet-close {
+  width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+.sheet-search {
+  margin: 4px 14px 8px;
+  height: 40px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ink) 4%, transparent);
+  border: 1px solid var(--hair);
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 12px;
+  font-size: 14px;
+  color: var(--ink-faint);
+}
+.sheet-search svg { color: var(--ink-soft); }
+.model-list { flex: 1; overflow: hidden; padding: 4px 12px 16px; }
+.provider-head {
+  padding: 12px 8px 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-soft);
+}
+.model-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px 10px 16px;
+  border-radius: 12px;
+  position: relative;
+}
+.model-row.selected { background: var(--accent-soft); }
+.model-row.selected::before {
+  content: "";
+  position: absolute;
+  left: 6px;
+  top: 16px; bottom: 16px;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+}
+.model-row .ic {
+  width: 30px; height: 30px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+  border: 1px solid var(--hair);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.02em;
+}
+.model-row.selected .ic {
+  background: var(--surface);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.theme-dark .model-row.selected .ic { background: var(--sheet-bg); }
+.model-row .meta { flex: 1; min-width: 0; }
+.model-row .name {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 3px;
+  letter-spacing: -0.008em;
+  font-family: var(--title-font);
+}
+.model-row .sub {
+  font-size: 11.5px;
+  color: var(--ink-soft);
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+}
+.cap-chip {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+  border: 1px solid var(--hair);
+  font-size: 10.5px;
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+.model-row.selected .cap-chip {
+  background: var(--surface);
+  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.theme-dark .model-row.selected .cap-chip { background: var(--sheet-bg); }
+.cap-chip svg { width: 11px; height: 11px; }
+.model-row .check {
+  width: 22px; height: 22px;
+  border-radius: 11px;
+  background: var(--accent);
+  color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.model-row:not(.selected) .check { display: none; }
+
+/* ============================================================
+   DRAWER
+   ============================================================ */
+.drawer {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 304px;
+  background: var(--sheet-bg);
+  display: flex; flex-direction: column;
+  box-shadow: 8px 0 24px rgba(0,0,0,0.06);
+  z-index: 2;
+  padding-top: 40px;
+}
+.drawer-head { padding: 12px 12px 6px; }
+.new-chat-btn {
+  height: 40px;
+  border-radius: 14px;
+  border: 1px solid var(--hair);
+  background: var(--surface);
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 14px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink);
+}
+.theme-dark .new-chat-btn { background: transparent; }
+.new-chat-btn .ic-plus { color: var(--accent); display: inline-flex; }
+.drawer-search {
+  margin: 8px 12px 4px;
+  height: 36px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--ink) 4%, transparent);
+  border: 1px solid var(--hair);
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 10px;
+  font-size: 13px;
+  color: var(--ink-faint);
+}
+.drawer-search svg { color: var(--ink-soft); }
+.drawer-list { flex: 1; overflow: hidden; padding: 4px 8px 12px; }
+.drawer-group-head {
+  padding: 14px 10px 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-soft);
+  display: flex; align-items: center; gap: 6px;
+}
+.drawer-group-head svg { width: 11px; height: 11px; }
+.conv-row {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+}
+.conv-row.active { background: var(--accent-soft); }
+.conv-row .ic {
+  width: 24px; height: 24px;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+  border: 1px solid var(--hair);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 9.5px;
+  font-weight: 700;
+  color: var(--ink-soft);
+  margin-top: 2px;
+  letter-spacing: -0.02em;
+}
+.conv-row.active .ic {
+  background: var(--surface);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.theme-dark .conv-row.active .ic { background: var(--sheet-bg); }
+.conv-row .text { flex: 1; min-width: 0; }
+.conv-row .title-line {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2px;
+  letter-spacing: -0.005em;
+  font-family: var(--title-font);
+}
+.conv-row .preview {
+  font-size: 11.5px;
+  color: var(--ink-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.drawer-foot {
+  padding: 10px 14px 14px;
+  display: flex; align-items: center; gap: 10px;
+  border-top: 1px solid var(--hair);
+}
+.user-mini { display: flex; align-items: center; gap: 10px; flex: 1; }
+.user-mini .av {
+  width: 30px; height: 30px;
+  border-radius: 15px;
+  background: linear-gradient(140deg, #FFD27C, #FF9447);
+  color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 11.5px;
+  font-weight: 700;
+}
+.user-mini .label {
+  font-size: 13.5px; color: var(--ink); font-weight: 500;
+}
+.drawer-settings {
+  width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-soft);
+}
+.drawer-scrim {
+  position: absolute;
+  left: 304px; right: 0; top: 0; bottom: 0;
+  background: rgba(0,0,0,0.30);
+  z-index: 2;
+}
+
+/* ============================================================
+   ATTACHMENT TRAY
+   ============================================================ */
+.attach-tray {
+  position: absolute;
+  left: 14px; right: 14px;
+  bottom: 88px;
+  background: var(--sheet-bg);
+  border: 1px solid var(--surface-edge);
+  border-radius: 22px;
+  padding: 14px 6px;
+  display: flex; align-items: center; justify-content: space-around;
+  box-shadow: var(--surface-shadow), 0 16px 36px -14px rgba(0,0,0,0.14);
+  z-index: 2;
+}
+.attach-tile {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  padding: 4px 8px;
+  border-radius: 12px;
+  color: var(--ink);
+}
+.attach-tile .ic-wrap {
+  width: 46px; height: 46px;
+  border-radius: 14px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.attach-tile .lbl {
+  font-size: 11.5px;
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+
+/* ============================================================
+   SLASH COMMAND PALETTE
+   ============================================================ */
+.slash-card {
+  position: absolute;
+  left: 18px; right: 18px;
+  bottom: 88px;
+  background: var(--sheet-bg);
+  border: 1px solid var(--surface-edge);
+  border-radius: 18px;
+  padding: 6px;
+  box-shadow: var(--surface-shadow), 0 18px 44px -16px rgba(0,0,0,0.16);
+  z-index: 2;
+}
+.slash-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+}
+.slash-row.focus { background: color-mix(in srgb, var(--ink) 5%, transparent); }
+.slash-row .ic {
+  width: 34px; height: 34px;
+  border-radius: 10px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+}
+.slash-row .meta { flex: 1; min-width: 0; }
+.slash-row .cmd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 2px;
+}
+.slash-row .desc {
+  font-size: 12px;
+  color: var(--ink-soft);
+  line-height: 1.4;
+}
+.slash-row .hint {
+  font-size: 10.5px;
+  color: var(--ink-faint);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ============================================================
+   TWEAKS PANEL
+   ============================================================ */
+.tweaks {
+  position: fixed;
+  right: 24px; bottom: 24px;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: 16px;
+  padding: 14px 18px;
+  box-shadow: 0 12px 32px -8px rgba(0,0,0,0.18);
+  font-size: 12px;
+  color: #1F1F1F;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  z-index: 99;
+  min-width: 252px;
+}
+.tweaks-label {
+  font-weight: 700;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #6B6761;
+}
+.tweaks-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px;
+  font-size: 12px;
+  color: #4A4742;
+}
+.tweaks-row .row-label { color: #6B6761; font-size: 11.5px; }
+.seg {
+  display: inline-flex;
+  border: 1px solid rgba(0,0,0,0.10);
+  border-radius: 8px;
+  overflow: hidden;
+  background: white;
+}
+.seg button {
+  appearance: none;
+  border: none;
+  background: white;
+  padding: 4px 9px;
+  font-size: 11.5px;
+  cursor: pointer;
+  color: #6B6761;
+  font-family: inherit;
+}
+.seg button + button { border-left: 1px solid rgba(0,0,0,0.08); }
+.seg button.on {
+  background: #1F1F1F;
+  color: white;
+}
+.tweaks-row .check {
+  width: 28px; height: 16px;
+  background: rgba(0,0,0,0.15);
+  border-radius: 9px;
+  position: relative;
+  cursor: pointer;
+  transition: background 140ms ease;
+  flex-shrink: 0;
+}
+.tweaks-row .check::after {
+  content: "";
+  position: absolute;
+  width: 12px; height: 12px;
+  background: white;
+  border-radius: 50%;
+  top: 2px; left: 2px;
+  transition: left 140ms ease;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.18);
+}
+.tweaks-row .check.on { background: #4EA8E8; }
+.tweaks-row .check.on::after { left: 14px; }
+.tweaks-reset {
+  appearance: none;
+  border: 1px solid rgba(0,0,0,0.10);
+  background: white;
+  border-radius: 8px;
+  padding: 5px 0;
+  font-size: 11px;
+  color: #6B6761;
+  cursor: pointer;
+  font-family: inherit;
+}
+.tweaks-reset:hover { background: #F7F7F5; }
+</style>
+</head>
+<body class="show-greeting">
+
+<!-- ============================================================
+     SHARED SVG ICON LIBRARY
+     ============================================================ -->
+<svg style="position:absolute; width:0; height:0;" aria-hidden="true">
+  <defs>
+    <symbol id="i-chev-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="6 9 12 15 18 9"/>
+    </symbol>
+    <symbol id="i-compose" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M20.5 11.3a8 8 0 0 1-.85 3.6 8 8 0 0 1-7.15 4.4 8 8 0 0 1-3.6-.85L3.5 20.5l1.45-5.4a8 8 0 0 1-.85-3.6 8 8 0 0 1 4.4-7.15 8 8 0 0 1 3.6-.85h.45a8 8 0 0 1 7.55 7.55v.45z"/>
+      <line x1="12" y1="8.4" x2="12" y2="14.6"/>
+      <line x1="8.9" y1="11.5" x2="15.1" y2="11.5"/>
+    </symbol>
+    <symbol id="i-plus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <line x1="12" y1="5" x2="12" y2="19"/>
+      <line x1="5" y1="12" x2="19" y2="12"/>
+    </symbol>
+    <symbol id="i-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <path d="M18 6 6 18M6 6l12 12"/>
+    </symbol>
+    <symbol id="i-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M20 6 9 17l-5-5"/>
+    </symbol>
+    <symbol id="i-slash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="17" y1="5" x2="7" y2="19"/>
+    </symbol>
+    <symbol id="i-arrow-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="12" y1="19" x2="12" y2="5"/>
+      <polyline points="5 12 12 5 19 12"/>
+    </symbol>
+    <symbol id="i-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <circle cx="11" cy="11" r="7"/>
+      <path d="m20 20-3.6-3.6"/>
+    </symbol>
+    <symbol id="i-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="3"/>
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1A1.7 1.7 0 0 0 9 19.4a1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1A1.7 1.7 0 0 0 4.6 9a1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/>
+    </symbol>
+    <symbol id="i-pin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 17v5"/>
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16h14v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V5a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z"/>
+    </symbol>
+    <symbol id="i-camera" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 8.5h2.6l1.7-2h9.4l1.7 2H21a1 1 0 0 1 1 1V18a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V9.5a1 1 0 0 1 1-1z"/>
+      <circle cx="12" cy="13.5" r="3.6"/>
+    </symbol>
+    <symbol id="i-image" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="4.5" width="18" height="15" rx="2.4"/>
+      <circle cx="8.6" cy="9.6" r="1.5"/>
+      <path d="m3.5 17 5-5 4 4 2.5-2.5 5.5 5.5"/>
+    </symbol>
+    <symbol id="i-video" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="6" width="13.5" height="12" rx="2"/>
+      <path d="m21 8-4.5 3v2L21 16z"/>
+    </symbol>
+    <symbol id="i-music" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 18V6l11-2v12"/>
+      <circle cx="6" cy="18" r="2.6"/>
+      <circle cx="17" cy="16" r="2.6"/>
+    </symbol>
+    <symbol id="i-file" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14 3H6.5A1.5 1.5 0 0 0 5 4.5v15A1.5 1.5 0 0 0 6.5 21h11a1.5 1.5 0 0 0 1.5-1.5V8z"/>
+      <path d="M14 3v5h5"/>
+    </symbol>
+    <symbol id="i-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 5.5A2 2 0 0 1 5 3.5h6.5v17H5a2 2 0 0 1-2-2z"/>
+      <path d="M21 5.5a2 2 0 0 0-2-2h-6.5v17H19a2 2 0 0 0 2-2z"/>
+    </symbol>
+    <symbol id="i-translate" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M3 5.5h10"/>
+      <path d="M7.5 3.5v2"/>
+      <path d="M11 5.5c-.6 4-3.5 7.5-7.5 9"/>
+      <path d="M5 9.5c1.7 2.7 4 4.6 7 5.6"/>
+      <path d="m13 20 4-9 4 9"/>
+      <path d="M14.5 17h5"/>
+    </symbol>
+    <symbol id="i-summary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 6h16M4 12h12M4 18h8"/>
+    </symbol>
+    <symbol id="i-globe" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9"/>
+      <path d="M3.5 12h17"/>
+      <path d="M12 3.2c2.5 2.4 3.8 5.6 3.8 8.8s-1.3 6.4-3.8 8.8c-2.5-2.4-3.8-5.6-3.8-8.8s1.3-6.4 3.8-8.8z"/>
+    </symbol>
+    <symbol id="i-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
+      <circle cx="12" cy="12" r="2.8"/>
+    </symbol>
+    <symbol id="i-tool" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14.7 5.3a4.6 4.6 0 0 1 6.3 4.3 4.6 4.6 0 0 1-6.1 4.3l-7.5 7.5a2 2 0 0 1-2.8-2.8l7.5-7.5a4.6 4.6 0 0 1 2.6-5.8z"/>
+    </symbol>
+    <symbol id="i-brain" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 4a2.5 2.5 0 0 0-2.5 2.5v.7A3 3 0 0 0 4 10v.5a3 3 0 0 0 0 5V16a3 3 0 0 0 3 3 2.5 2.5 0 0 0 2 1 2.5 2.5 0 0 0 2.5-2.5V4.5A2.5 2.5 0 0 0 9 4z"/>
+      <path d="M15 4a2.5 2.5 0 0 1 2.5 2.5v.7A3 3 0 0 1 20 10v.5a3 3 0 0 1 0 5V16a3 3 0 0 1-3 3 2.5 2.5 0 0 1-2 1 2.5 2.5 0 0 1-2.5-2.5V4.5A2.5 2.5 0 0 1 15 4z"/>
+    </symbol>
+    <symbol id="i-tool-pill" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M14.7 6.3a4 4 0 1 0 5 5L17 14l3 3-3 3-3-3 2.7-2.7a4 4 0 1 0-5-5L11.5 12 8.5 9 5.5 12 8.5 15"/>
+    </symbol>
+    <symbol id="i-bear" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="8" cy="6.5" r="2" />
+      <circle cx="16" cy="6.5" r="2" />
+      <circle cx="12" cy="13" r="6" />
+      <circle cx="10" cy="12" r="0.6" fill="currentColor" />
+      <circle cx="14" cy="12" r="0.6" fill="currentColor" />
+    </symbol>
+    <symbol id="i-bell-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 8a6 6 0 0 1 9.5-4.9"/>
+      <path d="M18 8c0 7 3 9 3 9H3s3-2 3-9"/>
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/>
+      <line x1="2" y1="2" x2="22" y2="22"/>
+    </symbol>
+    <symbol id="i-bluetooth" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="6.5 6.5 17.5 17.5 12 23 12 1 17.5 6.5 6.5 17.5"/>
+    </symbol>
+    <symbol id="i-wifi" viewBox="0 0 24 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round">
+      <path d="M2 6a16 16 0 0 1 20 0"/>
+      <path d="M5.5 9.5a11 11 0 0 1 13 0"/>
+      <path d="M9 13a6 6 0 0 1 6 0"/>
+      <circle cx="12" cy="16" r="1" fill="currentColor"/>
+    </symbol>
+  </defs>
+</svg>
+
+<!-- ============================================================
+     DOC HEADER
+     ============================================================ -->
+<div class="doc-header">
+  <div class="doc-eyebrow">DESIGN COMPS v2 · 2026-05-23</div>
+  <h1 class="doc-title">Amber Agent · 主聊天页 UI 重构 v2</h1>
+  <p class="doc-lede">
+    <strong>4 主题</strong>方案，对齐 Anthropic Design 最新设计包：<strong>雾蓝</strong>（默认）/ <strong>简约</strong>（黑白）/ <strong>琥珀</strong>三种浅色用户可手动切换；
+    <strong>深色</strong>由系统/应用深色模式自动接管。对话页里色彩降为"点缀" — 用户胶囊气泡、agent 小光珠 + 模型名、左侧竖条"思考了 N 秒"、单行工具调用胶囊（仅"完成"用主题色）。
+  </p>
+
+  <div class="theme-strip">
+    <div class="theme-card">
+      <h4>雾蓝 Misty <span class="badge">浅色 · 默认</span></h4>
+      <p class="meta">底部天蓝光晕；accent 真天蓝 <code>#3D8FD4</code>；对话页里去掉光晕，只在工具"完成"和图标上保留蓝。</p>
+      <div class="theme-row"><span class="swatch" style="background:#FAFBFC; border-color:#DDD"></span><span class="lbl">bg</span><span>#FAFBFC</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#4EA8E8"></span><span class="lbl">send</span><span>#4EA8E8</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#3D8FD4"></span><span class="lbl">accent</span><span>#3D8FD4</span></div>
+    </div>
+    <div class="theme-card">
+      <h4>简约 Plain <span class="badge">浅色 · 黑白</span></h4>
+      <p class="meta">纯白底 + 宋体标题；ink 软化到 <code>#1A1A1A</code> 避免对比过强；零色彩 accent。</p>
+      <div class="theme-row"><span class="swatch" style="background:#FFFFFF; border-color:#DDD"></span><span class="lbl">bg</span><span>#FFFFFF</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#1A1A1A"></span><span class="lbl">send</span><span>#1A1A1A</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#5A5A5A"></span><span class="lbl">muted</span><span>#5A5A5A</span></div>
+    </div>
+    <div class="theme-card">
+      <h4>琥珀 Amber <span class="badge">浅色 · 暖纸</span></h4>
+      <p class="meta">米黄底 + 宋体；保留底部淡暖光晕；accent 砖红 <code>#B5683A</code>。</p>
+      <div class="theme-row"><span class="swatch" style="background:#F3ECDD"></span><span class="lbl">bg</span><span>#F3ECDD</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#3B2418"></span><span class="lbl">send</span><span>#3B2418</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#B5683A"></span><span class="lbl">accent</span><span>#B5683A</span></div>
+    </div>
+    <div class="theme-card">
+      <h4>深色 Dark <span class="badge">深色 · 自动</span></h4>
+      <p class="meta">深墨蓝底；光晕降到原 1/3；气泡几乎透明白雾；蓝光 accent 留作焦点。</p>
+      <div class="theme-row"><span class="swatch" style="background:#0B0E14"></span><span class="lbl">bg</span><span>#0B0E14</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#8FA9E0"></span><span class="lbl">send</span><span>#8FA9E0</span></div>
+      <div class="theme-row"><span class="swatch" style="background:#E8EAEF"></span><span class="lbl">ink</span><span>#E8EAEF</span></div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     FRAMES
+     ============================================================ -->
+<div class="grid">
+
+  <div class="section-mark">
+    <span class="label">Theme Directions · 空白态 × 4</span>
+    <span class="sub">同一空白态在 4 个主题下的呈现。雾蓝 / 简约 / 琥珀 三种浅色由用户手动选；深色由系统模式接管。</span>
+  </div>
+
+  <!-- =========================================================
+       FRAME 01 — Empty · 雾蓝
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-misty">
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#7BA7C7"></div><div class="app-dot" style="background:#8FA89A"></div><div class="app-dot" style="background:#9AAABF"></div><div class="app-dot" style="background:#8FA89A"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">01 · 雾蓝 Misty · 空白态</div>
+      <div class="note">默认浅色；底部天蓝光晕；发送清亮天蓝 <code>#4EA8E8</code> 带双层呼吸光晕。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 02 — Empty · 简约
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-plain">
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#D6D6D6"></div><div class="app-dot" style="background:#D6D6D6"></div><div class="app-dot" style="background:#D6D6D6"></div><div class="app-dot" style="background:#D6D6D6"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">02 · 简约 Plain · 空白态</div>
+      <div class="note">纯白底 + 宋体标题；零色彩 accent；ink 用 <code>#1A1A1A</code> 而非纯黑，对比降一档。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 03 — Empty · 琥珀
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-amber">
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#C57B5E"></div><div class="app-dot" style="background:#A89678"></div><div class="app-dot" style="background:#7E8A7C"></div><div class="app-dot" style="background:#B89668"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">03 · 琥珀 Amber · 空白态</div>
+      <div class="note">米黄底 + 琥珀光晕 + 宋体标题与问候；发送墨褐 <code>#3B2418</code> 与暖光形成冷暖错位。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 04 — Empty · 深色
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-dark">
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#5E7BC7"></div><div class="app-dot" style="background:#5E8A78"></div><div class="app-dot" style="background:#7686A8"></div><div class="app-dot" style="background:#5E8A78"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">04 · 深色 Dark · 空白态（深色模式接管）</div>
+      <div class="note">深色模式打开时由 Dark 接管，无论你选的是雾蓝 / 简约 / 琥珀；光晕降到原 1/3，整体回归克制。</div>
+    </div>
+  </div>
+
+  <div class="section-mark">
+    <span class="label">Supporting Screens · 跟随主题切换</span>
+    <span class="sub">下面 5 屏由 Tweaks 控制主题。对话页里 accent 降到"点缀"级别：取消蓝光晕，只在工具"完成"和图标上保留主题色。</span>
+  </div>
+
+  <!-- =========================================================
+       FRAME 05 — Active conversation (per design bundle convo-*.jsx)
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-misty" data-themed>
+      <div class="screen">
+        <!-- NO .halo in convo screen per design package -->
+        <div class="status-bar">
+          <div class="left">
+            <span>00:36</span>
+            <div class="app-dots"><div class="app-dot" style="background:#7BA7C7"></div><div class="app-dot" style="background:#8FA89A"></div><div class="app-dot" style="background:#9AAABF"></div><div class="app-dot" style="background:#8FA89A"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="convo-header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <span class="agent-name">Amber</span>
+          </div>
+          <div class="compose-btn"><svg width="24" height="24"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="convo-body">
+          <div class="scroll">
+            <!-- User turn -->
+            <div class="user-turn">
+              <div class="user-identity">
+                <span>Arquiel</span>
+                <div class="user-avatar"><svg width="16" height="16"><use href="#i-bear"/></svg></div>
+              </div>
+              <div class="user-bubble-wrap">
+                <div class="user-bubble">@council 随便开会聊个什么</div>
+              </div>
+            </div>
+            <!-- Agent header -->
+            <div class="agent-header">
+              <div class="agent-mark"><div class="halo"></div><div class="dot"></div></div>
+              <span class="agent-model">deepseek-v4-pro</span>
+            </div>
+            <!-- Thinking strip (collapsed) -->
+            <div class="thinking">
+              <div class="thinking-rule"></div>
+              <div class="thinking-row">
+                <div class="thinking-label">
+                  <span>思考了 5.4 秒</span>
+                  <span class="sep">·</span>
+                  <span class="mode">auto</span>
+                </div>
+                <span class="thinking-chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+              </div>
+            </div>
+            <div class="para">好，随便聊，那就聊个轻松的但不乏深度的话题。我先看看 council 工具，然后设几个席位。</div>
+            <!-- Tool call -->
+            <div class="tool-call">
+              <div class="tool-pill">
+                <svg class="icon" width="14" height="14"><use href="#i-tool-pill"/></svg>
+                <span class="label">调用工具 · <span class="name">tool_search</span></span>
+                <span class="done">完成</span>
+              </div>
+            </div>
+            <div class="para">开一场轻松但有嚼头的圆桌会。话题：「AI 助手到底应该更像工具，还是更像朋友？」</div>
+            <div class="para dim">四个席位，各自立场鲜明，两轮辩论互相碰撞——<span class="cursor"></span></div>
+          </div>
+          <div class="fade"></div>
+        </div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">05 · 活跃对话（含 thinking + tool 调用）</div>
+      <div class="note">用户胶囊气泡贴右；agent 表头是小蓝光珠 + 模型名；思考条是左 2px 竖条 + 暗灰文字（可展开）；工具调用单行胶囊，仅"完成"用主题色；底部 fade mask 让正文自然隐入输入栏。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 06 — Model picker sheet
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-misty" data-themed>
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#7BA7C7"></div><div class="app-dot" style="background:#8FA89A"></div><div class="app-dot" style="background:#9AAABF"></div><div class="app-dot" style="background:#8FA89A"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+
+        <div class="scrim"></div>
+        <div class="sheet">
+          <div class="sheet-handle"></div>
+          <div class="sheet-head">
+            <span class="title">选择模型</span>
+            <div class="sheet-close"><svg width="18" height="18"><use href="#i-close"/></svg></div>
+          </div>
+          <div class="sheet-search">
+            <svg width="16" height="16"><use href="#i-search"/></svg>
+            <span>搜索模型</span>
+          </div>
+          <div class="model-list">
+            <div class="provider-head">DeepSeek</div>
+            <div class="model-row selected">
+              <div class="ic">DS</div>
+              <div class="meta">
+                <div class="name">Deepseek V4 Pro</div>
+                <div class="sub">
+                  <span>128K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+              <div class="check"><svg width="13" height="13"><use href="#i-check"/></svg></div>
+            </div>
+            <div class="model-row">
+              <div class="ic">DS</div>
+              <div class="meta">
+                <div class="name">DeepSeek V3.5</div>
+                <div class="sub"><span>64K</span><span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span></div>
+              </div>
+            </div>
+            <div class="provider-head">OpenAI</div>
+            <div class="model-row">
+              <div class="ic">GPT</div>
+              <div class="meta">
+                <div class="name">GPT-5 Pro</div>
+                <div class="sub">
+                  <span>200K</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+            <div class="model-row">
+              <div class="ic">GPT</div>
+              <div class="meta">
+                <div class="name">GPT-5</div>
+                <div class="sub"><span>200K</span><span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span><span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span></div>
+              </div>
+            </div>
+            <div class="provider-head">Anthropic</div>
+            <div class="model-row">
+              <div class="ic">CL</div>
+              <div class="meta">
+                <div class="name">Claude Opus 4.7</div>
+                <div class="sub">
+                  <span>1M</span>
+                  <span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span>
+                  <span class="cap-chip"><svg><use href="#i-tool"/></svg>工具</span>
+                  <span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span>
+                </div>
+              </div>
+            </div>
+            <div class="provider-head">Google</div>
+            <div class="model-row">
+              <div class="ic">GM</div>
+              <div class="meta">
+                <div class="name">Gemini 3 Pro</div>
+                <div class="sub"><span>1M</span><span class="cap-chip"><svg><use href="#i-eye"/></svg>视觉</span><span class="cap-chip"><svg><use href="#i-brain"/></svg>推理</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">06 · 模型选择面板</div>
+      <div class="note">选中行底色、左 3px 竖条、右侧勾都用当前主题 accent 色；主题切换时自动跟随。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 07 — Drawer
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-misty" data-themed>
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#7BA7C7"></div><div class="app-dot" style="background:#8FA89A"></div><div class="app-dot" style="background:#9AAABF"></div><div class="app-dot" style="background:#8FA89A"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="drawer">
+          <div class="drawer-head">
+            <div class="new-chat-btn">
+              <span class="ic-plus"><svg width="16" height="16"><use href="#i-plus"/></svg></span>
+              新对话
+            </div>
+          </div>
+          <div class="drawer-search">
+            <svg width="14" height="14"><use href="#i-search"/></svg>
+            <span>搜索会话</span>
+          </div>
+          <div class="drawer-list">
+            <div class="drawer-group-head"><svg><use href="#i-pin"/></svg>置顶</div>
+            <div class="conv-row active">
+              <div class="ic">DS</div>
+              <div class="text">
+                <div class="title-line">Amber Agent 主聊天 UI 重构</div>
+                <div class="preview">好的，我先整理整套设计稿…</div>
+              </div>
+            </div>
+            <div class="conv-row">
+              <div class="ic">CL</div>
+              <div class="text">
+                <div class="title-line">KMP 多平台架构梳理</div>
+                <div class="preview">commonMain 里这层 use case…</div>
+              </div>
+            </div>
+            <div class="drawer-group-head">今天</div>
+            <div class="conv-row">
+              <div class="ic">DS</div>
+              <div class="text">
+                <div class="title-line">翻译日语合同第 4–7 条</div>
+                <div class="preview">乙方依据本合同之约定…</div>
+              </div>
+            </div>
+            <div class="conv-row">
+              <div class="ic">GPT</div>
+              <div class="text">
+                <div class="title-line">Compose 性能优化 checklist</div>
+                <div class="preview">推荐顺序：1) defer 状态…</div>
+              </div>
+            </div>
+            <div class="drawer-group-head">昨天</div>
+            <div class="conv-row">
+              <div class="ic">GM</div>
+              <div class="text">
+                <div class="title-line">Gemini 3 体验记录</div>
+                <div class="preview">1M 上下文确实是质变…</div>
+              </div>
+            </div>
+            <div class="drawer-group-head">7 天内</div>
+            <div class="conv-row">
+              <div class="ic">CL</div>
+              <div class="text">
+                <div class="title-line">读 Designing Data-Intensive Applications 第 5 章</div>
+                <div class="preview">单 leader 复制的核心问题…</div>
+              </div>
+            </div>
+            <div class="conv-row">
+              <div class="ic">DS</div>
+              <div class="text">
+                <div class="title-line">Android Room 迁移调研</div>
+                <div class="preview">先把 @Insert 改成挂起函数…</div>
+              </div>
+            </div>
+          </div>
+          <div class="drawer-foot">
+            <div class="user-mini">
+              <div class="av">A</div>
+              <div class="label">Arquiel</div>
+            </div>
+            <div class="drawer-settings"><svg width="18" height="18"><use href="#i-settings"/></svg></div>
+          </div>
+        </div>
+        <div class="drawer-scrim"></div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">07 · 侧边抽屉（会话列表）</div>
+      <div class="note">顶部"新对话" + 搜索；按置顶 / 今天 / 昨天 / 7 天内分组；当前会话用主题 accent 高亮。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 08 — Attachment tray
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-misty" data-themed>
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#7BA7C7"></div><div class="app-dot" style="background:#8FA89A"></div><div class="app-dot" style="background:#9AAABF"></div><div class="app-dot" style="background:#8FA89A"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus expanded"><svg width="20" height="20"><use href="#i-close"/></svg></span>
+            <div class="divider"></div>
+            <span class="field">输入消息</span>
+            <span class="slash"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+        <div class="attach-tray">
+          <div class="attach-tile"><div class="ic-wrap"><svg width="22" height="22"><use href="#i-camera"/></svg></div><span class="lbl">拍照</span></div>
+          <div class="attach-tile"><div class="ic-wrap"><svg width="22" height="22"><use href="#i-image"/></svg></div><span class="lbl">图片</span></div>
+          <div class="attach-tile"><div class="ic-wrap"><svg width="22" height="22"><use href="#i-video"/></svg></div><span class="lbl">视频</span></div>
+          <div class="attach-tile"><div class="ic-wrap"><svg width="22" height="22"><use href="#i-music"/></svg></div><span class="lbl">音频</span></div>
+          <div class="attach-tile"><div class="ic-wrap"><svg width="22" height="22"><use href="#i-file"/></svg></div><span class="lbl">文件</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">08 · 附件菜单（轻量浮层）</div>
+      <div class="note">点加号 → 上方浮出一排 accent-soft 容器的图标按钮；加号变成关闭叉，状态清晰。</div>
+    </div>
+  </div>
+
+  <!-- =========================================================
+       FRAME 09 — Slash command palette
+       ========================================================= -->
+  <div class="frame">
+    <div class="phone theme-misty" data-themed>
+      <div class="screen">
+        <div class="halo"></div>
+        <div class="status-bar">
+          <div class="left">
+            <span>00:35</span>
+            <div class="app-dots"><div class="app-dot" style="background:#7BA7C7"></div><div class="app-dot" style="background:#8FA89A"></div><div class="app-dot" style="background:#9AAABF"></div><div class="app-dot" style="background:#8FA89A"></div></div>
+          </div>
+          <div class="right">
+            <svg width="13" height="13"><use href="#i-bell-off"/></svg>
+            <svg width="10" height="13"><use href="#i-bluetooth"/></svg>
+            <div class="kbs"><span class="num">0.20</span><span class="unit">KB/s</span></div>
+            <svg width="14" height="11"><use href="#i-wifi"/></svg>
+            <div class="signal"><span class="label">5G</span><div class="bar" style="height:3px"></div><div class="bar" style="height:5px"></div><div class="bar" style="height:7px"></div><div class="bar" style="height:9px"></div></div>
+            <div class="battery">100</div>
+          </div>
+        </div>
+        <div class="header">
+          <div class="left">
+            <div class="hamburger"><div class="line l1"></div><div class="line l2"></div><div class="line l3"></div></div>
+            <div class="title-pill">
+              <span class="name">Deepseek V4 Pro</span>
+              <span class="chev"><svg width="11" height="11"><use href="#i-chev-down"/></svg></span>
+            </div>
+          </div>
+          <div class="compose-btn"><svg width="26" height="26"><use href="#i-compose"/></svg></div>
+        </div>
+        <div class="hero"><div class="greet">Hi Arquiel，今天想聊点什么？</div></div>
+        <div class="input-region">
+          <div class="composer">
+            <span class="plus"><svg width="24" height="24"><use href="#i-plus"/></svg></span>
+            <div class="divider"></div>
+            <span class="field typed">/<span class="caret"></span></span>
+            <span class="slash active"><svg width="20" height="20"><use href="#i-slash"/></svg></span>
+            <div class="send-wrap"><div class="send-halo-outer"></div><div class="send-halo-inner"></div><div class="send-orb"><svg width="20" height="20"><use href="#i-arrow-up"/></svg></div></div>
+          </div>
+        </div>
+        <div class="home-bar"><div class="pill"></div></div>
+        <div class="slash-card">
+          <div class="slash-row focus">
+            <div class="ic"><svg width="18" height="18"><use href="#i-book"/></svg></div>
+            <div class="meta">
+              <div class="cmd">/deepread</div>
+              <div class="desc">把链接送入深度阅读，生成杂志风长文</div>
+            </div>
+            <span class="hint">↵</span>
+          </div>
+          <div class="slash-row">
+            <div class="ic"><svg width="18" height="18"><use href="#i-translate"/></svg></div>
+            <div class="meta">
+              <div class="cmd">/translate</div>
+              <div class="desc">把选中或下一条消息翻译成中文</div>
+            </div>
+          </div>
+          <div class="slash-row">
+            <div class="ic"><svg width="18" height="18"><use href="#i-summary"/></svg></div>
+            <div class="meta">
+              <div class="cmd">/summarize</div>
+              <div class="desc">把当前对话总结成 5 条要点</div>
+            </div>
+          </div>
+          <div class="slash-row">
+            <div class="ic"><svg width="18" height="18"><use href="#i-globe"/></svg></div>
+            <div class="meta">
+              <div class="cmd">/search</div>
+              <div class="desc">联网搜索后再让模型回答</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="caption">
+      <div class="title">09 · 斜杠命令面板</div>
+      <div class="note">键入 <code>/</code> 或点击输入框右侧斜线触发；斜线图标进入 active 用主题色高亮。</div>
+    </div>
+  </div>
+
+</div>
+
+<!-- ============================================================
+     TWEAKS
+     ============================================================ -->
+<div class="tweaks">
+  <span class="tweaks-label">Tweaks</span>
+  <div class="tweaks-row">
+    <span class="row-label">主题</span>
+    <div class="seg" id="seg-theme">
+      <button data-theme="misty" class="on">雾蓝</button>
+      <button data-theme="plain">简约</button>
+      <button data-theme="amber">琥珀</button>
+    </div>
+  </div>
+  <div class="tweaks-row">
+    <span class="row-label">深色模式</span>
+    <div class="check" id="tw-dark"></div>
+  </div>
+  <div class="tweaks-row">
+    <span class="row-label">显示问候</span>
+    <div class="check on" id="tw-greeting"></div>
+  </div>
+  <button class="tweaks-reset" id="tw-reset">重置</button>
+</div>
+
+<script>
+  // The top 4 "theme directions" phones are LOCKED (no data-themed attr).
+  // The 5 supporting screens are live-themable via Tweaks.
+  const phones = document.querySelectorAll('.phone[data-themed]');
+  const segTheme = document.getElementById('seg-theme');
+  const darkToggle = document.getElementById('tw-dark');
+  const greetToggle = document.getElementById('tw-greeting');
+  const resetBtn = document.getElementById('tw-reset');
+
+  let currentTheme = 'misty';  // user-chosen light theme: misty | plain | amber
+  let darkOn = false;
+  let greetOn = true;
+
+  function applyTheme() {
+    const effective = darkOn ? 'dark' : currentTheme;
+    phones.forEach(p => {
+      p.classList.remove('theme-misty', 'theme-plain', 'theme-amber', 'theme-dark');
+      p.classList.add('theme-' + effective);
+    });
+  }
+
+  segTheme.querySelectorAll('button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      segTheme.querySelectorAll('button').forEach(b => b.classList.remove('on'));
+      btn.classList.add('on');
+      currentTheme = btn.dataset.theme;
+      applyTheme();
+    });
+  });
+
+  darkToggle.addEventListener('click', () => {
+    darkOn = !darkOn;
+    darkToggle.classList.toggle('on', darkOn);
+    applyTheme();
+  });
+
+  greetToggle.addEventListener('click', () => {
+    greetOn = !greetOn;
+    greetToggle.classList.toggle('on', greetOn);
+    document.body.classList.toggle('no-greeting', !greetOn);
+  });
+
+  resetBtn.addEventListener('click', () => {
+    currentTheme = 'misty';
+    darkOn = false;
+    greetOn = true;
+    segTheme.querySelectorAll('button').forEach(b => {
+      b.classList.toggle('on', b.dataset.theme === 'misty');
+    });
+    darkToggle.classList.remove('on');
+    greetToggle.classList.add('on');
+    document.body.classList.remove('no-greeting');
+    applyTheme();
+  });
+</script>
+
+</body>
+</html>

--- a/docs/CODEX_HANDOFF_2026-05-21_AMBER_AGENT_CONTINUATION.md
+++ b/docs/CODEX_HANDOFF_2026-05-21_AMBER_AGENT_CONTINUATION.md
@@ -1,0 +1,348 @@
+# Codex Handoff: AmberAgent / RikkaHub Main Continuation, 2026-05-21
+
+## TL;DR
+
+This handoff is for a fresh Codex session taking over AmberAgent mainline development.
+
+Repo:
+
+```text
+/Users/arquiel/Downloads/AI/rikkashit/rikkahub
+```
+
+Current branch:
+
+```text
+main
+```
+
+Product remote:
+
+```text
+github-private  https://github.com/soul99soul-glitch/AmberAgent.git
+```
+
+Upstream reference remote:
+
+```text
+origin          https://github.com/rikkahub/rikkahub.git
+```
+
+Current pushed HEAD at handoff creation:
+
+```text
+470d6f29 Improve deep read templates and board model requests
+```
+
+The latest local `main` has already been rebased onto `github-private/main` and pushed successfully.
+
+## Current Working Tree
+
+At handoff creation, the only intentional local change is this handoff file itself.
+
+Run first:
+
+```bash
+git status --short
+git branch --show-current
+git log --oneline -12
+```
+
+Do not assume older handoff docs are current. Prefer this document plus the live repo state.
+
+## Recent Development Context
+
+The last several sessions focused on 今日看板 / 深度阅读 / 小应用设置, especially after the Today Board refactor exposed unstable hot-list and deep-read behavior.
+
+Important user direction:
+
+- Main board should remain dense and mostly text-only.
+- Deep Read should be the magazine-like, image-rich reading surface.
+- Deep Read output must be genuinely useful. A low-information fallback article is not acceptable as “deep reading”.
+- English sources are allowed, but the rendered dashboard/deep-read content should be Chinese. Original links may still point to English pages.
+- Deep Read templates should be controlled/static templates, not arbitrary miniapps with JS or bridge access.
+- Visual polish matters. The user strongly dislikes rough layout, oversized typography, broken image placeholders, duplicated images, and chaotic settings UI.
+- Do not mix unrelated chat timeline animation work into Today Board / Deep Read patches.
+
+## What Was Just Shipped
+
+Commit:
+
+```text
+470d6f29 Improve deep read templates and board model requests
+```
+
+Main changes in that commit:
+
+- Bumped local Notion build version to `2.2.5` / versionCode `384`.
+- Reworked Deep Read template rendering and settings polish.
+- Added Deep Read template runtime CSS injection so selected fonts also affect custom templates.
+- Fixed selected Slides / built-in font routing into template CSS variables.
+- Added broken image re-render handling in Deep Read WebView templates.
+- Added image deduping so timeline/body images do not repeat several times.
+- Improved title localization for cached/stale hot-list snapshots.
+- Improved Deep Read empty-output diagnostics and retry messaging.
+- Improved Deep Read template generation validation/repair flow.
+- Reorganized miniapp settings into cleaner grouped secondary pages.
+- Added Today Board model request option helper:
+  - `app/src/main/java/me/rerere/rikkahub/data/agent/board/BoardModelRequestOptions.kt`
+  - It rehydrates headers/bodies from the canonical model stored under `settings.providers`.
+  - It is used by board summary, daily review, hot-list title localization, deep read generation, and deep-read template generation.
+
+Why the model request helper exists:
+
+The user reported that the model selected in Today Board seemed not to carry the Provider-model Header parameters, causing some Coding IDE / Coding Plan models to be rejected. In this codebase there is no separate `ProviderSetting.headers` field; the per-provider-model headers live on `Model.customHeaders`. The board code was making direct model calls, so the safer path is to resolve the canonical model from `settings.providers` at request time and merge headers/bodies from there.
+
+## Build / Install State
+
+Already verified before this handoff:
+
+```bash
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:compileNotionKotlin
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:assembleNotion
+```
+
+Both passed.
+
+The APK was installed successfully via:
+
+```bash
+/Users/arquiel/Library/Android/sdk/platform-tools/adb install -r app/build/outputs/apk/notion/app-arm64-v8a-notion.apk
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s c9a8a837 install -r app/build/outputs/apk/notion/app-arm64-v8a-notion.apk
+```
+
+Last visible connected device during handoff:
+
+```text
+c9a8a837  OPD2515 / OP6548L1
+```
+
+APK path:
+
+```text
+app/build/outputs/apk/notion/app-arm64-v8a-notion.apk
+```
+
+Copy target used in previous packaging runs:
+
+```text
+/Users/arquiel/Downloads/APK/AmberAgent-2.2.5-notion-arm64-v8a.apk
+```
+
+## Key Files To Know
+
+Today Board / dashboard:
+
+```text
+app/src/main/java/me/rerere/rikkahub/ui/pages/board/BoardPage.kt
+app/src/main/java/me/rerere/rikkahub/ui/pages/board/SettingTodayBoardPage.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/BoardSettings.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/agent/BoardAgent.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/agent/DailyReviewAgent.kt
+```
+
+Hot list:
+
+```text
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/HotListRepository.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/HotListTitleLocalizer.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/providers/
+```
+
+Deep Read generation:
+
+```text
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/DeepReadAgent.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/DeepReadPrompt.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/DeepReadOutputParser.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/DeepReadSanitizer.kt
+app/src/main/java/me/rerere/rikkahub/ui/pages/board/DeepReadScreen.kt
+```
+
+Deep Read templates:
+
+```text
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/template/DeepReadTemplateAgent.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/template/DeepReadTemplateRenderer.kt
+app/src/main/java/me/rerere/rikkahub/data/agent/board/hotlist/deepread/template/DeepReadTemplateValidator.kt
+app/src/main/java/me/rerere/rikkahub/ui/pages/board/DeepReadTemplateSettings.kt
+```
+
+Miniapp settings:
+
+```text
+app/src/main/java/me/rerere/rikkahub/ui/pages/miniapp/MiniAppSettingsPage.kt
+```
+
+Board model request headers/bodies:
+
+```text
+app/src/main/java/me/rerere/rikkahub/data/agent/board/BoardModelRequestOptions.kt
+```
+
+Tests touched recently:
+
+```text
+app/src/test/java/me/rerere/rikkahub/data/agent/board/hotlist/DeepReadSanitizerTest.kt
+```
+
+## Known Issues / Likely Next Work
+
+### 1. Deep Read quality still needs real-device validation
+
+The latest code has been built and installed, but the user may still find that Deep Read content is not informative enough for major topics like Gemini / Google I/O / Qwen / AI industry news.
+
+Do not treat “model returned some Chinese text” as success. The success bar is:
+
+- enough facts,
+- timeline/background/causal story,
+- clear “why it matters” analysis,
+- source links clickable,
+- Chinese presentation,
+- no low-information source-list filler.
+
+If quality is poor, inspect:
+
+- `DeepReadPrompt.kt`
+- source collection/enrichment in `DeepReadAgent.kt`
+- staged generation prompts and token/time limits
+- whether search results are actually relevant and rich
+- model max-token rejection / empty-output diagnostics
+
+### 2. Deep Read streaming/template generation UX is still experimental
+
+The user wanted the final magazine template itself to appear immediately and fill in progressively, not a separate generic loading checklist. Some pieces exist, but the current experience may still not match that ideal.
+
+If continuing this:
+
+- Prefer rendering the chosen template skeleton first.
+- Fill sections as overview/timeline/analysis/extended reading arrive.
+- Keep layout stable during staged generation.
+- Avoid huge placeholder cards that look like error cards.
+
+### 3. Template typography/layout can still regress
+
+The user called out:
+
+- font size too large,
+- low information density,
+- selected fonts not taking effect,
+- broken image placeholders,
+- duplicate images,
+- timeline text collapsing into one-character vertical columns,
+- chaotic template settings controls.
+
+Recent fixes address these, but validate on device before assuming solved.
+
+### 4. Hot-list English display titles
+
+Dashboard items can still surface English titles if localization is skipped, times out, or cannot repair stale cache. User wants displayed board titles to be Chinese when possible. Original URL can remain English.
+
+### 5. Old handoff hygiene
+
+Older handoff docs are often stale. If creating another handoff, either name it clearly with the current date or replace/remove obsolete untracked handoffs.
+
+## Constraints / Preferences
+
+- Do not push unless the user explicitly asks.
+- Do not reopen large chat streaming/reveal experiments while working on Today Board.
+- Keep patches scoped and simple.
+- Do not over-engineer template runtime into unrestricted miniapps.
+- Use subagents only when explicitly asked or when the task has clear independent review value. The user recently complained about too many open subagents, so close any subagents when done.
+- Preserve unrelated user changes.
+- Prefer `rg` for search.
+- Use `apply_patch` for manual edits.
+
+## Commands
+
+Build:
+
+```bash
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:compileNotionKotlin
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:assembleNotion
+```
+
+Install:
+
+```bash
+/Users/arquiel/Library/Android/sdk/platform-tools/adb devices -l
+/Users/arquiel/Library/Android/sdk/platform-tools/adb install -r app/build/outputs/apk/notion/app-arm64-v8a-notion.apk
+```
+
+Copy APK:
+
+```bash
+mkdir -p /Users/arquiel/Downloads/APK
+cp app/build/outputs/apk/notion/app-arm64-v8a-notion.apk /Users/arquiel/Downloads/APK/AmberAgent-2.2.5-notion-arm64-v8a.apk
+```
+
+Useful checks:
+
+```bash
+git diff --check
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:testDebugUnitTest --tests 'me.rerere.rikkahub.data.agent.board.hotlist.*'
+```
+
+## Bootstrap Prompt For New Session
+
+Use this prompt to start the next Codex session:
+
+```text
+你接手 AmberAgent / RikkaHub Android Kotlin/Compose 项目主线开发。
+
+项目路径：
+/Users/arquiel/Downloads/AI/rikkashit/rikkahub
+
+当前产品线分支：
+main
+
+产品远端：
+github-private = https://github.com/soul99soul-glitch/AmberAgent.git
+
+请先按顺序读取：
+1. docs/AI_HANDOFF_ZONES.md
+2. CLAUDE.md
+3. docs/CODEX_HANDOFF_2026-05-21_AMBER_AGENT_CONTINUATION.md
+
+然后运行：
+git status --short
+git branch --show-current
+git log --oneline -12
+
+当前最新已推送提交：
+470d6f29 Improve deep read templates and board model requests
+
+当前重点方向：
+今日看板 / 深度阅读 / 深度阅读模板 / 小应用设置。最近刚修了：
+- 深读模板字体与图片链路
+- 图片去重
+- 模板生成校验/修复
+- 小应用设置分组页面
+- 看板模型请求携带 Provider 模型里的 customHeaders/customBodies
+
+请不要直接猜补丁。先基于真机复现、logcat、实际搜索结果和模型响应判断问题在：
+1. 热榜源抓取
+2. 搜索/来源收集
+3. DeepRead prompt 与 staged generation
+4. JSON/parser/repair
+5. 模板渲染/WebView/CSS
+6. 设置/模型请求参数
+哪一层。
+
+用户核心要求：
+- 主看板不需要图片，保持高密度中文热点列表。
+- 深度阅读必须有真正信息量，不接受低质量“来源列表式兜底稿”。
+- 英文源可以抓，但 UI 呈现尽量中文；原文链接保留跳转。
+- 深读要有杂志感，但不能牺牲可读性和信息密度。
+- 模板系统 v1 必须受控：静态 HTML/CSS，不开放 JS/bridge/任意网络。
+- 不要混入聊天发送动画、蓝点等待态、bottom-follow 等无关实验。
+- 不 push，除非我明确要求。
+
+构建命令：
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:compileNotionKotlin
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home ./gradlew --offline -Pksp.incremental=false :app:assembleNotion
+
+安装命令：
+/Users/arquiel/Library/Android/sdk/platform-tools/adb devices -l
+/Users/arquiel/Library/Android/sdk/platform-tools/adb install -r app/build/outputs/apk/notion/app-arm64-v8a-notion.apk
+```

--- a/docs/V3_HANDOFF_SESSION_2_2026-05-23.md
+++ b/docs/V3_HANDOFF_SESSION_2_2026-05-23.md
@@ -1,0 +1,375 @@
+# V3 Refactor Handoff — Session 2 (2026-05-23, post-rev2)
+
+> 接续 `V3_REFACTOR_HANDOFF_2026-05-23.md` 的工作。本 session 主要：
+> 1. 完整重构 ChatDrawer 为 V3 history-screen 布局
+> 2. 完整重构 ModelList picker (active card / 段控 / provider 分组)
+> 3. 写 ToolResultPreview Composable (3:4 sticky shelf 规格)
+> 4. 修 SearchImageBlock 4:3 → 3:4
+> 5. 修 reasoning header / askUserStep / ProviderPage / ProviderDetailPage / SkillsPage 等多页 V3 对齐
+> 6. 修 build hook 误报 exit 0 但 BUILD FAILED 的陷阱
+
+## TL;DR 当前状态
+
+| 项 | 状态 |
+|---|---|
+| Build variant | `refactortest`（applicationIdSuffix `.refactortest`） |
+| 包名 | `me.rerere.amberagent.refactortest` |
+| 真机 | OPPO PMA110，`3B164901CEF00000` |
+| 主分支 | `feature/chat-ui-refresh`（未 push） |
+| 最新 APK | `app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk` (~105MB) |
+| 当前活动主题 | Paper 砖红 |
+| Subagent reviews | 共 6 次（最新审计的二级页 audit 报告在 `/private/tmp/claude-501/...` task transcripts） |
+
+## 本 session 完成 ✅
+
+### Drawer V3 完整重构（约 5 个 turn）
+
+**最关键改动** — 之前只塞了 Amber 文字 + 加了 statusBars padding，骨架仍是旧 IA。本 session 完整重排：
+
+| 区域 | 实现 |
+|---|---|
+| 1) Amber wordmark | 32sp Serif 置顶 |
+| 2) Search bar | 999 圆角胶囊 + 搜索图标 + "搜索聊天" placeholder |
+| 3) Primary nav | 新聊天 (accent W500) + 今日看板 + 小应用 |
+| 4) QuickRow | 3 个 36×36 icon-only 圆角方块 (Folder/Sparkles/ChartColumn) |
+| 5) Divider | 1dp hair line |
+| 6) "最近" label | 12sp inkFaint |
+| 7) ConversationList | active = accentSoft 胶囊 + accent 文字 |
+| 8) Footer | hair line + 32dp 头像（无铅笔徽标） + Arquiel + Settings gear |
+| 9) 全屏拉出 | 手机端 `drawerWidth = windowAdaptiveInfo.width` |
+
+辅助 Composable：`V3NavRow`、`V3QuickBtn`、`UIAvatar.showEditBadge` 新参数
+
+### ModelList picker V3 重构
+
+| 项 | 实现 |
+|---|---|
+| Active 卡 | 跟同 provider 其他 model 在同张 group card 内（不再单独划出）；active 行 accentSoft 高亮 + 段控内嵌 |
+| Group card | 每 provider 一张 16dp 圆角 card，内部模型行用 hairline 分隔 |
+| Provider 名 label | accent 色 + 12sp |
+| 头像 | 单层 32dp（去掉外层 rounded-rect + 内层圆形的嵌套） |
+| 模型名字号 | 13.5sp（紧凑） |
+| Capability icons | Message01 / Text 或 Image03 / Wrench01 / AiMagic（按 model.abilities + modalities） |
+| 段控 | CircleShape 999 + theme.surface 白底 + 2dp padding + 11sp 字 + accent 实心选中段 |
+| 段集按 model 推断 | DeepSeek = off/high/max (3 段, [官方文档](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode)) / Claude = low/med/high/xhigh/max (5) / OpenAI = low/med/high/xhigh (4) / Kimi+GLM = off/auto (2) / **默认 fallback = off/auto** (2) |
+| 收藏拖拽 | 移除 ReorderableItem，仅保留心形 toggle |
+| 底部 provider chips | 12dp 圆角矩形 + 18×18 logo 块 + 名 + hairline 顶 |
+
+新增数据通路：`ModelSelector` + `ModelList` 接 `currentAssistant: Assistant?` + `onUpdateAssistant: ((Assistant) -> Unit)?` (10 个 callsite 无需改)，ChatPage TopBar 接通 `vm.updateSettings(assistants map)` 回写。
+
+### 思考展开 + ContextRing
+
+| 项 | 实现 |
+|---|---|
+| ChainOfThought 左竖线 | colorScheme.outlineVariant (faint 灰) → **chatTheme.thinkRule** (accent@45% 主题色) + stroke 1→2dp |
+| "思考了 N 秒" 头部 | brain 图标移除 (设计稿无) + 文字 12sp → 13sp + 字距 0.2 + 纯 accent (去 0.72 alpha) |
+| metaText (auto / ≤ 8K) | 之前在右 extra 跑到右边 → **合并到主标签 inline "思考了 5.4 秒 · auto"** |
+| 正文 ReasoningContent | 改读 `chatTheme.thinkBodyInk` 替代直接 `inkSoft`（token 语义分离）|
+| ContextRing | 真实 token usage 接通（最后一条 assistant 消息 totalTokens / 200K 估值）|
+| ContextRing popup | 290dp 浮层 (用量与上下文 / 5h/周/Context 行 / meta strip 本次/缓存命中/速度) |
+
+### AskUserStep V3
+
+| 项 | 实现 |
+|---|---|
+| AskOptionChip 圆角 | 20dp → **CircleShape 999 真胶囊** |
+| 未选中 chip | accent 重蓝底 → **chatTheme.surface 白底 + 1dp surfaceEdge 6% 墨灰边 + 1dp 极淡阴影** |
+| 选中 chip | chatTheme.accent 实心 + onAccent 文字 |
+| chip 字号 | → 13.5sp + 字距 0.2 + 行高 17.5 |
+| chip padding | → 8/14dp |
+
+### 二级页面 V3 batch
+
+| 文件 | 改 |
+|---|---|
+| `WorkspaceStyle.kt:104` 浅色支镜像深色支 | `paper / row / ink / muted / hairline` 全部走 `MaterialTheme.colorScheme.surface/onSurface/...` → 所有 settings 页自动跟主题 |
+| `WorkspaceTone.Accent` (4 helpers) | 硬 `colors.blue/blueContainer` → `scheme.primary/primaryContainer` (跟主题 accent) |
+| `Select.kt` | 方框 6dp → CircleShape 999 + chatTheme.accentSoft/accent + 去掉 `fillMaxWidth + Text.weight(1f)` 防止把 ListItem 文字挤出去 |
+| `CardGroup.kt:35` | CardGroupCorner 12 → 18dp |
+| `SettingPage.kt:309 SettingLeadingIcon` | 30/15dp → 32/21dp |
+| `SettingAgentMemoryPage.kt` agents.md preview | 加 `FontFamily.Monospace` + 12.5sp + 18sp lineHeight |
+| `SettingExperimentalPage.kt ExperimentDivider` | `padding(start = 46.dp)` → 60dp 对齐 leading icon 右边线 |
+| `SettingProviderPage.kt ProviderItem` | 彩色 Surface 堆 → 极简 hairline 列表（移除行内删除按钮）|
+| `SettingProviderDetailPage.kt bottomBar` | `NavigationBar` 重壳 → V3 2-flex tab + hair top + accent 选中 |
+| `SettingDisplayPage.kt 圆角 hack` | 4/8 → 2/16（顶 16dp / 底 2dp 配 16dp 整组 18dp 圆角）|
+| 12 处 Select 硬宽 100~180dp | 全部去掉，让 Select 内容自适应 (4 个 setting 页 sed 批改)|
+| `SkillsPage.kt` Stats card | 8dp → 18dp / "已启用" Success 绿 → **Accent (设计稿明确"no green")** / 已加 logo 34dp/20dp |
+| `SkillsPage.kt SkillCard` | 8dp Surface → 18dp + chatTheme.surface + hair border / 仅 disabled 显示未启用 pill / MCP pill "包含 MCP 配置" → "MCP" / 行内 magicWand + delete icon → **overflow menu (DropdownMenu)** |
+
+### ToolResultPreview (standalone Composable)
+
+按 claude design pixel spec 重写 (`ui/components/message/ToolResultPreview.kt`)：
+- 72×96 (3:4) thumb + 8dp 圆角 + 1dp 8% ink border + 单层柔影 0.06
+- 容器 padding (start=14, end=32, top=10, bottom=8) **asymmetric**
+- align-items: Bottom（胶囊底沿与缩略图底沿对齐，不是 center）
+- FakeBrowser 内 mock（Google 字标 / 搜索框 / tab strip / 2 result blocks / divider）
+- ResultPill: fillMaxWidth + 999 圆角 + 22dp 高 (3px 上下 padding + 16dp 圆) + 11.5sp tool · query inline + 9dp chevrons + tabular-nums page nav
+
+**注意**：组件本身实现完整，但**未集成进 chat flow**（数据层缺 web-search streaming 入口）。用户反馈"实际用的时候本来就是会显示真实的网页内容的，不是一个虚假的" → FakeBrowser 是 placeholder mock，等真实数据接入后替换。
+
+### SearchImageBlock 改 3:4
+
+`SearchImageBlock.kt:248` aspectRatio `4f/3f` → **`3f/4f`** 竖向 + heightIn min 72 → 96dp。
+
+## 本 session 未做 / 部分做 ⏳
+
+| 项 | 原因 |
+|---|---|
+| **ResultPill 集成到 chat flow** | 当前 SearchImageBlock 只显示图片 + caption；要在缩略图旁加 status pill 需要从消息数据里抽 tool name + query + page，数据层穿透深 |
+| **SettingPage 主入口分组** 4 → 2 组 | audit 建议收敛，但合并后丢"模型与服务"/"数据"分组，决定保留 |
+| **SettingModelPage hero + ModelPickerRow logo+accent** | 当前 3 个对等 ModelSection；改为 hero card + 辅助任务 hairline 列表需要 ModelSelector 内部重写 |
+| **SettingAgentExecutionPage 字段集** | audit 标记为 IA 决策差异（设计稿是 Workspace/Runtime，Kotlin 是 操作预览/Tool Loop），非 UI 对齐问题 |
+| **WorkspaceTopBar 抽象** | audit 建议抽 22sp medium + 14px padding + 32dp chevron + 无 elevation 的通用 TopBar，affect 10+ pages，但当前 M3 TopAppBar via CustomColors 已跟主题，纯样式抽象 ROI 低 |
+| **SettingProviderConfigPage Field 平卡输入** | OutlinedTextField → 平卡输入，需重写 ProviderConfigure，>2h |
+| **Thinking strip label + body 整体竖线** | 当前竖线在 ChainOfThought wrapper 上覆盖所有 step；设计稿仅 reasoning step 应有竖线，AskUser 不应有 |
+
+## 踩过的坑（务必记住）
+
+### 1. Build hook 误报 exit 0 但实际 BUILD FAILED
+
+**多次出现**：调用 `Bash run_in_background` 跑 `gradlew assembleRefactortest`，task notification 报 `status: completed`、`exit code 0`，但实际 BUILD FAILED（编译错误）。导致：
+- 我 push 旧 apk 到设备
+- 用户看到的还是旧版本
+- 我以为 "已部署" 实际 APK 时间戳还是几分钟前的
+
+**对策**：每次 build 必须验证：
+```bash
+# 1. 看 task output 是否真 SUCCESSFUL
+tail -3 /private/tmp/claude-501/.../tasks/<task-id>.output
+# 2. 对比 APK mtime vs 源文件 mtime（apk 必须比 src 新）
+stat -f "%m %Sm" app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk
+stat -f "%m %Sm" <修改的源文件>
+```
+若 apk mtime < src mtime，就是 build 没真成功。
+
+### 2. PMA110 设备 adb input 不稳
+
+- swipe 容易把 app 切到后台（手势导航）
+- 通知栏经常被 input swipe 误触发拉下来
+- tap 坐标基于 1440x3168，部分 region 用绝对坐标算不准
+- 解决：远程截图 + 用户手动点；或 `am start` deep link
+
+### 3. workspaceColors() 浅色支硬编码白色
+
+`WorkspaceStyle.kt:104-122` 之前浅色支返回 hardcoded `paper = Color.White` / `ink = #1F1F1F` 等，**不读 MaterialTheme.colorScheme**。导致：
+- 切到 Paper 主题，设置页/抽屉/二级页背景全是白色（不跟主题）
+- TopBar 用 workspace.paper@96% → Paper 顶栏白条遮住底部 halo
+
+**对策**：浅色支镜像深色支，全部 `scheme.surface/onSurface/...`。Theme.kt 的 colorScheme override 已经把 scheme 替成 chatTheme，workspace 自动跟随。
+
+### 4. Select 去掉 width 后挤垮 ListItem
+
+`Modifier.width(150.dp)` 去掉后，ExposedDropdownMenuBox 默认 wrap content **但内 Row 用了 `fillMaxWidth + Text.weight(1f)`** 撑满剩余空间，把 ListItem 的 headlineContent "颜色模式" 文字挤到左边变成竖排单字。
+
+**对策**：Select.kt 内 Row 去掉 `.fillMaxWidth()` 和 Text 的 `.weight(1f)` → 让 Row wrap content。
+
+### 5. ModelAbility 包 path 错
+
+`me.rerere.ai.core.ModelAbility` ❌ → `me.rerere.ai.provider.ModelAbility` ✓
+
+### 6. WindowInsets.statusBars 在 ChatDrawer 没 import
+
+直接写 `windowInsetsPadding(androidx.compose.foundation.layout.WindowInsets.statusBars)` 不行，需要 import 完整：
+```kotlin
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+```
+
+### 7. ChatTheme data class 加 token 顺序敏感
+
+加 `isDark / topHaloCore / topHaloAlpha / bloomHeightFrac / heroSize/Weight/Letter / contextEmpty..High/Track / popoverBg` 都是在末尾 + default value，没破 4 个实例化（全命名参数）。**新加字段必须 default value + 加末尾**。
+
+### 8. drawerWidth 全屏算法
+
+之前手机端 `drawerWidth = 336.dp` 留右侧空隙。用户要全屏：
+```kotlin
+else -> windowAdaptiveInfo.width  // 手机端全屏覆盖
+```
+`windowAdaptiveInfo` 来自 `currentWindowDpSize()`，type 是 `WindowDpSize`，`.width` 直接是 Dp。
+
+### 9. 设计稿"思考了 N 秒"无 brain 图标
+
+我硬塞了 `HugeIcons.Brain02 14dp`，设计稿没有 → `icon = null`。同样 metaText "auto / ≤ 8K tokens" 不是右 extra slot，而是 inline 拼到主标签后面：`"思考了 5.4 秒 · auto"`。
+
+### 10. ChainOfThought 左线粗细 1dp 看不见
+
+底分屏 1dp 容易消失，**最少 2dp**。设计稿 spec `width: 2px` 也是 2dp。
+
+### 11. ToolResultPreview FakeBrowser 没真实数据
+
+用户反馈："实际用的时候本来就是会显示真实的网页内容的，不是一个虚假的" → mock 是 placeholder，真实接入后用 WebView/AsyncImage 替换。
+
+## 文件改动 git diff stat
+
+```
+新增（本 session）:
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ToolResultPreview.kt
+  docs/V3_HANDOFF_SESSION_2_2026-05-23.md (本文档)
+
+修改（核心）:
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt (V3 全量重构 + helpers)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt (drawerWidth 全屏 + onUpdateAssistant 接通 + ContextRing 真实数据 + 56dp fade scrim 已有 + 主题 bloomTarget)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListNormalSection.kt (showBloomInConvo 时 canvasAlpha 上限 0.85)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatTheme.kt (+ token isDark/topHalo/bloomHeight/hero/context/popover/WhisperTheme 显式 bloomHeightFrac)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ContextRing.kt (真实数据 + popup)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt (active 卡 + 段控 + provider 分组 + 紧凑布局 + chips 重设计)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/Select.kt → 实际是 ui/components/ui/Select.kt (胶囊 + 内容自适应)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceStyle.kt (浅色支接 scheme + 4 helpers Tone.Accent 跟主题)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/CardGroup.kt (12 → 18dp)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/UIAvatar.kt (+ showEditBadge param)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt (头部主题色 + 13sp + 无 brain icon + inline auto + thinkBodyInk + ReasoningTitle)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAskUserStep.kt (AskOptionChip 999 圆角 + 主题色 + 13.5sp + padding 8/14)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/ChainOfThought.kt (lineColor outlineVariant → thinkRule + stroke 2dp)
+  app/src/main/java/me/rerere/rikkahub/ui/components/richtext/SearchImageBlock.kt (aspectRatio 4:3 → 3:4)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt (SettingLeadingIcon 32/21 + 移 Select 硬宽)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt (圆角 hack 4/8 → 2/16)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt (极简 hairline 列表)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt (V3 2-flex tab + V3DetailTab helper)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentMemoryPage.kt (agents.md monospace)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalPage.kt (divider indent 46 → 60dp)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingWebPage.kt (Select 硬宽移除)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSandboxPage.kt (同上)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalModelCouncilPage.kt (同上)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentExecutionPage.kt (同上)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/SkillsPage.kt (stats card 18dp + 已启用 Accent + SkillCard 18dp + overflow menu + 仅 disabled pill + MCP→MCP)
+```
+
+## 真机截图记录
+
+```
+/tmp/p_paper_final.png      Paper 空白态 + 全屏暖纸
+/tmp/p_drawer_real_v3.png   Drawer V3 (Amber/搜索/3 nav/QuickRow/最近/footer)
+/tmp/p_drawer_full.png      Drawer 全屏覆盖（无右侧空隙）
+/tmp/p_drawer_clean.png     Footer 头像无铅笔徽标
+/tmp/p_settings_main.png    Settings 主页 Paper 暖色 + "颜色模式 跟随系统" 胶囊
+/tmp/p_skill_now.png        Skill 页 (stats card 18dp + 已启用 accent + skill 行)
+/tmp/p_picker.png           Model picker (Paper accentSoft 高亮 + 段控)
+/tmp/p_currstate.png        "Hi Arquiel, 今天想聊点什么？" hero 加昵称
+```
+
+## Subagent reviews 列表（保留供回溯）
+
+```
+1) Midnight composer shadow review (本 session 前)
+2) 设计稿对照 audit (Phase 4 → P0/P1/P2 punch list)
+3) 最终综合 review (4 套主题 token 完整性 + 7.5/10)
+4) 二级页面 V3 audit (Settings 主页/Display/Search/Memory/Execution/Provider/Skills audit 5.5/10)
+5) (隐式) 多次构建 review
+6) (隐式) ContextUsagePopup spec compliance
+```
+
+## 下个 session 优先级建议
+
+按 ROI:
+
+1. **(S) ResultPill 集成到 SearchImageBlock** — 在缩略图侧并排显示 status pill；需要从消息或 tool call 数据里抽 tool name / query / pagination
+2. **(M) ToolResultPreview FakeBrowser → 真实 web preview** — 接入 WebView/AsyncImage 渲染真实截图；需要 web-search-streaming pipeline
+3. **(M) SettingProviderConfigPage Field 平卡输入** — OutlinedTextField → V3 平卡 + 12dp 圆角 + hair border
+4. **(M) SettingModelPage hero + 辅助任务两段化** — chat model 提到 hero card + 辅助任务列表 hairline
+5. **(L) 真机切 Whisper / Plain / Midnight 全主题回归** — 各主题二级页 V3 alignment 验证
+6. **(L) WorkspaceTopBar 抽象 + 10 个 setting 页统一应用** — 22sp medium + 14dp padding + 32dp chevron + no elevation
+
+## 重要硬约束
+
+- 不 push，除非用户明确要求
+- 用户主 app `me.rerere.amberagent.notion` 不能被覆盖（refactortest 是独立 build variant）
+- AmoledDark 用户的纯黑省电选择不能被 chatTheme.bg 覆盖（已修，`useAmoledBlack` 标志）
+- dynamicColor 用户的 Material You 偏好不能被静默覆盖（已修，`shouldApplyChatTheme` 跳过 override）
+- adb install 卡死时换 `pm install` 绕过：
+  ```bash
+  adb -s 3B164901CEF00000 push <apk> /data/local/tmp/refresh.apk
+  adb -s 3B164901CEF00000 shell pm install -r -t /data/local/tmp/refresh.apk
+  ```
+
+## 恢复 Prompt（用于下个 session）
+
+```
+你接手 AmberAgent / RikkaHub Android Kotlin/Compose 项目的 V3 UI 重构 (session 3)。
+
+项目路径：
+/Users/arquiel/Downloads/AI/rikkashit/rikkahub
+
+行为准则（必读）：
+1. 用户原话："不能跟设计稿对齐吗？""我感觉实现的美感仍然很差很差"——说明对像素级还原要求高，认真比照设计稿，不要凭印象写
+2. 每次 build 必须验证 BUILD SUCCESSFUL 真假 (apk mtime 比 src 新)，hook 多次误报 exit 0 但实际失败
+3. 不 push，除非用户明确要求
+4. 不混入 deepread/today-board/template-workbench 等 V3 范围外的改动
+
+【第一步：读上 session 的 handoff doc】
+docs/V3_HANDOFF_SESSION_2_2026-05-23.md (本文档)
+docs/V3_REFACTOR_HANDOFF_2026-05-23.md (rev 1 + rev 2)
+
+【第二步：读设计原稿】
+/tmp/design-new/amberagent/project/*.jsx (themes / phone-screen / convo-* / model-picker / settings-* / provider-screens / convo-history)
+/tmp/amber-zip/ (原始 zip 解压，如 /tmp 被清重解压 /Users/arquiel/Downloads/AI/amberagent.zip)
+
+【第三步：确认 git 状态】
+git status --short
+git branch --show-current
+git log --oneline -8
+
+【当前 build 变体】
+buildType = refactortest
+applicationId = me.rerere.amberagent.refactortest（与主 notion 包并存）
+App 名 = "Amber Refresh"
+真机 = OPPO PMA110, 3B164901CEF00000
+
+【构建】
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home \
+  ./gradlew --offline -Pksp.incremental=false :app:assembleRefactortest
+
+# 必查 BUILD SUCCESSFUL 真假，比对 apk mtime 和 src mtime
+stat -f "apk: %m %Sm" app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk
+stat -f "src: %m %Sm" <last edited file>
+
+【装机】
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 push \
+  app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk /data/local/tmp/refresh.apk
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 shell \
+  pm install -r -t /data/local/tmp/refresh.apk
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 shell am force-stop me.rerere.amberagent.refactortest
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 shell am start -n me.rerere.amberagent.refactortest/me.rerere.rikkahub.RouteActivity
+
+【session 2 已完成的（按 handoff doc）】
+- Drawer V3 完整重构 (Amber/search/3 nav/QuickRow/最近/footer 32dp 头像无铅笔)
+- ModelList V3 重构 (active 卡内嵌段控 / provider 分组 hairline / 段集按 model 推断 / chips 重设计)
+- 思考展开 V3 (无 brain icon / 13sp accent / inline "auto" / 左竖线 thinkRule 2dp / body 13.5/inkSoft/1.7 lineHeight)
+- AskUserStep V3 (option 999 圆角 / 白底 hair border / 极淡阴影 / 13.5sp 字距 0.2)
+- ContextRing 真实 token usage + popup
+- ToolResultPreview standalone Composable (3:4 thumb + asymmetric padding + FakeBrowser mock + ResultPill)
+- SearchImageBlock 4:3 → 3:4
+- WorkspaceStyle 浅色支接 scheme (二级页自动跟主题)
+- WorkspaceTone.Accent 跟主题 (4 helpers)
+- Select 胶囊 + 主题色 + 内容自适应
+- CardGroup 18dp + LeadingIcon 32/21dp
+- SkillsPage V3 (stats card 18dp / 已启用 accent / overflow menu)
+- ProviderPage 极简 hairline 列表
+- ProviderDetailPage V3 2-flex tab
+- AgentMemoryPage agents.md monospace
+- 多页 12 处 Select 硬宽移除
+
+【未做（按 ROI 排）】
+1. (S) ResultPill 集成到 SearchImageBlock 边上 (数据层缺 tool/query/page，需挖)
+2. (M) ToolResultPreview 接真实 web 内容 (FakeBrowser 是 placeholder，等接入 web-search-stream pipeline)
+3. (M) SettingProviderConfigPage Field 平卡 (OutlinedTextField → 平卡)
+4. (M) SettingModelPage hero + 辅助任务两段化
+5. (L) Whisper / Plain / Midnight 全主题二级页回归
+6. (L) WorkspaceTopBar 抽象统一 10+ pages
+7. (L) Phase 3.5 model picker "adaptive auto" 按钮 (Claude 专属)
+
+【硬规则】
+- 不 push，除非用户明确要求
+- 不混入 V3 范围外改动
+- 每个 Phase 做完跑 Subagent review
+- 真机视觉验证 > 单元测试
+- adb install 卡死时换 pm install
+- 添加 ChatTheme token 必须 default value 加末尾，4 个 instance 全命名参数
+
+【硬约束保留】
+- 用户主 app me.rerere.amberagent.notion 不能被覆盖
+- AmoledDark 用户的纯黑省电选择不能被 chatTheme.bg 覆盖
+- dynamicColor 用户的 Material You 偏好不能被静默覆盖
+```
+
+## END

--- a/docs/V3_HANDOFF_SESSION_3_2026-05-24.md
+++ b/docs/V3_HANDOFF_SESSION_3_2026-05-24.md
@@ -1,0 +1,268 @@
+# V3 Refactor Handoff — Session 3 (2026-05-24)
+
+> 接续 `docs/V3_HANDOFF_SESSION_2_2026-05-23.md`。Session 3 主要做大量精修与 bug 修复：主题色全局贯通、组件双层嵌套消除、动画/律动调整、loading 体验、各类硬编码蓝色清扫。
+
+## TL;DR 当前状态
+
+| 项 | 状态 |
+|---|---|
+| Build variant | `refactortest`（applicationIdSuffix `.refactortest`） |
+| 包名 | `me.rerere.amberagent.refactortest` |
+| 真机 | OPPO PMA110，`3B164901CEF00000` |
+| 主分支 | `feature/chat-ui-refresh`（未 push） |
+| 最新 APK | `app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk` |
+| Subagent reviews | 本 session 没跑（直接迭代 + 真机验证） |
+
+## 本 session 完成 ✅
+
+### 设置页 / Provider 配置
+
+| 项 | 改动 |
+|---|---|
+| **SettingProviderConfigPage Field 平卡输入** | 新建 `FlatTextField` (Input.kt) 替换 14 处 OutlinedTextField。设计稿 spec: 12sp label 在上 + 12dp 圆角平卡 + hair border + 14.5sp ink + mono 字体支持 |
+| **SettingModelPage hero + 辅助任务两段化** | Chat hero 用 36/20 leadingIcon accent + 15sp/12.5sp + ModelSelector inline mode (22dp logo + 14.5sp accent + chevron-down)。辅助任务 ModelPickerRow 改 inline picker (padding start 42dp 对齐 leadingIcon 右边) |
+| **WorkspaceTopBar 抽象** | `WorkspaceStyle.kt` 末尾新增 `WorkspaceTopBar` (22sp Medium + 字距 0.3 + workspace.paper + scheme.primary 跟主题)。替换 ~15 个 setting page (含 SettingPage 主页 / Display / Model / Provider / Search / TTS / Sandbox / Web / Files / Mcp / AgentMemory / AgentExecution / AgentExtensions / AgentPermissions / SystemAccess / SlidesFont / About / ExperimentalModelCouncil / 等) |
+| **Provider 设置页 V3** | (1) 顶部 action icon `workspace.blue` → `scheme.primary`. (2) ProviderItem logo 双层嵌套 (圆角矩形 + 内圆形) 改单层 40dp CircleShape, AutoAIIcon(color=Transparent, size=28dp) 避免内置 Surface 圆形 bg 形成"双重圆环". (3) 启用/禁用对比加强: enabled = `accent 30% spot` (Paper 砖红 / Whisper 天蓝 / Plain 深灰 / Midnight 冷靛蓝) + row bg `accent 18% over surface`; disabled = transparent |
+| **WorkspaceSearchField 统一为 drawer Amber 下方风格** | CircleShape 999 + chatTheme.searchBarBg + 1dp hair border + HugeIcons.Search01 16dp inkSoft + 14.5sp inkFaint placeholder. Provider 页 / SettingSearch 页 / Model picker 内搜索都改用同款 |
+| **Model picker 优化** | (1) 字号 13.5 → 12.5sp + lineHeight 16 → 15sp. (2) 删 V3CapabilityIcons (chat/text/tool/AI 图标行没意义). (3) 选中区分裂修复: 把 `combinedClickable` 从 Card 内 Column 移到 Card 外层 modifier. (4) 底部 provider chip 三层嵌套 → CircleShape capsule + AutoAIIcon(color=Transparent) 16dp + 12.5sp text 单层. (5) reasoning segment 高度压缩: 外 padding 2→1.5dp, 内段 vertical 2→1dp, 字号 11→10sp + lineHeight 12sp |
+| **Model picker 双击关闭** | 点非 active model → 切换 model 但保持 picker 开 (让用户顺手改 reasoning level); 点已 active model → 关闭 picker |
+| **Claude adaptive auto** | `reasoningLevelsForModel` Claude 段集加 auto: `auto/low/med/high/xhigh/max` (6 段). ClaudeProvider 已映射 AUTO → thinking.type=adaptive |
+| **子代理实验"限制" Select 右对齐** | `SubAgentSelectRow` Select 去掉 `width(112.dp)` 硬约束, Select 自适应内容 + weight(1f) Text 撑开后自动靠 row 右端 |
+| **颜色模式下拉"跟随系"截断修复** | strings.xml 中文 (zh + zh-rTW) `_light` → "浅色模式" / `_dark` → "深色模式" (跟"跟随系统"齐 4 字) + Select.kt DropdownMenuItem `softWrap = false` + `widthIn(min = 140.dp)` |
+| **隐藏 Web 服务器入口** | SettingPage 用 `val SHOW_WEB_SERVER = false` 守护, 改 true 恢复 |
+| **聊天主题切换器** | SettingDisplayPage 把"Notion style"项重写: headline "聊天主题" + supportingContent `WorkspaceSegmentedChoice(微光/素白/暖纸)`. 删除下面重复的"聊天主题 (V3)" FilterChip 项 |
+| **WorkspaceSegmentedChoice 胶囊化** | 外 6dp 圆角 + 内 4dp 圆角 → 两层都 CircleShape. 启动入口 / 聊天主题切换 一并变胶囊 |
+| **飞书办公"保存包名" + "已就绪" pill 蓝色** | `ExperimentActionButton` primary 容器 `workspace.blue` → `scheme.primary`; `ExperimentBooleanPill` ready 态 `workspace.blue` → `scheme.primary/primaryContainer` |
+| **Skill 详情加号按钮蓝色** | `WorkspaceIconButton(tone=Accent)` 删 `containerColor = colors.blueContainer` 硬编码, 让 tone 自己映射 scheme |
+| **奥黛门 / 显示设置主题色全局** | Theme.kt `themedColorScheme` 加 `surfaceBright = chatTheme.containerHighest` + `surfaceDim = chatTheme.containerLowest`. dynamicLight 不再给浅蓝 tinted |
+
+### Chat 流 / 消息渲染
+
+| 项 | 改动 |
+|---|---|
+| **User message 隐藏头像 + 长按弹菜单** | `ChatMessage.kt` USER 分支用 `val SHOW_USER_AVATAR = false` + `val SHOW_USER_ACTION_BUTTONS = false` 守护; user bubble Surface 改 `combinedClickable(onClick=edit, onLongClick=openSheet)` |
+| **ChatMessageActionsSheet 改造** | 加 `onCopy` + `onRegenerate` 行 (复制 / 重试); 删除"网页视图渲染" (`onWebViewPreview`) 项 |
+| **Assistant avatar 固定 "Amber"** | ChatMessageAvatar 把 `model.displayName` 替成 `"Amber"` 固定字符串 |
+| **思考展开 V3** | (1) ChainOfThought wrapper Card 改 `Color.Transparent + 0 elevation + 0 padding` 取消外框. (2) 加 `drawTimeline: Boolean = true` 参数, 多 step 链条 (含 tool steps) 时调用方传 false, 不画 wrapper 竖线避免工具串. (3) Reasoning 加 brain icon (Brain02 14dp accent) + `flushContent=true` 让 content 起始 X 跟 step icon center 对齐 (12dp). 删 ReasoningContent 内部 drawBehind 引用竖线 (依赖 wrapper timeline). icon 后面遮挡 bg 用 `scheme.background` 而非 LocalCardColor (透明时遮挡失效 bug). step content 加 `AnimatedVisibility(expand + fadeIn / shrink + fadeOut)` 过渡 |
+| **AgentToolCallCapsule V3 比例** | `fillMaxWidth()` → `wrapContentWidth + widthIn(max=460dp)` 自适应宽度; 删除右侧 "失败" status pill (左侧 16dp red X badge 已表达); padding 3/10/3/3 (~22dp 高); 11.5sp letter 0.2 W500/W400 |
+| **AskUserStep V3** | 已在 session 2 完成, session 3 维持 |
+| **SandboxPeekBar V3** | (1) 缩略图 118×78 4:3 → 72×96 3:4. (2) 状态条 10dp 圆角矩形 → CircleShape 胶囊 + 3/10/3/3 padding + 11.5sp/10.5sp text + 9dp chevrons. (3) Status badge 20dp → 16dp accent 圆 + 10dp 白勾. (4) 父级 spacedBy 8 → 2dp 让卡片紧贴 composer. (5) 字号再压: 10.5 / 9.5sp |
+| **Composer pill** | (1) 圆角 CircleShape → RoundedCornerShape(38dp) (= 76/2 单行 SendOrb 撑起的高度的一半, 保持单行完美半圆胶囊, 多行扩高时不再变更圆). (2) 高度 fix 68dp → heightIn(min=60dp) 允许多行扩展. (3) 左右 padding 12dp (跟屏幕边线留 12dp). (4) TextField `.absoluteOffset(x=-8dp)` + Row padding(start=8) + spacedBy(0) 让光标位置左移 ~20dp 抵消 M3 TextField 内置 16dp content padding |
+| **深色阴影修复** | composer Surface `Modifier.shadow` ambient/spot 在深色下强制 Color.Black, 避免 default 白色 shadow 在 Midnight 上扩散成"白晕". border 改顶 5% 底 16% 白模拟落地下沉感 |
+| **欢迎语两行** | `"Hi $nick，\n今天想聊点什么？"` + lineHeight 1.4f + Center align |
+| **底部 NerdLine 隐藏** | `val SHOW_NERD_LINE = false` 守护两处 (ChatMessage / ChatMessageVirtualItems), token 数 / cached / tok/s / 2.3s 整行不显示 |
+| **翻译按钮隐藏** | `val SHOW_TRANSLATE = false` 守护 (ChatMessageActionButtons) |
+| **SearchImageBlock 3:4** | (session 2 已改 4:3 → 3:4, session 3 维持) |
+| **Blockquote 灰蒙层 bug** | Markdown.kt / MarkdownNew.kt 两处 `drawWithContent` (bg 画在 content 之上盖住文字) → `drawBehind` (bg 在文字后). alpha 0.2 → 0.12 减轻蒙层感 |
+| **Markdown 黑字 bug** | Theme.kt CompositionLocalProvider 加 `LocalContentColor provides themedColorScheme.onSurface`. M3 默认 LocalContentColor = Color.Black, 没 Surface 包裹时深色模式黑字看不见 |
+
+### Drawer / TopBar / ContextRing
+
+| 项 | 改动 |
+|---|---|
+| **Drawer 圆角** | `drawerShape` 0dp 直角 → `RoundedCornerShape(topEnd=24dp, bottomEnd=24dp)` 右侧圆角 |
+| **"最近" section label** | 跟 V3NavRow accent=true 同款: HugeIcons.Time02 19dp accent + 15sp Medium accent + 字距 0.2 |
+| **TopBar 模型名 ⌄ 移除 + ripple 胶囊** | ModelSelector minimalText 模式删 `Text("⌄")` chevron, Row 加 `clip(CircleShape).clickable.padding(12h,6v)` ripple 跟随胶囊 |
+| **抽屉按钮 / 新聊天按钮 / ContextRing ripple 圆形** | `Box(.size(36dp).clip(CircleShape).clickable)` ripple 跟随圆形 |
+| **ContextRing 白色 bug** | Midnight `contextEmpty` 默认 0xFFD6D9DE 浅灰在深底变白. override `contextEmpty = 0x38E8EAEF` (跟 contextTrack 同色) |
+| **ContextRing popup 改进** | (1) width 290 → 260dp (左边不顶屏幕边). (2) 5h/周额度行守护 `quotaSupported = false` 默认隐藏 (大部分 model 没限额查询). (3) 底部 meta strip 从 Row 横排改 Column (label 上 / value 下) + Row SpaceBetween, 避免"速度"换行. (4) 删菱形箭头 (rotate 45° square 没遮住下半看着像奇怪对话框勾). (5) 加 popup 出场动画 `Animatable(0→1) tween(180ms) + fadeIn + scale 0.94→1` + transformOrigin (92%, 0) 从 ring 位置扩开 |
+
+### 输入法 / 命令 / 互动
+
+| 项 | 改动 |
+|---|---|
+| **TextField 圆角 + 半圆胶囊** | composerShape `RoundedCornerShape(38.dp)` = 单行 76/2 半圆胶囊; 多行扩高时半径固定不再变圆 |
+| **SendOrb 呼吸增强** | outerScale 0.85↔1.50 / outerAlpha 0.40↔0.90 / innerScale 0.95↔1.30 / innerAlpha 0.65↔1.0 (比原振幅大). Paper sendHalo 砖红 alpha 50% (`0x80B5683A`) 适中清淡 |
+| **Bloom 律动增强** | (session 中改了又改, 当前 radiusBreath 0.92↔1.05 / alphaBreath 0.88↔1.12 未提交改大版本, 留待 session 4 fine-tune) |
+| **Session 切换 spinner** | (尝试过多种方案, 最终撤了 overlay. 当前 hero block 用 `!timelineLoadState.initialized → 居中 spinner / initialized=true && messageNodes empty → hero`. bloom 加 `!initialized → 锁定对话态低值` 避免切换瞬间 messageNodes 空快照触发 bloom 误升) |
+| **斜杠命令面板 Popup 化** | (1) `SlashCommandPanel` 用 `Popup + 自定义 PopupPositionProvider` 浮在 composer 上方, 不占布局空间. y = anchor.top - panel.height - 8dp gap; x = 屏幕居中 = composer 左右齐平. (2) 显示条件 `isFocused && slashQuery != null` → `slashQuery != null` (点 / 按钮 append 后即弹, 不依赖 TextField 获焦). (3) width = `LocalConfiguration.screenWidthDp - 24.dp` 跟 composer 横向齐平. (4) border `workspace.hairline (12% ink)` → `chatTheme.surfaceEdge (5% ink)` 更细; shape 10dp → 14dp; shadow 1dp → 8dp |
+| **"编辑中" 框隐藏** | `val SHOW_EDITING_BANNER = false` 守护 (硬编码蓝色 + 顶 composer 内部) |
+| **斜杠图标主题色** | SlashCommandRow 内嵌图标 `workspace.blueContainer/blue` → `scheme.primaryContainer/primary`; SlashCommandLeadingMark 同改 |
+| **发送按钮左侧 `/` 跟字体** | Canvas 画 line 改 `Text("/")` 字符, 跟 SlashCommandLeadingMark 同字体, 角度一致 |
+| **Heatmap 主题色** | StatsPage `HeatmapGridCanvas` + `HeatmapCell` 改用 `LocalChatTheme.current.accent` + `toolPillBg` 替代 `MaterialTheme.colorScheme.primary/surfaceVariant` (即便 dynamicColor 开 Material You 也跟主题) |
+| **agents.md/soul Card 蓝底** | SettingAgentMemoryPage Card colors 强制 `chatTheme.surface` 替代 `CustomColors.cardColorsOnSurfaceContainer` |
+| **MessageJumper 浮卡** | border `outlineVariant@60% (粗黑勾边)` → `chatTheme.surfaceEdge` 极淡; 加 `Modifier.shadow(elevation=8dp, ambient/spot = composerShadow)`, 关闭 tonalElevation. divider 用 chatTheme.hair, icon tint chatTheme.inkSoft |
+
+## 本 session 未完成 / 待 session 4 ⏳
+
+| 项 | 状态 |
+|---|---|
+| **Bloom 律动幅度** | session 中改了 radiusBreath 0.78↔1.25 / alphaBreath 0.55↔1.30 但被 reverted. 用户希望"更明显"的呼吸. 待 session 4 重新调 |
+| **Provider 组卡内 model 行左侧分界小缺口** | 用户提到但没看代码定位. ProviderGroup wrapper 的 hairline divider 缩进可能不对齐 |
+| **Editing banner 真正修复** | 目前是 `SHOW_EDITING_BANNER = false` 整块隐藏. 长期方案应当: hoist 状态到父级让它浮在 composer 之上 + 改主题色 |
+| **真机三主题回归** | 当前主要在 Paper 主题验证. Whisper / Plain / Midnight 全主题二级页 alignment 没系统跑完 |
+| **WorkspaceTopBar 抽象统一** | 已替换 ~15 页, 但还有些边缘页 (SettingExperimentalOfficeProPage / SettingExperimentalSubAgentPage / SettingExperimentalModelCouncilPage 内部 SubAgent / Council 等) 没替换. 各 page 子页面 (SettingProviderConfigPage 等) 也没替换 |
+| **ResultPill 集成到 SearchImageBlock 边** | session 2 留下的 (S) 任务. 数据层缺 tool/query/page 字段, 没接 |
+| **ToolResultPreview FakeBrowser → 真实 web 内容** | session 2 留下的 (M) 任务 |
+| **SettingProviderConfigPage Field 平卡** | session 3 已用 FlatTextField 替换 OutlinedTextField. 但 GoogleAuth OAuth / Codex OAuth 子表单内部还有 Checkbox / SegmentedButton 等没动 V3 化 |
+| **SettingModelPage hero + 辅助任务两段化** | 改了 inline picker 但内部细节 (icon padding / chip 样式) 没全 align 设计稿 |
+
+## 踩过的坑（务必记住）
+
+### 1. M3 TextField 不可直接修改 content padding
+M3 state-based `TextField` 内置 16dp horizontal content padding 无法通过 API 改. 想压缩光标位置只能:
+- 减外层 Row padding + spacedBy
+- 用 `Modifier.absoluteOffset(x=(-N).dp)` 视觉左移 TextField (不影响布局尺寸, 不会跟旁边元素重叠)
+
+### 2. M3 LocalContentColor 默认 Color.Black
+没有 Surface 显式提供 contentColor 时 LocalContentColor = `Color.Black`. 深色主题下 ChatPage 直接调 MarkdownBlock 的无 bubble 路径会黑字看不见.
+**修复**: Theme.kt CompositionLocalProvider 显式 `LocalContentColor provides themedColorScheme.onSurface`.
+
+### 3. `drawWithContent` 把 bg 画在 content 之上
+Markdown.kt / MarkdownNew.kt 的 BlockQuote 用 `drawWithContent { drawContent(); drawRect(bg, ...) }` —— 先画文字再画灰矩形覆盖. **改 `drawBehind`** 让 bg 画在 content 之后.
+
+### 4. CircleShape 在 Surface 高度变化时半径 = 高度/2
+Composer pill 多行扩高时 CircleShape 越变越圆. 用 `RoundedCornerShape(N.dp)` 固定半径让单行 = height/2 = 完美半圆, 多行扩高时圆角不变.
+
+### 5. AutoAIIcon 内置 Surface 圆形 bg
+AutoAIIcon 内部用 `Surface(shape = avatarShape, color = secondaryContainer)` 画品牌 logo. 外层再包圆形 bg → "双重圆环". 传 `color = Color.Transparent` 让内层 Surface 透明.
+
+### 6. ChainOfThought icon 后面遮挡 bg = LocalCardColor
+原代码 icon Box.background(LocalCardColor.current) 遮挡 wrapper timeline 竖线. 我把 cardColors.containerColor 改透明后 LocalCardColor 也透明 → 竖线穿过 icon. **修复**: `maskColor = if (transparent) scheme.background else cardColors.containerColor`.
+
+### 7. ChainOfThoughtScope interface 加参数需要同步 override
+加 `flushContent` 参数到 `ControlledChainOfThoughtStep` interface + impl 必须同步, 否则 override 错配.
+
+### 8. Popup + AnimatedVisibility 不兼容
+Popup 不在 layout 树, AnimatedVisibility 包它无效. 想给 Popup 加入场动画用 `Animatable(0→1) + graphicsLayer { alpha; scale; transformOrigin }`.
+
+### 9. Loading overlay 越改越烂
+试过 spinner overlay + animation 衔接, 引入多次闪烁. 最终撤回, 只在 hero block 加 `!initialized → spinner / initialized + messageNodes empty → hero / messageNodes non-empty → ChatList`. 简单方案最优.
+
+### 10. Bloom 误升 bug
+切换 conversation 瞬间 messageNodes 空快照, bloomTarget 误判为"空白态"开始 700ms 渐变到 1.0, messageNodes 填充后又反向. **修复**: bloomTarget 加 `!initialized → 锁定对话态低值`.
+
+### 11. Slash panel 浮位置 + focus 双 bug
+(1) panel 在 TextInputRow Column 内顶起 composer pill (占布局空间). 用 Popup + 自定义 PopupPositionProvider 浮在上方.
+(2) 点 / 按钮 append "/" 不让 TextField 获焦. 把 `slashVisible = isFocused && slashQuery != null` 改 `slashQuery != null`.
+
+### 12. dropdown menu width = anchor width
+M3 ExposedDropdownMenu 默认 width = anchor width. 短 anchor ("浅色" 60dp) → dropdown item ("跟随系统" 80dp) 被截. **修复**: 用 strings "浅色模式" / "深色模式" 让 anchor 拉长; 也给 DropdownMenuItem 加 `softWrap=false + widthIn(min=140dp)` 兜底.
+
+### 13. Build hook 误报 exit 0 但 BUILD FAILED
+延续 session 2 教训, 必须验证 `BUILD SUCCESSFUL` + APK mtime > src mtime.
+
+## 关键文件改动
+
+```
+新增（本 session）:
+  docs/V3_HANDOFF_SESSION_3_2026-05-24.md (本文档)
+
+主要修改:
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+    (composer CircleShape→RoundedCornerShape, heightIn min 60dp, padding 12dp,
+     TextField absoluteOffset -8dp, send button shadow 深色 Color.Black,
+     "/" 按钮 Canvas line → Text("/"), MessageJumper 浮卡 shadow + surfaceEdge)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputComposers.kt
+    (Editing banner 隐藏, SlashCommandPanel Popup 浮于 composer 上方,
+     SlashCommandRow + LeadingMark 主题色, slashVisible 去 isFocused 条件)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputSandbox.kt
+    (SandboxPeekBar 72×96 3:4 缩略图 + CircleShape 胶囊状态条 +
+     16dp accent 圆 + 10.5/9.5sp text + 紧贴 composer)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
+    (字号 12.5sp / 删 V3CapabilityIcons / Card clickable 移外层 /
+     底部 provider chip 单层 CircleShape / Claude auto / 双击关闭 /
+     reasoning segment 高度压缩 / 模型 picker 搜索改 WorkspaceSearchField)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
+    (USER avatar 隐藏 / actions 行隐藏 / NerdLine 隐藏 / Sheet 加 onCopy + onRegenerate)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+    (Sheet 加 copy + regenerate row, 删 onWebViewPreview row, 翻译按钮隐藏)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAvatar.kt
+    (model.displayName 固定 "Amber")
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageMessagePartsBlock.kt
+    (user bubble combinedClickable long-press → sheet, DisableSelection 屏蔽系统 ActionMode,
+     ChainOfThought drawTimeline = isReasoningOnlyBlock)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
+    (brain icon + flushContent=true + 删除 ReasoningContent 内部 drawBehind 竖线)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+    (AgentToolCallCapsule wrapContentWidth + 删失败 pill + V3ToolLeadingBadge)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageVirtualItems.kt
+    (NerdLine 隐藏 + Sheet 加 onCopy/onRegenerate)
+  app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+    (BlockQuote drawBehind 修复)
+  app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
+    (HtmlBlockquote drawBehind 修复)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/ChainOfThought.kt
+    (Card transparent + drawTimeline param + flushContent param + maskColor 修复 +
+     AnimatedVisibility content expand)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/Input.kt
+    (新增 FlatTextField — V3 平卡输入)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/Select.kt
+    (DropdownMenuItem softWrap=false + widthIn min 140dp)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceSearchField.kt
+    (drawer Amber 下方风格: 999 capsule + chatTheme.searchBarBg + HugeIcons.Search01)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ui/WorkspaceStyle.kt
+    (WorkspaceTopBar helper + Tone.Accent 用 scheme.primary)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+    (drawerShape 右侧 24dp 圆角 + "最近" label V3NavRow accent 风格)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListSubViews.kt
+    (MessageJumper 浮卡 surfaceEdge + shadow 8dp)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+    (TopBar ripple 圆形 + 欢迎语两行 + bloom !initialized 锁低值 + spinner hero block 共存)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatTheme.kt
+    (Midnight contextEmpty override + Paper sendHalo 0x80B5683A)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ContextRing.kt
+    (260dp panel + ripple 圆形 + meta strip 列 + popup 入场动画 + 删菱形箭头)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/SkillDetailPage.kt
+    (加号按钮去硬编码 blueContainer)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+    (Notion style → 聊天主题切换器 + WorkspaceSegmentedChoice 胶囊)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalPage.kt
+    (ExperimentActionButton + ExperimentBooleanPill scheme.primary)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingExperimentalSubAgentPage.kt
+    (SubAgentSelectRow Select 自适应宽度)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
+    (chat hero + ModelSelector inline + WorkspaceTopBar)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+    (WorkspaceTopBar + 隐藏 Web 服务器)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt
+    (WorkspaceTopBar + ProviderItem 单层 logo + enabled/disabled accent 区分)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingAgentMemoryPage.kt
+    (soul Card 强制 chatTheme.surface 避免蓝底)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
+    (14 处 OutlinedTextField → FlatTextField)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsPage.kt
+    (heatmap 改 chatTheme.accent + toolPillBg, 强制跟主题)
+  app/src/main/java/me/rerere/rikkahub/ui/theme/Theme.kt
+    (themedColorScheme 加 surfaceBright/Dim + LocalContentColor provides onSurface)
+  app/src/main/res/values-zh/strings.xml (浅色模式 / 深色模式)
+  app/src/main/res/values-zh-rTW/strings.xml (淺色模式 / 深色模式)
+  + ~15 个 setting page 同步用 WorkspaceTopBar 替换 TopAppBar
+```
+
+## 重要硬约束（延续）
+
+- 不 push，除非用户明确要求
+- 用户主 app `me.rerere.amberagent.notion` 不能被覆盖（refactortest 是独立 build variant）
+- AmoledDark 用户的纯黑省电选择不能被 chatTheme.bg 覆盖（已修，`useAmoledBlack` 标志）
+- dynamicColor 用户的 Material You 偏好不能被静默覆盖（已修，`shouldApplyChatTheme` 跳过 override）
+- adb install 卡死时换 `pm install` 绕过
+
+## 构建/装机命令
+
+```bash
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home \
+  ./gradlew --offline -Pksp.incremental=false :app:assembleRefactortest
+
+# 验证: BUILD SUCCESSFUL 真假 + apk mtime > src mtime
+stat -f "apk: %m %Sm" app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk
+stat -f "src: %m %Sm" <last edited file>
+
+# 装机:
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 push \
+  app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk /data/local/tmp/refresh.apk
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 shell pm install -r -t /data/local/tmp/refresh.apk
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 shell am force-stop me.rerere.amberagent.refactortest
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 shell am start -n me.rerere.amberagent.refactortest/me.rerere.rikkahub.RouteActivity
+```
+
+## 用户协作偏好（从本 session 摸出来的）
+
+- "不要直接动手做": 重大方向决策先列方案让用户选, 不要直接 implementation
+- "保留代码不删除": 用户希望隐藏 feature 用 `val SHOW_X = false` 守护, 改 true 即恢复
+- 像素级对齐: "我感觉实现的美感仍然很差很差" / "不能跟设计稿对齐吗?" → 认真对照原稿
+- 严禁硬编码 workspace.blue / blueContainer 等: 必须跟主题 `scheme.primary / chatTheme.accent`
+- 双层嵌套 = 反模式: 用户反复指出"框中框", 始终单层
+- 律动 / 动画 / 阴影都要"有感觉但不突兀": 调到中间值
+
+## END

--- a/docs/V3_REFACTOR_HANDOFF_2026-05-23.md
+++ b/docs/V3_REFACTOR_HANDOFF_2026-05-23.md
@@ -1,0 +1,345 @@
+# V3 Refactor Handoff — 2026-05-23 (rev 2)
+
+> rev 2 (本 session 续): Paper 全屏暖纸色修复 / Select 胶囊主题色 / ContextRing usage panel popup
+> / 4 项 P1 S 修复 / workspaceColors 浅色支跟主题。详见底部"rev 2 改动"。
+
+
+
+> Amber Refresh UI 重构（Anthropic Design "Refined Chat Screens" V3 设计稿）。
+> 本文档作为下个 session 的接续入口，覆盖：当前状态 / 已完成 / 设计依据 / 测试方法 / 待办。
+
+## TL;DR
+
+| 项 | 状态 |
+|---|---|
+| Build variant | `refactortest`（applicationIdSuffix `.refactortest`，与主 `notion` 变体并存） |
+| 包名 | `me.rerere.amberagent.refactortest` |
+| App 显示名 | "Amber Refresh"（`app/src/refactortest/res/values/strings.xml`） |
+| 真机 | 用户 OPPO PMA110，`3B164901CEF00000` |
+| 安装命令 | 见下面 [构建 / 安装](#构建--安装) |
+| 主分支 | `feature/chat-ui-refresh`（基于 main，未 push） |
+| 设计稿位置 | `/tmp/design-new/amberagent/` (新版 README + chat 对话稿) 与 `/tmp/amber-design/` (旧版 jsx 包) |
+| 设计 chat 对话稿 | `/tmp/design-new/amberagent/chats/chat1.md` —— **强烈建议读** |
+| Subagent reviews | 共 4 次（Phase 1 / Phase 2+3 / Phase 4 迁移 / colorScheme override） |
+
+## 构建 / 安装
+
+```bash
+# 构建（refactortest 变体，会带 .refactortest 包名后缀）
+JAVA_HOME=$HOME/.gradle/jdks/jetbrains_s_r_o_-21-aarch64-os_x.2/jbrsdk_jcef-21.0.10-osx-aarch64-b1163.110/Contents/Home \
+  ./gradlew --offline -Pksp.incremental=false :app:assembleRefactortest
+
+# adb install 在 OPPO PMA110 上会卡在 "通过 USB 安装" 确认框（看不到原因 / 不超时）。
+# **绕过：先 push 到 /data/local/tmp/ 再用 pm install**
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 \
+  push app/build/outputs/apk/refactortest/app-arm64-v8a-refactortest.apk /data/local/tmp/refresh.apk
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 \
+  shell pm install -r -t /data/local/tmp/refresh.apk
+
+# 启动
+/Users/arquiel/Library/Android/sdk/platform-tools/adb -s 3B164901CEF00000 \
+  shell am start -n me.rerere.amberagent.refactortest/me.rerere.rikkahub.RouteActivity
+```
+
+**注：PMA110 手势导航对 swipe / back 行为有干扰；远程 input tap/swipe 测主题切换会把 app 切到后台**。截图测试建议让用户手动操作。
+
+## 设计稿来源
+
+```text
+/Users/arquiel/Downloads/AI/amberagent.zip        ← 用户提供的离线包，已解压到 /tmp/amber-design/
+WebFetch design URL 拿到的 5.8MB gzip 二进制       ← 解压到 /tmp/design-new/amberagent/
+```
+
+两份内容大致一致，**新版包额外有**：
+- `amberagent/chats/chat1.md` (97KB) ——记录设计迭代的完整对话稿，包含所有 UI 决策的 WHY
+- `amberagent/README.md` —— 明确说"先读 chat1.md"
+- `themes.jsx` 仅微小更新（`popoverBg` for Midnight）
+
+**关键 jsx**：
+- `themes.jsx` — Whisper / Plain / Paper / Midnight 4 套 token
+- `phone-screen.jsx` — 空白态 header / hero / composer / send orb
+- `convo-screen.jsx` + `convo-user.jsx` + `convo-agent.jsx` + `convo-tool-result.jsx` — 对话页所有元素
+- `model-picker.jsx` — 模型选择 bottom sheet (active card + thinking-level segment + provider chips)
+
+## 关键设计决策（chat1.md 摘要）
+
+1. **空白态**：早期有 AmberMark 几何宝石 → user "算了去掉吧" → **最终只剩居中问候**（无图标）
+2. **底部蓝光晕** Whisper：Gemini 风格冷蓝雾，**对话页完全去掉**，纯白底
+3. **送按钮**：早期玻璃质感 → user "有点丑，不要玻璃" → **纯色圆 + 双层呼吸光晕**
+4. **用户气泡**：早期蓝灰底 + 18px 圆角 → 不对称圆角 → **borderRadius 999 capsule** + `#F2F4F7` 灰
+5. **对话页色彩降为点缀**：Whisper "蓝光晕去掉"、Plain 黑胶囊改灰、Paper 保留极淡暖光、Midnight 蓝光降到 1/3
+6. **新建按钮**：phone-screen.jsx 注释明确 "**naked compose icon — no surrounding circle**"
+7. **斜杠按钮**：SVG line (7,19)→(17,5)，约 54° 角，不是字符 `/`
+8. **composer 阴影**：`0 1px 2px rgba(15,20,25,0.04), 0 10px 32px rgba(15,20,25,0.08)` 双层墨灰，必须同时存在（单层都不够"浮"）
+9. **不要麦克风**：phone-screen.jsx 早期版本有 mic，最终版**没有 mic**，斜杠按钮取代
+
+## 已完成 ✅
+
+### Phase 1 · Whisper 空白态主视觉
+| File | 改动 |
+|---|---|
+| `WhisperHalo.kt` (新建) | 主题色 token (`ChatTheme.kt` 替代) + `WhisperBottomBloom` Canvas 动态光晕 |
+| `SendOrb.kt` (新建) | 48dp 圆球 + 双层呼吸光晕（外 3.6s / 内 2.8s） |
+| `ChatPage.kt` | TopBar: hamburger 三长短 + 模型名 + chevron + naked compose icon |
+| `ChatPage.kt` | Surface 改 Box(.background(paper)) 强制 z-order，让 bloom 透到 chat content |
+| `ChatPage.kt` | EmptyChatHero: 居中"今天想聊点什么？"（无宝石） |
+| `ChatListNormalSection.kt` | 空白态时 background = Transparent，让 bloom 透上来 |
+| `ChatInput.kt` | composer pill: 68dp CircleShape + naked compose + 双层 elevation shadow + 5% surfaceEdge + SVG slash glyph |
+
+### Phase 1.x · Bloom 多次迭代
+| 用户反馈 | 改动 |
+|---|---|
+| "蓝色太灰像雾霾" | core color #78AAF0 → #7AC0FF（Gemini 同色系，更饱和） |
+| "范围太大不要超过半屏" | center y = h*1.0、radius = h*0.30，限到底部 1/3 |
+| "一会左白一会右白" | 重写：基础蓝层居中 + 不漂移，3 个 ripple 高光斑叠加做波纹流动 |
+| "硬切看不到淡出" | `animateFloatAsState` tween 700ms FastOutSlowInEasing 让 empty→convo bloom 淡出 |
+| "对话态灰白分界线" | ChatListNormalSection bg 用 `paper`（白）而非 `canvas`（off-white #F7F7F5） |
+
+### Phase 2 · 对话页视觉
+| Element | File | 改动 |
+|---|---|---|
+| User bubble | `ChatMessageMessagePartsBlock.kt:215` | CircleShape + `#F2F4F7` + 1px 极淡边 + 18/10 padding + 取消左蓝条 |
+| Tool pill | `ChatMessageTools.kt:335 AgentToolCallCapsule` | 灰底胶囊 + sky-blue wrench + V3 完成 badge（蓝填充圆+白勾） |
+| Agent header | `ChatMessageAvatar.kt:130` | 6dp 绿点 + 模型名（取代 32dp provider 图标） |
+| Thinking strip body | `ChatMessageReasoning.kt:205 ReasoningContent` | 左 2dp sky-blue 竖线 (drawBehind) + dim 文字 + 取消 Surface card |
+| Context ring | `ContextRing.kt` (新建) | 22dp donut + 4 阈值色 (gray/blue/amber/red) + leading head dot |
+| ChatPage TopBar 右侧 | `ChatPage.kt:1320` | 仅 hasMessages 时显 ring |
+
+### Phase 3 · 模型选择 sheet
+| File | 改动 |
+|---|---|
+| `ModelList.kt:254 ModalBottomSheet` | shape topStart/topEnd 28dp + containerColor = surface + 36×4dp 自定义 drag handle + sheetBackdrop scrim |
+| `ModelList.kt:761 ModelItem` | active 卡片 accentSoft + accent 文字 + edge 高亮；非 active surface + ink + 1px hair border |
+| `ModelList.kt:798 provider icon` | toolPillBg + 1px hair border 圆角 10dp |
+
+### Phase 4 · 4 主题切换基建
+| File | 改动 |
+|---|---|
+| `ChatTheme.kt` (新建) | `data class ChatTheme` 含 47 个 token + 4 instance (WhisperTheme / PlainTheme / PaperTheme / MidnightTheme) + `LocalChatTheme` static CompositionLocal |
+| `Theme.kt:200` | `LocalChatTheme provides chatTheme`，浅色读 `displaySetting.chatThemeChoice`，深色强制 Midnight |
+| `WhisperHalo.kt` | bloom 从 LocalChatTheme 读 `bloomCore/Secondary/Highlight/bloomMaxAlpha` |
+| `SendOrb.kt` | 送按钮 从 LocalChatTheme 读 `sendBg/sendArrow/sendHalo` |
+| 6 个 chat 文件 | `WhisperTokens.X` → `LocalChatTheme.current.X` 批量迁移（`ChatPage.kt` / `ChatMessageAvatar.kt` / `ChatMessageReasoning.kt` / `ChatMessageTools.kt` / `ChatMessageMessagePartsBlock.kt` / `ModelList.kt`） |
+| 真机验证 | 系统深色模式自动切到 Midnight（截图 `/tmp/p30_midnight.png`） |
+
+### Phase 4.5 · 用户主题切换 UI
+| File | 改动 |
+|---|---|
+| `PreferencesStore.kt:DisplaySetting` | 新增 `chatThemeChoice: String = "WHISPER"` 字段（向后兼容，缺省解码到默认值） |
+| `SettingDisplayPage.kt:327` | 新增"聊天主题 (V3)"item，3 个 `FilterChip` (微光 / 素白 / 暖纸) |
+| `Theme.kt:200` | 读 `settings.displaySetting.chatThemeChoice` 选 Whisper/Plain/Paper；深色仍 Midnight |
+
+### Phase 4.6 · MaterialTheme.colorScheme override（二级页面自动主题）
+**核心**：所有用 `MaterialTheme.colorScheme` 的二级页面（Settings / Providers / History / Tablet）自动跟随聊天主题，无需逐文件迁移。
+
+`Theme.kt:218 themedColorScheme` override 字段：
+```
+background = bg
+onBackground = ink
+surface = paper
+onSurface = ink
+surfaceVariant = toolPillBg
+onSurfaceVariant = inkSoft
+surfaceContainerLowest / Low / Mid (= surfaceContainer) / High / Highest  (5 级 hierarchy)
+surfaceTint = accent
+primary = accent
+onPrimary = onAccent           ← Subagent #3 修复：Midnight 用 #0B0E14 深字
+primaryContainer = accentSoft
+onPrimaryContainer = accentDeep
+secondary = accent
+secondaryContainer = accentSoft
+onSecondaryContainer = accentDeep
+tertiary = accentDeep          ← Subagent #8 修复：FAB tertiary 同色系
+onTertiary = onAccent
+tertiaryContainer = accentTint
+onTertiaryContainer = accentDeep
+inverseSurface = ink           ← Subagent #9 修复：Snackbar 跟主题
+inverseOnSurface = paper
+inversePrimary = accentTint
+outline = outlineStrong (20%)  ← Subagent #4 修复：TextField 边可见
+outlineVariant = outlineSoft (12%)
+```
+
+**绕过条件**（Subagent #1/#2 修复）：
+- `amoledDarkMode = true` → 跳过 override，用户得到真黑屏
+- `dynamicColor = true && SDK>=S` → 跳过 override，尊重 Material You
+
+### Phase 4.7 · 5 级 surfaceContainer hierarchy (Subagent #6 修复)
+ChatTheme 新增 `containerLowest/Low/Mid/High/Highest` 5 个明度梯度。Whisper 例：
+```
+Lowest:  #FAFBFC (页面背景)
+Low:     #FFFFFF (Card / Sheet 默认)
+Mid:     #F7F9FB (NavDrawer)
+High:    #F1F4F7 (BottomSheet head)
+Highest: #E9EDF1 (TopAppBar elevated)
+```
+Plain / Paper / Midnight 各自的 5 级见 `ChatTheme.kt`。
+
+### Subagent Reviews
+
+| # | 范围 | 主要发现 | 修复状态 |
+|---|---|---|---|
+| 1 | Phase 1 (bloom / SendOrb / TopBar / composer) | 颜色/几何/动画 timing 完全对齐 themes.jsx | ✅ |
+| 2 | Phase 2+3 (user bubble / tool pill / agent header / thinking / context ring / picker shell) | user bubble 用 CircleShape 而非 asymmetric, thinking rule 仅覆盖正文未覆盖 label | 已知 trade-off |
+| 3 | Phase 4 (WhisperTokens→LocalChatTheme 迁移) | Midnight userBubble 5% 白对比度逼近 WCAG 下限 | ✅ 提到 12% |
+| 4 | colorScheme override 10 个风险 | AmoledDark / dynamicColor / outline alpha / Midnight 阴影 / 5 级 hierarchy / tertiary 等 | ✅ 修了 8/10 |
+
+## 终审 Subagent 风险（4 个，修了 3 个）
+
+| # | 风险 | 修复 |
+|---|---|---|
+| 1 | Snackbar 深色反相 (inverseSurface 用 ink 在 dark 主题反了) | ✅ `if (darkTheme) chatTheme.paper else chatTheme.ink` |
+| 2 | AmoledDark 时 bg=#000 但 LocalChatTheme.bg=#0B0E14 表面不一致 | ✅ `useAmoledBlack` 标志：仅 bg/surface/surfaceVariant 保留 amoled 黑，其他 token 仍用 chatTheme |
+| 3 | Midnight composer shadow 25% 白 Material shadow 可能成"白晕"非顶部高光 | ⏳ 留下 session；如真机看怪，可换 Canvas 自绘 glow |
+| 4 | M3 FilterChip 默认色在 Midnight 选中/未选中 ~12% alpha 看不出 | ✅ SettingDisplayPage 显式 `FilterChipDefaults.filterChipColors`：选中 = primary 实心，未选中 = surfaceVariant |
+
+## 仍待办 ⏳
+
+### 高优先级
+- [ ] **Plain / Paper / Midnight 真机视觉验证**：用户需要在手机上：
+  1. 打开 Amber Refresh
+  2. 进入"设置 → 显示"
+  3. 找到"聊天主题 (V3)"，点击 3 个 chip 切换
+  4. 回到聊天页观察整 app 颜色（含设置页本身）
+  5. 反馈每个主题哪里看着怪
+- [ ] **Phase 3.5 完整 model picker**：active model 单独 card + thinking-level segment (off/on/max/adaptive) + provider chips 横滑栏。**未做**。需要扩展 `Model` 数据增加 effort tiers，或基于 ReasoningLevel 推断。
+
+### 中优先级
+- [ ] 二级页面 button alignment / size / corner radius 系统核查
+  - 用户原话："按钮的对齐、大小、圆角，以及这个二级页面里面按钮到底是统一成大按钮还是小按钮等等"
+  - 当前各页 button size 由 M3 default 决定（OutlinedButton 40dp / FilledButton 40dp / IconButton 48dp），不一致。
+  - 建议统一：FilledButton 高度 48dp、IconButton size 40dp、圆角 RoundedCornerShape(12dp)
+- [ ] **Thinking strip 整体竖线**（label + body 一起）：当前只在正文加了左 2dp rule，label 行（icon + "思考了 N 秒" + chevron）在外侧未被竖线覆盖。需要重构 `ControlledChainOfThoughtStep` 容器（共享于 5 个 chat message component，重构有连带风险）。
+
+### 低优先级
+- [ ] NotionLike palette 与 chatTheme 关系（Subagent #7）：当前 NotionLike build flavor 仍受 chatTheme override，Notion-tuned 灰色基底被覆盖。当前 refactortest 也是 NotionLike，所以 OK，但需要文档化"V3 chat theme 覆盖 Notion palette"是有意为之。
+- [ ] User bubble asymmetric corners (chat1.md L514 提到 18/6/18/18) 被改成 full capsule (L549) 后未恢复；目前是 capsule，符合最终决策。
+- [ ] AmberMark 几何宝石组件 `AmberMark.kt` 已写但不再使用（之前误以为是 hero icon），保留备用作其他场景。
+
+## 设计映射 quickref
+
+```
+chat1.md 决策                                    → 实现位置
+─────────────────────────────────────────────────────────────────────────────
+"naked compose icon — no surrounding circle"     → ChatPage.kt:1325-1340
+"按钮回到干净的纯色圆形，双层呼吸光晕"            → SendOrb.kt
+"用户消息 → 真胶囊 borderRadius 999"             → ChatMessageMessagePartsBlock.kt:215
+"对话页 Whisper：背景蓝光晕去掉，干净浅灰白"      → ChatPage.kt:524 (intensity = 0 when has msg)
+"调用工具 灰底 + 蓝色图标 + 蓝色完成 badge"      → ChatMessageTools.kt:335
+"模型名 + 6px 绿色状态点（取消 provider 图标）"  → ChatMessageAvatar.kt:130
+"思考条左侧 2px 竖线 + 暗调文字"                 → ChatMessageReasoning.kt:205
+"context ring 22px donut + threshold + head dot"→ ContextRing.kt
+"模型选择 sheet 顶 28dp 圆角 + 4dp drag handle" → ModelList.kt:254
+themes.jsx WHISPER bloom 配色                    → ChatTheme.kt:WhisperTheme (bloomCore #7AC0FF)
+themes.jsx PAPER amber                           → ChatTheme.kt:PaperTheme (bloomCore #E6A564)
+themes.jsx MIDNIGHT cool indigo                  → ChatTheme.kt:MidnightTheme (bloomCore #6E8CDC)
+```
+
+## 下个 session 建议优先级
+
+```text
+1. (1h)  问用户哪个 Plain/Paper/Midnight 真机看着不对，按反馈微调
+2. (2h)  Phase 3.5 model picker 完整 V3 化（active card + segment + chips）
+3. (2h)  二级页面 button 一致性 audit + 修
+4. (1h)  Thinking strip label 行整体放进左竖线（重构 ChainOfThought 容器）
+```
+
+## 重要原则保留
+
+来源 `/Users/arquiel/Documents/Codex/2026-05-22/https-x-com-anatolikopadze-status-2050225292585607440/AGENTS.md`：
+
+1. 不清楚就问，不要假设
+2. 先做最简单可行方案，不要过度设计
+3. 只修改与当前任务直接相关的内容
+4. 大改 / 破坏性 / 外部动作前必须确认
+5. 对事实 / 数据 / 来源不确定时，必须明说
+6. 完成任务后简要说明改了什么 / 没改什么 / 还需注意什么
+7. 不 push，除非用户明确要求
+
+## 已修改的文件（git diff stat 一览）
+
+```
+新增：
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatTheme.kt
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/WhisperHalo.kt
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/SendOrb.kt
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/AmberMark.kt (备用，未使用)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ContextRing.kt
+  docs/V3_REFACTOR_HANDOFF_2026-05-23.md (本文档)
+
+修改：
+  app/src/main/java/me/rerere/rikkahub/ui/theme/Theme.kt
+  app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt (DisplaySetting + chatThemeChoice)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt (+ FilterChip 行)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt (TopBar + bloom 注入 + EmptyChatHero)
+  app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatListNormalSection.kt (空白态 bg = Transparent + fade)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt (composer pill V3 + SendOrb 接入)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInputComposers.kt (minimalChrome param)
+  app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt (sheet shell V3 + row 颜色)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageMessagePartsBlock.kt (user bubble V3)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt (tool pill V3 + badge)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageAvatar.kt (绿点 + 模型名)
+  app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt (左竖线正文)
+
+新增 buildType resource:
+  app/src/refactortest/res/values/strings.xml (codex 之前留的 "Amber Refresh" 名)
+```
+
+## 真机截图（验证记录）
+
+```
+/tmp/p12.png      Whisper 空白态：bloom 出来，naked compose icon，问候居中
+/tmp/p18.png      Whisper 对话态：agent 绿点 + 模型名，bloom 已淡出
+/tmp/p23.png      Whisper composer pill 双层阴影确认
+/tmp/p25.png      Bloom 满底均匀 + 3 ripple 波纹
+/tmp/p30_midnight.png  Midnight 主题真机验证：深墨蓝底 + 冷靛蓝 bloom + 浅文字
+```
+
+## rev 2 改动（2026-05-23 续 session）
+
+### 用户反馈触发的修复
+1. **"顶栏没变 Paper 暖色"** → `ChatPage.kt:1323` TopBar Surface `workspace.paper@96%` → `Color.Transparent`；`AmberHeaderLine` ink 改 `LocalChatTheme.current.ink`
+2. **"二级页 Settings 没变 Paper"** → `WorkspaceStyle.kt:104` 浅色分支镜像深色分支，从 `MaterialTheme.colorScheme` 读取（之前硬编码白 → 自动跟随聊天主题）
+3. **"Paper 太淡"** → 一度过暖回滚 → 最终方案：`bg=#FDFAF3` 设计稿原值 + `topHaloAlpha 0.22→0.30` 补 Compose 单 pass 衰减
+4. **"跟随系统是方框 + 固定蓝"** → `Select.kt`: `RoundedCornerShape(6.dp)` → `CircleShape`；`workspace.blueContainer/blue` → `chatTheme.accentSoft/accent` (17 处 Select 一起改)
+
+### 新增 ChatTheme token (10 个)
+- `isDark` (Midnight=true, 用于跳 Material shadow)
+- `topHaloCore` / `topHaloAlpha` (Paper/Midnight 顶层 ambient halo)
+- `bloomHeightFrac` (Whisper 0.38 / Plain 0.50 / Paper 0.55 / Midnight 0.55)
+- `heroSize/heroWeight/heroLetter` (Paper W600/0.5 / Plain 25sp/0.6 / Whisper/Midnight 26sp/0.2)
+- `contextEmpty/Low/Mid/High/contextTrack` (Paper 棕渐变, Midnight 22% 白 track)
+- `popoverBg` (Midnight #1A1F2A)
+
+### P1 S batch (本 session 后段)
+- `ChatMessageTools.kt:404` subtitle color: `workspace.faint` → `chatTheme.inkSoft`
+- `ChatMessageAvatar.kt:145` agent name `15sp` → `17sp`
+- `CardGroup.kt:35` `CardGroupCorner = 12.dp` → `18.dp` (settings 全站圆角)
+- `ChatPage.kt` 对话态底部 56dp fade scrim（gradient bg(0→75%)）
+- `ModelList.kt:278` drag handle 36→40dp
+- `ChatMessageMessagePartsBlock.kt:215` user bubble 加 `paddingStart=60.dp` 强制右对齐留白
+
+### ContextRing 升级
+- 完整重写 `ContextRing.kt` 加 `ContextUsagePopup` (290dp 浮层)：用量与上下文 / 5h 额度 / 本周额度 / Context / meta strip
+- Popup 用 `Popup` + custom `PopupPositionProvider`，箭头 14×14 旋转 45° 模拟
+- 主题感知：阈值色用 `theme.contextEmpty/Low/Mid/High`，浮层 bg 用 `theme.popoverBg`(Midnight) ?: `surface`
+- 数据：5h/周用量是 placeholder（app 当前未追踪），Context 用真实 used/total
+
+### Phase 3.5 model picker thinking-level segment ✅ (本 session 续做)
+- `ModelSelector` + `ModelList` 加 optional `currentAssistant` + `onUpdateAssistant` 参数（10 个 callsite 无需改）
+- `ChatPage.kt` TopBar 接通 `onUpdateAssistant` callback（assistant 列表 map 更新）
+- `ModelList.kt` 新增 `ThinkingLevelSegment` Composable —— OFF/AUTO/LOW/MED/HIGH/MAX 6 段 CircleShape 容器，主题色填充
+- 渲染条件: `isActive && model.abilities.contains(ModelAbility.REASONING) && currentAssistant != null`
+- 真机验证: `deepseek-v4-flash` 没 REASONING ability 不显示（条件正确）；用户切到 GPT/Claude/DeepSeek-pro reasoning 模型时才出 segment
+
+### 还未做（按 design 但本 session 决定不做）
+- **ToolResultPreview / AskUserCard 新组件**：当前 UI 无对应入口，纯新增组件，>2h
+- **History drawer V3 重做**：当前 `workspaceColors()` 适配后已自动跟主题，视觉差距小
+- **ContextUsagePopup 数据接通**：5h/周用量 app 当前未追踪，placeholder 是合理的
+
+### Subagent reviews (rev 2)
+- Midnight composer shadow review (gradient border P2 方案 → 安全合并)
+- 设计稿对照审计 (P0/P1/P2 punch list 推动后续修复)
+- 最终综合 review (4 套主题 token / colorScheme override / data class 向后兼容)
+
+## END


### PR DESCRIPTION
## Summary

V3 UI refactor 整体合并到 main. 3-4 个 session 累计, Codex 已 review (GO with caveats).

- 4 主题系统 (Whisper / Plain / Paper / Midnight) — 新 ChatTheme.kt
- Chat 流全部重做 (ChatPage / ChatList / ChatMessage / 输入器)
- 新组件: SendOrb / ContextRing / WhisperHalo / AmberMark / ToolResultPreview
- Provider 配置页 OutlinedTextField → FlatTextField (14 处)
- Settings 大量重写 (显示页/模型页/Provider 页)
- Model picker 优化 + thinking-level segment 搬 slash panel footer
- Slash button toggle + Popup 入场动画 + 中文 IME 全角 \"／\" 支持
- 流式 char-reveal ease-out-expo + BaselineShift (Codex 浮现感)

## 关键数据层修复

- **ai/ProviderSetting**: `hasUsableAuth()` 提取共用 (picker + data 同源)
- **PreferencesStore.getCurrentImageGenerationModel**: 三级 fallback + DEFAULT_AUTO_MODEL_ID sentinel + hasUsableAuth 兜底 (Codex review P2 修复)
- **ai/ResponseAPI**: stream-scoped sharedAssistantId normalize + done event 转空 delta — 修 Codex OAuth/GPT 单回复多 MessageNode + 内容闪现消失

## i18n

显示模型名 → 显示 Agent 名字 (en/zh/zh-rTW)

## Codex Review

GO with caveats. Follow-ups (合并后另起 task):
- 显式选中 image model 也走 hasUsableAuth 全链路 (目前只校验 type=IMAGE)
- ContextRing 速度接入 firstTokenAt 算纯推理 tok/s

## Stats

76 files changed, ~10099+/1469-

## Test plan
- [x] :app:assembleRefactortest BUILD SUCCESSFUL
- [x] 真机 OPPO PMA110 — Whisper / Paper 主题 / GPT (Codex OAuth) / DeepSeek
- [x] ask_user / generate_image / streaming 验证通过

## 回退首选 (若线上炸)

ProviderSetting.kt / PreferencesStore.kt / ResponseAPI.kt / ChatMessageReasoning.kt + ChatMessageMessagePartsBlock.kt / ContextRing.kt